### PR TITLE
docs: rewrite README as Infinity ecosystem overview, refactor runtime docs, add NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Infinity
+Copyright 2026 Hydro Contributors
+
+The Initial Developer of some parts of the framework is Amazon Web Services.
+Copyright 2026 Amazon.com, Inc. or its affiliates.

--- a/README.md
+++ b/README.md
@@ -1,104 +1,107 @@
-# Infinity Code
+# Infinity
 
-A coding agent you run in your terminal. It spins up sandboxed workspaces, spawns parallel threads, and persists conversations to disk — so you can background an agent, switch to another, and come back later.
+A tool protocol, agent runtime, and coding harness for principled agent concurrency.
 
-## What it does
+Infinity is an ecosystem for building AI agents that can wait for things, work in parallel, and cost nothing when idle. It consists of three layers:
 
-- **Sandboxed editing** — The agent never writes to your working directory. Changes land on isolated branches (Jujutsu bookmarks or git worktree branches) that you inspect and merge when ready.
-- **Parallel threads** — The agent can spawn child threads that work on sub-tasks concurrently. Each thread gets its own sandbox. Threads report results back to the parent in real-time.
-- **Background agents** — Run multiple agent sessions at once. Background a busy agent, start a new one, and switch between them with `/load`. Conversations persist across CLI restarts.
-- **MCP support** — Load any MCP server as a tool source.
-- **Steering files** — Automatically discovers CLAUDE.md, AGENTS.md, .kiro/steering/, and other project convention files.
+- **[Reactive Agent Protocol (RAP)](#reactive-agent-protocol-rap)**: An async tool protocol with native support for subscriptions, long-running operations, and agent hibernation.
+- **[Infinity Runtime](#infinity-runtime)**: A time-sliced agent runtime that processes work in short bursts and releases resources between them, whether deployed as a serverless function or running as a local daemon.
+- **[Infinity Code](#infinity-code)**: A coding agent built on the runtime, with sandboxed editing, durable concurrent threads, and background sessions.
 
-## Quick start
+## Core Capabilities
 
-First install the prerequisites:
+### Native Tool Call Asynchrony & Subscriptions (RAP)
 
-- [Rust](https://rustup.rs) (for building from source)
-- [Ripgrep](https://github.com/BurntSushi/ripgrep) — `brew install ripgrep`
-- [Jujutsu](https://docs.jj-vcs.dev/latest) (optional, recommended) — `brew install jj`
+RAP replaces MCP's synchronous request/response model with fire-and-forget tool calls. The agent invokes a tool via HTTP, the tool acknowledges immediately, and the agent shuts down. When the tool finishes (100ms or 3 days later) it POSTs the result to a callback URL and the agent wakes up.
 
-Then install:
+This enables:
+- **Subscriptions**: Tools register ongoing event streams (GitHub webhooks, price alerts, Slack messages). Each event wakes the agent, which processes it and goes back to sleep.
+- **Long-running operations**: A CI pipeline or deployment takes 20 minutes? The agent hibernates at zero cost and resumes when it completes.
+- **MCP compatibility**: Any MCP server works through a proxy layer. You keep the full MCP ecosystem and gain async execution for tools that need it.
+
+### Time-Sliced Agent Runtime
+
+The Infinity Runtime is stateless and ephemeral. Each execution slice follows a three-phase cycle:
+
+1. **Load**: Restore conversation history and state from durable storage.
+2. **Complete**: Run the LLM, stream the response, collect tool calls.
+3. **Dispatch & Exit**: Fire off tool calls via HTTP, persist state, shut down.
+
+Nothing runs between slices. An agent waiting for a 3-day CI pipeline costs exactly the same as one that was never created. In the cloud, the process literally exits. Locally, it idles on a channel at zero CPU. Multiple agents share compute because they're never all active simultaneously; work is serialized through FIFO queues.
+
+### Durable Concurrent Threads
+
+Agents can spawn child threads for parallel work. Each thread has its own conversation context, message stream, and lifecycle:
+
+- Threads inherit the parent's history up to the spawn point, then diverge.
+- Children report results back via message passing. The parent sees reports as synthetic events without its context being polluted.
+- Subscription events are automatically routed to isolated child threads for processing.
+- Threads are durable: they survive restarts, process interruptions, and cold starts.
+
+This enables patterns like parallel code review (one thread per file), research-while-implementing, and long-running event processing, all with proper context isolation.
+
+## Quick Start
+
+### Install Infinity Code
+
+Prerequisites: [Rust](https://rustup.rs), [Ripgrep](https://github.com/BurntSushi/ripgrep) (`brew install ripgrep`), [Jujutsu](https://docs.jj-vcs.dev/latest) (optional, `brew install jj`).
 
 ```bash
-# Install the CLI (includes the desktop web UI; remove --features bundled-web if you don't have npm)
+# Install the CLI
 cargo install infinity-agent-cli --git https://github.com/hydro-project/infinity --features bundled-web
+
+# Install the local sandbox RAP server
 infinity rap install --user --git https://github.com/hydro-project/infinity --crate sandbox-local
 
-# Run it
+# Run it in any repo
 cd your-repo
 infinity
 ```
 
 To update: `infinity update`
 
-### Desktop UI
+### Build a RAP Agent
 
-Infinity Code comes with a desktop UI that provides a native interface for concurrent threads. There are two ways to run it:
+See the [Getting Started guide](docs/docs/infinity-runtime/getting-started.md) for a walkthrough of running a RAP agent locally with a custom tool server.
 
-**Bundled (recommended if you have npm)** — install with the `bundled-web` feature and the daemon serves the UI automatically:
+### Deploy to Production
 
-```bash
-cargo install infinity-agent-cli --git https://github.com/hydro-project/infinity --features bundled-web
-```
-
-Then open `http://localhost:8080` in a browser. The `bundled-web` feature is preserved across `infinity update`.
-
-**Standalone** — run the Vite dev server separately (requires npm):
-
-```bash
-cd infinity-web
-npm ci
-VITE_WS_PORT=8080 npm run dev
-```
-
-The `VITE_WS_PORT` variable tells the frontend to connect its WebSocket to the daemon on port 8080. Without it, the app tries to connect to the Vite dev server itself and the WebSocket connection will fail.
-
-Then open the URL printed in your terminal (typically http://localhost:5173).
-
-Both modes connect to the same daemon as the CLI, so you can use all three interchangeably.
+The cloud runtime deploys to AWS Lambda via CDK. Agents persist state to Aurora DSQL, route messages through SQS FIFO, and hibernate at true zero compute. See [Cloud Deployment](docs/docs/infinity-runtime/cloud-deployment.mdx).
 
 ## Documentation
 
-Full docs are in the [Infinity Code section](docs/docs/infinity-code/overview.md) of the docs site:
+### RAP (Reactive Agent Protocol)
 
-- [Overview](docs/docs/infinity-code/overview.md) — Installation, first run, slash commands
-- [Coding with Jujutsu](docs/docs/infinity-code/coding-with-jj.md) — Jujutsu workspace sandboxes
-- [Coding with Git](docs/docs/infinity-code/coding-with-git.md) — Git worktree sandboxes
-- [Background Agents](docs/docs/infinity-code/background-agents.md) — Multiple sessions, backgrounding, persistence
-- [Configuring MCP](docs/docs/infinity-code/configuring-mcp.md) — Adding MCP servers
-- [RAP Servers](docs/docs/infinity-code/rap-servers.md) — Sandbox, steering, GitHub event poller, and more
+- [What is RAP?](docs/docs/rap/what-is-rap.md): Motivation, capabilities, and when to use it
+- [Architecture](docs/docs/rap/about/architecture.md): Message flow, callbacks, hibernation, and threading
+- [RAP Specification](docs/docs/rap/spec/overview.md): The authoritative protocol reference
+- [Building a RAP Tool](docs/docs/rap/using-rap/building-a-rap-tool.md): Create your own async tool server
+- [Building a Runtime](docs/docs/rap/using-rap/building-a-runtime.md): Implement the runtime contract
 
----
+### Infinity Runtime
 
-## Infinity Agents (Runtime)
+- [Overview](docs/docs/infinity-runtime/overview.md): Time-sliced architecture and deployment options
+- [Getting Started](docs/docs/infinity-runtime/getting-started.md): Run a local RAP agent
+- [Threading](docs/docs/infinity-runtime/threading.md): Spawn threads, report results, process events
+- [Built-in Tools](docs/docs/infinity-runtime/built-in-tools.md): Sleep, threading, and subscriptions
 
-The Rust runtime that powers Infinity Code. It comes in two flavors that share the same engine (`infinity-agent-core`):
+### Infinity Code
 
-| | Cloud (Lambda) | Local (CLI) |
-|---|---|---|
-| State | Aurora DSQL + DynamoDB | In-memory + file persistence |
-| Messaging | SQS FIFO | `mpsc` channels |
-| Hibernation | Lambda exits, SQS/EventBridge restarts | Process stays alive, idle on channel |
-| Tool auth | SigV4-signed HTTP | Plain HTTP |
-
-See the [runtime docs](docs/docs/infinity-runtime/overview.md) for details.
-
-## Reactive Agent Protocol (RAP)
-
-RAP replaces MCP's synchronous request/response model with async, event-driven communication. Tool calls are fire-and-forget: the agent invokes a tool via HTTP, the tool acknowledges immediately, and the agent shuts down. When the tool finishes — 100ms or 3 days later — it POSTs the result to a callback URL and the agent wakes up.
-
-This enables subscriptions, long-running tool calls, and agent hibernation at zero compute cost.
-
-See the [RAP spec](docs/spec/overview.md) and [docs](docs/docs/what-is-rap.md).
+- [Overview](docs/docs/infinity-code/overview.md): Installation, first run, slash commands
+- [Coding with Jujutsu](docs/docs/infinity-code/coding-with-jj.md): Jujutsu workspace sandboxes
+- [Coding with Git](docs/docs/infinity-code/coding-with-git.md): Git worktree sandboxes
+- [Background Agents](docs/docs/infinity-code/background-agents.md): Multiple sessions, backgrounding, persistence
+- [Configuring MCP](docs/docs/infinity-code/configuring-mcp.md): Adding MCP servers
+- [RAP Servers](docs/docs/infinity-code/rap-servers.md): Sandbox, steering, GitHub event poller
 
 ## Project Structure
 
 ```
 crates/
-  infinity-agent-cli/       # Local CLI binary
   infinity-agent-core/       # Shared agent loop, tools, traits
+  infinity-agent-cli/        # Local CLI binary (Infinity Code)
   infinity-agent-lambda/     # AWS Lambda runtime
+  infinity-daemon/           # Local Infinity Runtime
   sandbox-core/              # Sandbox RAP server (shared logic)
   sandbox-local/             # Local sandbox backend (macOS/Linux sandboxing + jj/git)
   sandbox-remote/            # Remote sandbox backend
@@ -106,4 +109,5 @@ crates/
   rap-github-event-poller/   # GitHub event subscription RAP server
 agent/                       # CDK constructs for cloud deployment
 docs/                        # RAP specification and documentation site
+infinity-web/                # Desktop web UI
 ```

--- a/docs/docs/infinity-runtime/deployment-modes.md
+++ b/docs/docs/infinity-runtime/deployment-modes.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 3
+title: Deployment Modes
+---
+
+# Deployment Modes
+
+The Infinity Runtime ships in two deployment modes that share a single core engine (`infinity-agent-core`). The time-sliced execution model is identical — the differences are infrastructure-level: where state lives, how messages are delivered, and how hibernation is implemented.
+
+## Shared core
+
+Both modes are built on `infinity-agent-core`, a Rust crate containing the agent loop, conversation history management, tool dispatch, and all platform-independent logic. The core defines trait abstractions that each mode implements:
+
+| Trait | Cloud (Lambda) | Local (Daemon) |
+|---|---|---|
+| `ConversationStore` | Aurora DSQL | In-memory `Vec` + file persistence |
+| `StateStore` | DynamoDB | In-memory `HashMap` + file persistence |
+| `InputSender` | SQS FIFO queue | `mpsc` channel |
+| `HttpClient` | SigV4-signed requests | Plain HTTP |
+
+The core also owns the built-in tools that work identically in both environments: `sleep_until_event_or_input`, `spawn_thread`, `report_to_parent`, and `close_thread`. These tools are generic over the `InputSender` trait, so they route messages through SQS in the cloud and through an in-memory channel locally.
+
+## State persistence
+
+The cloud runtime persists conversation history to Aurora DSQL and deduplication state to DynamoDB, so it survives across Lambda invocations. The daemon persists sessions to disk (`~/.infinity/sessions.json`) and can restore them across restarts.
+
+## Hibernation
+
+In the cloud, hibernation is real: the Lambda function exits, zero compute runs, and a future message on SQS restarts it. The daemon simulates this by pausing the agent loop on an `mpsc` channel, consuming zero CPU while idle.
+
+## Timed sleep
+
+Both modes support `sleep`, `sleep_until`, and `sleep_until_event_or_input`, but the underlying mechanism differs:
+
+- **Cloud:** Delays ≤ 900 seconds use SQS `DelaySeconds` via a relay queue. Longer delays use EventBridge Scheduler. The Lambda exits and restarts when the timer fires.
+- **Local:** `tokio::time::sleep` timers fire in spawned tasks and deliver the result through the in-memory channel. The process stays alive.
+
+## Tool authentication
+
+Cloud tool invocations use SigV4-signed HTTP requests to Lambda Function URLs with IAM auth. The daemon uses plain HTTP to local tool servers.
+
+## Deployment
+
+The cloud runtime is provisioned via CDK (`InfinityAgent` construct) with Lambda, SQS, DSQL, EventBridge, and IAM wiring. The daemon is installed with `cargo install` and runs locally.

--- a/docs/docs/infinity-runtime/overview.md
+++ b/docs/docs/infinity-runtime/overview.md
@@ -5,47 +5,50 @@ title: Overview
 
 # Infinity Runtime
 
-The Infinity Runtime is the reference RAP agent runtime. It's written in Rust and comes in two flavors: a cloud deployment on AWS Lambda and an in-memory local CLI for development. Both share the same core engine — the difference is where state lives and how messages are delivered.
+The Infinity Runtime is the reference RAP agent runtime. It implements a time-sliced execution model: agents process work in short bursts (load state, run the LLM, dispatch tool calls) then release resources. In the cloud the process exits entirely; locally the daemon idles at zero CPU. Cost is proportional to work done, not time elapsed.
 
-## Shared core
+## Time-sliced execution
 
-Both runtimes are built on `infinity-agent-core`, a Rust crate that contains the agent loop, conversation history management, tool dispatch, and all the logic that doesn't depend on a specific platform. The core defines trait abstractions that each runtime implements:
+Every agent invocation follows the same three-phase cycle:
 
-| Trait | Cloud (Lambda) | Local (CLI) |
+1. **Load** — Restore conversation history and deduplication state from durable storage. Append the new input message (user text, tool result, or subscription event).
+2. **Complete** — Send the conversation to the LLM and stream back the response. If the model produces a tool call, collect it.
+3. **Dispatch & Yield** — POST the tool call to the RAP server (fire-and-forget), persist updated state, and yield. In the cloud the Lambda exits; locally the daemon returns to an idle wait on the message channel.
+
+The cycle repeats when the next message arrives. The runtime doesn't distinguish between tool results, user messages, and subscription events at the execution level — it loads state and processes whatever's in the queue.
+
+```
+┌─────────┐     ┌─────────┐     ┌───────────────┐
+│  Load   │ ──▶ │Complete │ ──▶ │Dispatch/Yield │
+└─────────┘     └─────────┘     └───────────────┘
+     ▲                                    │
+     │    ╌╌╌╌ idle / exited ╌╌╌╌╌╌       │
+     └───────── next message ◀────────────┘
+```
+
+This architecture makes hibernation free. An agent waiting for a 3-day CI pipeline, a human approval, or a GitHub webhook costs exactly zero compute. It wakes instantly when the next message arrives.
+
+## Resource efficiency
+
+Because agents are stateless between slices, multiple agents share the same compute. In the cloud (Lambda), each slice is a separate invocation — hundreds of agents share the same function, and idle agents consume nothing. Locally, threads idle on `mpsc` channels at zero CPU. The runtime serializes work within each conversation thread via FIFO message ordering, while different threads execute concurrently.
+
+This is fundamentally different from long-lived agent processes that hold connections open and spin idle. A RAP agent monitoring GitHub PRs, reacting to Slack messages, and tracking stock prices can stay alive for months, waking only when something happens.
+
+## Deployment modes
+
+The runtime ships in two deployment modes that share a single core engine (`infinity-agent-core`). The time-sliced execution model is identical in both — the only differences are where state lives and how messages are delivered.
+
+| | Cloud (Lambda) | Local (Daemon) |
 |---|---|---|
-| `ConversationStore` | Aurora DSQL | In-memory `Vec` |
-| `StateStore` | DynamoDB | In-memory `HashMap` |
-| `InputSender` | SQS FIFO queue | `mpsc` channel |
-| `HttpClient` | SigV4-signed requests | Plain HTTP |
+| State | Aurora DSQL + DynamoDB | In-memory + file persistence |
+| Messaging | SQS FIFO | `mpsc` channels |
+| Hibernation | Process exits, SQS/EventBridge restarts | Process idles on channel |
+| Tool auth | SigV4-signed HTTP | Plain HTTP |
 
-The core also owns the built-in tools that work identically in both environments: `sleep_until_event_or_input`, `spawn_thread`, `report_to_parent`, and `close_thread`. These tools are generic over the `InputSender` trait, so they route messages through SQS in the cloud and through an in-memory channel locally.
-
-## The agent loop
-
-Both runtimes run the same three-phase cycle:
-
-1. **Prepare** — load conversation history, append the new input message, resolve any synthetic events (thread reports, subscription events).
-2. **Completion** — send the conversation to the LLM and stream back the response. Tool calls are collected as they arrive.
-3. **Execute** — dispatch each tool call via HTTP (fire-and-forget), persist updated state, and exit.
-
-The loop repeats when the next message arrives — a tool result, user input, or subscription event. The runtime doesn't distinguish between these; it loads state and processes whatever's there.
-
-## What differs
-
-The core loop is the same, but the two runtimes diverge in how they handle infrastructure concerns:
-
-**State persistence.** The cloud runtime persists conversation history to DSQL and deduplication state to DynamoDB, so it survives across Lambda invocations. The CLI keeps everything in memory — if the process exits, state is gone.
-
-**Hibernation.** In the cloud, hibernation is real: the Lambda function exits, zero compute runs, and a future message on SQS restarts it. The CLI simulates this by pausing the agent loop on the channel — the process stays alive but idle.
-
-**Timed sleep.** Both runtimes have `sleep` and `sleep_until` tools, but the implementation differs. The cloud runtime schedules future wake-ups via SQS delay queues (≤ 900s) or EventBridge Scheduler (longer) — the Lambda exits and restarts when the timer fires. The CLI uses in-memory `tokio::time::sleep` timers in spawned tasks — the process stays alive and delivers the result through the channel when the timer completes.
-
-**Tool authentication.** Cloud tool invocations use SigV4-signed HTTP requests to Lambda Function URLs with IAM auth. The CLI uses plain HTTP to local tool servers — no signing needed.
-
-**Deployment.** The cloud runtime is provisioned via CDK (`InfinityAgent` construct) with Lambda, SQS, DSQL, EventBridge, and IAM wiring. The CLI is `cargo run`.
+See [Deployment Modes](./deployment-modes.md) for the full comparison.
 
 ## When to use which
 
-Use the **cloud deployment** for production agents that need to run indefinitely, survive restarts, handle concurrent threads across invocations, and scale to zero between activity. This is the full-featured runtime.
+Use the **cloud deployment** for production agents that need to run indefinitely, survive restarts, handle concurrent threads across invocations, and scale to zero between activity.
 
-Use the **local CLI** for developing and testing agent behavior, iterating on conversation flows, debugging tool call sequences, and building RAP tool servers. It's faster to iterate with and doesn't require any AWS infrastructure.
+Use the **local daemon** for developing and testing agent behavior, iterating on conversation flows, debugging tool call sequences, and building RAP tool servers.


### PR DESCRIPTION
- Rewrote README.md from a coding-agent-focused page to an ecosystem-level
  overview covering RAP (tool protocol), Infinity Runtime (time-sliced agent
  runtime), and Infinity Code (coding harness).
- Core capabilities section highlights three pillars: native tool call
  asynchrony & subscriptions (RAP), time-sliced agent runtime for resource
  efficiency, and durable concurrent threads as the semantic model.
- Added quick start material, doc links organized by component, and updated
  project structure.
- Replaced emdashes with colons/semicolons/parentheses throughout.
- Renamed "CLI" to "Daemon" in all runtime deployment references.
- Refactored docs/docs/infinity-runtime/overview.md to focus on time-sliced
  execution architecture rather than deployment differences.
- Extracted detailed deployment comparison into new
  docs/docs/infinity-runtime/deployment-modes.md.
- Added NOTICE file with Hydro Contributors and Amazon Web Services copyright.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>