### PR TITLE
feat(docs): redesign landing page slider diagrams and reorder navigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
+      - name: Check docs formatting
+        run: |
+          cd docs && npm ci && npx prettier --check "src/**/*.{tsx,ts,css}" "docusaurus.config.ts"
+
+      - name: Check infinity-ui formatting
+        run: |
+          cd infinity-ui && npm ci && npx prettier --check "src/**/*.{tsx,ts,css}"
+
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Infinity
+# [Infinity](https://infinity.hydro.run)
 
 A tool protocol, agent runtime, and coding harness for principled agent concurrency.
 
 Infinity is an ecosystem for building AI agents that can wait for things, work in parallel, and cost nothing when idle. It consists of three layers:
 
-- **[Reactive Agent Protocol (RAP)](#reactive-agent-protocol-rap)**: An async tool protocol with native support for subscriptions, long-running operations, and agent hibernation.
-- **[Infinity Runtime](#infinity-runtime)**: A time-sliced agent runtime that processes work in short bursts and releases resources between them, whether deployed as a serverless function or running as a local daemon.
-- **[Infinity Code](#infinity-code)**: A coding agent built on the runtime, with sandboxed editing, durable concurrent threads, and background sessions.
+- **[Reactive Agent Protocol (RAP)](https://infinity.hydro.run/docs/rap/what-is-rap)**: An async tool protocol with native support for subscriptions, long-running operations, and agent hibernation.
+- **[Infinity Runtime](https://infinity.hydro.run/docs/infinity-runtime/overview)**: A time-sliced agent runtime that processes work in short bursts and releases resources between them, whether deployed as a serverless function or running as a local daemon.
+- **[Infinity Code](https://infinity.hydro.run/docs/infinity-code/overview)**: A coding agent built on the runtime, with sandboxed editing, durable concurrent threads, and background sessions.
 
 ## Core Capabilities
 
@@ -62,37 +62,11 @@ To update: `infinity update`
 
 ### Build a RAP Agent
 
-See the [Getting Started guide](docs/docs/infinity-runtime/getting-started.md) for a walkthrough of running a RAP agent locally with a custom tool server.
+See the [Getting Started guide](https://infinity.hydro.run/docs/infinity-runtime/getting-started) for a walkthrough of running a RAP agent locally with a custom tool server.
 
 ### Deploy to Production
 
-The cloud runtime deploys to AWS Lambda via CDK. Agents persist state to Aurora DSQL, route messages through SQS FIFO, and hibernate at true zero compute. See [Cloud Deployment](docs/docs/infinity-runtime/cloud-deployment.mdx).
-
-## Documentation
-
-### RAP (Reactive Agent Protocol)
-
-- [What is RAP?](docs/docs/rap/what-is-rap.md): Motivation, capabilities, and when to use it
-- [Architecture](docs/docs/rap/about/architecture.md): Message flow, callbacks, hibernation, and threading
-- [RAP Specification](docs/docs/rap/spec/overview.md): The authoritative protocol reference
-- [Building a RAP Tool](docs/docs/rap/using-rap/building-a-rap-tool.md): Create your own async tool server
-- [Building a Runtime](docs/docs/rap/using-rap/building-a-runtime.md): Implement the runtime contract
-
-### Infinity Runtime
-
-- [Overview](docs/docs/infinity-runtime/overview.md): Time-sliced architecture and deployment options
-- [Getting Started](docs/docs/infinity-runtime/getting-started.md): Run a local RAP agent
-- [Threading](docs/docs/infinity-runtime/threading.md): Spawn threads, report results, process events
-- [Built-in Tools](docs/docs/infinity-runtime/built-in-tools.md): Sleep, threading, and subscriptions
-
-### Infinity Code
-
-- [Overview](docs/docs/infinity-code/overview.md): Installation, first run, slash commands
-- [Coding with Jujutsu](docs/docs/infinity-code/coding-with-jj.md): Jujutsu workspace sandboxes
-- [Coding with Git](docs/docs/infinity-code/coding-with-git.md): Git worktree sandboxes
-- [Background Agents](docs/docs/infinity-code/background-agents.md): Multiple sessions, backgrounding, persistence
-- [Configuring MCP](docs/docs/infinity-code/configuring-mcp.md): Adding MCP servers
-- [RAP Servers](docs/docs/infinity-code/rap-servers.md): Sandbox, steering, GitHub event poller
+The cloud runtime deploys to AWS Lambda via CDK. Agents persist state to Aurora DSQL, route messages through SQS FIFO, and hibernate at true zero compute. See [Cloud Deployment](https://infinity.hydro.run/docs/infinity-runtime/cloud-deployment).
 
 ## Project Structure
 

--- a/check.bash
+++ b/check.bash
@@ -23,7 +23,23 @@ export RUST_BACKTRACE=1
 step "Formatting"
 # Suppress diff output so AI agents run `cargo fmt` instead of manually applying each diff.
 cargo fmt --all --check > /dev/null 2>&1 || fail "formatting issues found (run 'cargo fmt --all' to fix)"
-pass "All code is formatted"
+pass "All Rust code is formatted"
+
+step "Docs formatting"
+if [ -f docs/node_modules/.bin/prettier ]; then
+    (cd docs && npx prettier --check "src/**/*.{tsx,ts,css}" "docusaurus.config.ts") || fail "docs formatting issues found (run 'cd docs && npm run format' to fix)"
+    pass "All docs code is formatted"
+else
+    echo "  (skipped: docs node_modules not installed)"
+fi
+
+step "infinity-ui formatting"
+if [ -f infinity-ui/node_modules/.bin/prettier ]; then
+    (cd infinity-ui && npx prettier --check "src/**/*.{tsx,ts,css}") || fail "infinity-ui formatting issues found (run 'cd infinity-ui && npm run format' to fix)"
+    pass "All infinity-ui code is formatted"
+else
+    echo "  (skipped: infinity-ui node_modules not installed)"
+fi
 
 step "Clippy (warnings denied)"
 cargo clippy --all-targets -- -D warnings || fail "clippy warnings found"

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -56,12 +56,6 @@ const config: Config = {
       items: [
         {
           type: "docSidebar",
-          sidebarId: "infinityCodeSidebar",
-          position: "left",
-          label: "Infinity Code",
-        },
-        {
-          type: "docSidebar",
           sidebarId: "rapSidebar",
           position: "left",
           label: "Reactive Agent Protocol",
@@ -71,6 +65,12 @@ const config: Config = {
           sidebarId: "infinityRuntimeSidebar",
           position: "left",
           label: "Infinity Runtime",
+        },
+        {
+          type: "docSidebar",
+          sidebarId: "infinityCodeSidebar",
+          position: "left",
+          label: "Infinity Code",
         },
         {
           href: "https://github.com/hydro-project/infinity",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -25,6 +25,7 @@
         "@docusaurus/tsconfig": "3.9.2",
         "@docusaurus/types": "3.9.2",
         "degit": "^3.4.6",
+        "prettier": "^3.5.0",
         "typescript": "~5.6.2"
       },
       "engines": {
@@ -16317,6 +16318,22 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-error": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
+    "format": "prettier --write \"src/**/*.{tsx,ts,css}\" \"docusaurus.config.ts\"",
+    "format:check": "prettier --check \"src/**/*.{tsx,ts,css}\" \"docusaurus.config.ts\"",
     "postinstall": "degit hydro-project/hydro/hydro-docusaurus-theme#53901b1b2642fec45bcc84bce2767e8b067f1135 node_modules/@hydro-project/docusaurus-theme"
   },
   "dependencies": {
@@ -32,6 +34,7 @@
     "@docusaurus/tsconfig": "3.9.2",
     "@docusaurus/types": "3.9.2",
     "degit": "^3.4.6",
+    "prettier": "^3.5.0",
     "typescript": "~5.6.2"
   },
   "browserslist": {

--- a/docs/src/components/DesktopMini.tsx
+++ b/docs/src/components/DesktopMini.tsx
@@ -296,7 +296,12 @@ interface AnimState {
   sessions: Record<string, SessionInfo>;
   messages: MessageItemType[];
   spinner: SpinnerState | null;
-  diffFiles: { path: string; status: "modified" | "added"; oldContents: string; newContents: string }[];
+  diffFiles: {
+    path: string;
+    status: "modified" | "added";
+    oldContents: string;
+    newContents: string;
+  }[];
   chatVisible: boolean;
   typingInput: string;
 }

--- a/docs/src/components/FeatureCards.tsx
+++ b/docs/src/components/FeatureCards.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 
 interface Feature {
   icon: string;
@@ -10,11 +10,11 @@ interface Feature {
 
 const features: Feature[] = [
   {
-    icon: '🔔',
-    title: 'Subscriptions',
+    icon: "🔔",
+    title: "Subscriptions",
     description: (
       <>
-        Tools register ongoing subscriptions — GitHub webhooks, price feeds,
+        Tools register ongoing subscriptions: GitHub webhooks, price feeds,
         monitoring alerts. Each event wakes the agent, which processes it in an
         isolated thread and goes back to sleep. The subscription persists across
         hibernations.
@@ -35,17 +35,17 @@ const features: Feature[] = [
   charge.succeeded — $847.00 from cus_Lx8mQ
 
 🤖 Agent:  Looking up the customer details...`,
-    link: '/docs/rap/about/subscription-events',
+    link: "/docs/rap/about/subscription-events",
   },
   {
-    icon: '⏳',
-    title: 'Long-running tools',
+    icon: "⏳",
+    title: "Long-running tools",
     description: (
       <>
-        Tool calls are fire-and-forget. The agent dispatches a request and
-        goes into hibernation. When the tool finishes — minutes or hours
-        later — it POSTs the result and the agent resumes. No compute is
-        consumed while waiting.
+        Tool calls are fire-and-forget. The agent dispatches a request and goes
+        into hibernation. When the tool finishes, minutes or hours later, it
+        POSTs the result and the agent resumes. No compute is consumed while
+        waiting.
       </>
     ),
     code: `🔧 Tool call:  deploy_to_staging({
@@ -63,15 +63,15 @@ const features: Feature[] = [
 
 🤖 Agent:  Staging looks good. Ready to
             promote to production.`,
-    link: '/docs/rap/about/rap-servers',
+    link: "/docs/rap/about/rap-servers",
   },
   {
-    icon: '💤',
-    title: 'Hibernation',
+    icon: "💤",
+    title: "Hibernation",
     description: (
       <>
         When there's nothing to do, the agent shuts down completely. No idle
-        process, no polling, no cost. It wakes instantly when a message arrives —
+        process, no polling, no cost. It wakes instantly when a message arrives:
         user input, tool result, or external event. Agents can run for years at
         near-zero cost.
       </>
@@ -91,7 +91,7 @@ const features: Feature[] = [
                 2025-03-15 09:30 America/New_York"
 
 🤖 Agent:  Market is open. Checking portfolio...`,
-    link: '/docs/rap/about/architecture#hibernation',
+    link: "/docs/rap/about/architecture#hibernation",
   },
 ];
 
@@ -105,13 +105,15 @@ export default function FeatureCards(): React.JSX.Element {
 
   return (
     <section className="features-section">
-      <h2 style={{ fontSize: "2.5rem" }}>Built for agents that live in the real world</h2>
+      <h2 style={{ fontSize: "2.5rem" }}>
+        Built for agents that live in the real world
+      </h2>
       <div className="features-tabbed">
         <div className="features-left">
           {features.map((feature, i) => (
             <button
               key={feature.title}
-              className={`feature-tab ${i === active ? 'feature-tab--active' : ''}`}
+              className={`feature-tab ${i === active ? "feature-tab--active" : ""}`}
               onClick={() => switchTab(i)}
               type="button"
             >
@@ -124,7 +126,9 @@ export default function FeatureCards(): React.JSX.Element {
           ))}
         </div>
         <div className="features-right">
-          <pre><code>{features[active].code}</code></pre>
+          <pre>
+            <code>{features[active].code}</code>
+          </pre>
           <a href={features[active].link} className="feature-learn-more">
             Learn more →
           </a>

--- a/docs/src/components/ProtocolComparison.tsx
+++ b/docs/src/components/ProtocolComparison.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React from "react";
 
 export default function ProtocolComparison(): React.JSX.Element {
   return (
     <section className="comparison-section">
       <h2>Backwards-Compatible with MCP.</h2>
       <p>
-        RAP includes a compatibility layer for MCP servers. RAP agents can hibernate during MCP tool calls — whether that takes 100ms or 3 days.
+        RAP includes a compatibility layer for MCP servers. RAP agents can
+        hibernate during MCP tool calls, whether that takes 100ms or 3 days.
       </p>
       <div className="comparison-grid">
         <div className="comparison-card">

--- a/docs/src/components/ProtocolDiagram.tsx
+++ b/docs/src/components/ProtocolDiagram.tsx
@@ -1,0 +1,574 @@
+import React, { useEffect, useState, useRef, useCallback } from "react";
+
+/**
+ * Animated protocol diagram showing RAP's fire-and-forget async model.
+ * Two swim lanes (Agent Runtime / RAP Tool) with time flowing left to right.
+ * Elements are revealed by a clip rect that tracks the playhead position.
+ */
+
+const CYCLE_MS = 12000;
+
+// Layout constants
+const W = 780;
+const H = 280;
+const LANE_Y_RUNTIME = 40;
+const LANE_Y_TOOL = 150;
+const LANE_H = 36;
+const LANE_LABEL_X = 12;
+const TIMELINE_START = 130;
+const TIMELINE_END = 750;
+const WEBHOOK_Y = 270; // external event source below tool lane
+
+// Colors — use CSS variables for theme compatibility
+const C_PRIMARY = "var(--ifm-color-primary)";
+const C_SUCCESS = "#28c840";
+const C_EVENT = "#d29922";
+const C_DIM = "var(--ifm-color-emphasis-300)";
+const C_LABEL = "var(--ifm-color-emphasis-600)";
+const C_ACTIVE_RUNTIME = "var(--ifm-color-primary)";
+
+// Timeline phases (x-positions for key moments)
+const T = {
+  llmStart: 145,
+  llmEnd: 230,
+  // Subscribe call
+  subSent: 230,
+  toolSubStart: 260,
+  toolSubEnd: 320,
+  // Runtime idle while tool registers
+  runtimeIdle1Start: 230,
+  runtimeIdle1End: 340,
+  // Tool sends "subscribed" result back
+  subscribedSent: 320,
+  // Runtime processes result, then idles again
+  llm2Start: 340,
+  llm2End: 390,
+  runtimeIdle2Start: 390,
+  runtimeIdle2End: 615,
+  // Tool idle after sending subscribed
+  toolIdleStart: 320,
+  toolIdleEnd: 530,
+  // Webhook arrives directly into tool (diagonal, no gap)
+  webhookArrives: 530,
+  toolWakeStart: 530,
+  toolWakeEnd: 590,
+  // Tool idle after processing webhook
+  toolIdle2Start: 590,
+  toolIdle2End: 800,
+  // Tool sends event to runtime
+  eventSent: 590,
+  // Runtime wakes
+  llm3Start: 615,
+  llm3End: 800,
+};
+
+export default function ProtocolDiagram({
+  active,
+}: {
+  active: boolean;
+}): React.JSX.Element {
+  const [progress, setProgress] = useState(0);
+  const startRef = useRef(0);
+  const rafRef = useRef(0);
+
+  const stop = useCallback(() => {
+    cancelAnimationFrame(rafRef.current);
+  }, []);
+
+  const runCycle = useCallback(() => {
+    startRef.current = Date.now();
+    function tick() {
+      const p = Math.min(1, (Date.now() - startRef.current) / CYCLE_MS);
+      setProgress(p);
+      if (p < 1) rafRef.current = requestAnimationFrame(tick);
+    }
+    rafRef.current = requestAnimationFrame(tick);
+  }, []);
+
+  useEffect(() => {
+    if (!active) {
+      stop();
+      setProgress(0);
+      return;
+    }
+    runCycle();
+    return stop;
+  }, [active, runCycle, stop]);
+
+  const playheadX = TIMELINE_START + progress * (W - TIMELINE_START);
+
+  return (
+    <div style={{ width: "100%", maxWidth: 1100, margin: "0 auto" }}>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        width="100%"
+        style={{ display: "block" }}
+        role="img"
+        aria-label="Animated diagram showing RAP protocol fire-and-forget async flow"
+      >
+        <defs>
+          <marker
+            id="arrow-down"
+            markerWidth="8"
+            markerHeight="6"
+            refX="4"
+            refY="3"
+            orient="auto"
+          >
+            <path d="M0,0 L8,3 L0,6" fill={C_PRIMARY} />
+          </marker>
+          <marker
+            id="arrow-up"
+            markerWidth="8"
+            markerHeight="6"
+            refX="4"
+            refY="3"
+            orient="auto"
+          >
+            <path d="M0,0 L8,3 L0,6" fill={C_SUCCESS} />
+          </marker>
+          <marker
+            id="arrow-event"
+            markerWidth="8"
+            markerHeight="6"
+            refX="4"
+            refY="3"
+            orient="auto"
+          >
+            <path d="M0,0 L8,3 L0,6" fill={C_EVENT} />
+          </marker>
+          {/* Mask with soft fade at the reveal edge */}
+          <linearGradient
+            id="reveal-fade"
+            gradientUnits="userSpaceOnUse"
+            x1={playheadX - 15}
+            y1="0"
+            x2={playheadX}
+            y2="0"
+          >
+            <stop offset="0" stopColor="white" stopOpacity="1" />
+            <stop offset="1" stopColor="white" stopOpacity="0" />
+          </linearGradient>
+          <mask id="reveal-mask">
+            <rect
+              x="0"
+              y="0"
+              width={Math.max(0, playheadX - 15)}
+              height={H}
+              fill="white"
+            />
+            <rect
+              x={Math.max(0, playheadX - 15)}
+              y="0"
+              width="15"
+              height={H}
+              fill="url(#reveal-fade)"
+            />
+          </mask>
+        </defs>
+
+        {/* ─── Always visible: lane labels, baselines, time axis ─── */}
+        <text
+          x={LANE_LABEL_X}
+          y={LANE_Y_RUNTIME + LANE_H / 2}
+          dominantBaseline="central"
+          fill={C_LABEL}
+          fontSize="11"
+          fontWeight="600"
+          fontFamily="system-ui, sans-serif"
+        >
+          Agent Runtime
+        </text>
+        <text
+          x={LANE_LABEL_X}
+          y={LANE_Y_TOOL + LANE_H / 2}
+          dominantBaseline="central"
+          fill={C_LABEL}
+          fontSize="11"
+          fontWeight="600"
+          fontFamily="system-ui, sans-serif"
+        >
+          RAP Tool
+        </text>
+        <text
+          x={LANE_LABEL_X}
+          y={WEBHOOK_Y}
+          dominantBaseline="central"
+          fill={C_LABEL}
+          fontSize="10"
+          fontWeight="500"
+          fontFamily="system-ui, sans-serif"
+          opacity="0.7"
+        >
+          External
+        </text>
+        <line
+          x1={TIMELINE_START}
+          y1={LANE_Y_RUNTIME + LANE_H / 2}
+          x2={TIMELINE_END}
+          y2={LANE_Y_RUNTIME + LANE_H / 2}
+          stroke={C_DIM}
+          strokeWidth="1"
+          strokeDasharray="4 4"
+          opacity="0.4"
+        />
+        <line
+          x1={TIMELINE_START}
+          y1={LANE_Y_TOOL + LANE_H / 2}
+          x2={TIMELINE_END}
+          y2={LANE_Y_TOOL + LANE_H / 2}
+          stroke={C_DIM}
+          strokeWidth="1"
+          strokeDasharray="4 4"
+          opacity="0.4"
+        />
+        <line
+          x1={TIMELINE_START}
+          y1={H - 20}
+          x2={TIMELINE_END - 10}
+          y2={H - 20}
+          stroke={C_DIM}
+          strokeWidth="1"
+          markerEnd="url(#arrow-down)"
+        />
+        <text
+          x={(TIMELINE_START + TIMELINE_END) / 2}
+          y={H - 8}
+          textAnchor="middle"
+          fill={C_DIM}
+          fontSize="9"
+          fontFamily="system-ui, sans-serif"
+        >
+          time →
+        </text>
+
+        {/* ─── Masked group: revealed by playhead with soft edge ─── */}
+        <g mask="url(#reveal-mask)">
+          {/* Runtime: LLM decides to subscribe */}
+          <rect
+            x={T.llmStart}
+            y={LANE_Y_RUNTIME}
+            width={T.llmEnd - T.llmStart}
+            height={LANE_H}
+            rx={4}
+            fill={C_ACTIVE_RUNTIME}
+            opacity={0.15}
+            stroke={C_ACTIVE_RUNTIME}
+            strokeWidth="1.5"
+          />
+          <text
+            x={(T.llmStart + T.llmEnd) / 2}
+            y={LANE_Y_RUNTIME + LANE_H / 2 + 1}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill={C_PRIMARY}
+            fontSize="9"
+            fontWeight="500"
+            fontFamily="system-ui, sans-serif"
+          >
+            LLM
+          </text>
+
+          {/* Subscribe arrow (diagonal down-right) */}
+          <line
+            x1={T.subSent}
+            y1={LANE_Y_RUNTIME + LANE_H}
+            x2={T.toolSubStart}
+            y2={LANE_Y_TOOL}
+            stroke={C_PRIMARY}
+            strokeWidth="1.5"
+            markerEnd="url(#arrow-down)"
+          />
+          <text
+            x={(T.subSent + T.toolSubStart) / 2 + 8}
+            y={(LANE_Y_RUNTIME + LANE_H + LANE_Y_TOOL) / 2 - 4}
+            fill={C_PRIMARY}
+            fontSize="8"
+            fontFamily="system-ui, sans-serif"
+            dominantBaseline="central"
+          >
+            subscribe
+          </text>
+
+          {/* Tool runs briefly to register subscription */}
+          <rect
+            x={T.toolSubStart}
+            y={LANE_Y_TOOL}
+            width={T.toolSubEnd - T.toolSubStart}
+            height={LANE_H}
+            rx={4}
+            fill={C_SUCCESS}
+            opacity={0.15}
+            stroke={C_SUCCESS}
+            strokeWidth="1.5"
+          />
+          <text
+            x={(T.toolSubStart + T.toolSubEnd) / 2}
+            y={LANE_Y_TOOL + LANE_H / 2 + 1}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill={C_SUCCESS}
+            fontSize="9"
+            fontWeight="500"
+            fontFamily="system-ui, sans-serif"
+          >
+            register
+          </text>
+
+          {/* Tool sends "subscribed" result back (diagonal up-right) */}
+          <line
+            x1={T.subscribedSent}
+            y1={LANE_Y_TOOL}
+            x2={T.llm2Start}
+            y2={LANE_Y_RUNTIME + LANE_H}
+            stroke={C_SUCCESS}
+            strokeWidth="1.5"
+            markerEnd="url(#arrow-up)"
+          />
+          <text
+            x={(T.subscribedSent + T.llm2Start) / 2 + 8}
+            y={(LANE_Y_RUNTIME + LANE_H + LANE_Y_TOOL) / 2 + 4}
+            fill={C_SUCCESS}
+            fontSize="8"
+            fontFamily="system-ui, sans-serif"
+            dominantBaseline="central"
+          >
+            subscribed
+          </text>
+
+          {/* Runtime processes result */}
+          <rect
+            x={T.llm2Start}
+            y={LANE_Y_RUNTIME}
+            width={T.llm2End - T.llm2Start}
+            height={LANE_H}
+            rx={4}
+            fill={C_ACTIVE_RUNTIME}
+            opacity={0.15}
+            stroke={C_ACTIVE_RUNTIME}
+            strokeWidth="1.5"
+          />
+          <text
+            x={(T.llm2Start + T.llm2End) / 2}
+            y={LANE_Y_RUNTIME + LANE_H / 2 + 1}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill={C_PRIMARY}
+            fontSize="9"
+            fontWeight="500"
+            fontFamily="system-ui, sans-serif"
+          >
+            LLM
+          </text>
+
+          {/* Runtime idle while tool registers */}
+          <rect
+            x={T.runtimeIdle1Start}
+            y={LANE_Y_RUNTIME}
+            width={T.runtimeIdle1End - T.runtimeIdle1Start}
+            height={LANE_H}
+            rx={4}
+            fill="none"
+            stroke="var(--ifm-color-emphasis-500)"
+            strokeWidth="1.5"
+            strokeDasharray="4 3"
+            opacity="0.8"
+          />
+          <text
+            x={(T.runtimeIdle1Start + T.runtimeIdle1End) / 2}
+            y={LANE_Y_RUNTIME + LANE_H / 2 + 1}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill="var(--ifm-color-emphasis-700)"
+            fontSize="9"
+            fontFamily="system-ui, sans-serif"
+          >
+            💤
+          </text>
+
+          {/* Runtime idles after processing */}
+          <rect
+            x={T.runtimeIdle2Start}
+            y={LANE_Y_RUNTIME}
+            width={T.runtimeIdle2End - T.runtimeIdle2Start}
+            height={LANE_H}
+            rx={4}
+            fill="none"
+            stroke="var(--ifm-color-emphasis-500)"
+            strokeWidth="1.5"
+            strokeDasharray="4 3"
+            opacity="0.8"
+          />
+          <text
+            x={(T.runtimeIdle2Start + T.runtimeIdle2End) / 2}
+            y={LANE_Y_RUNTIME + LANE_H / 2 + 1}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill="var(--ifm-color-emphasis-700)"
+            fontSize="9"
+            fontFamily="system-ui, sans-serif"
+          >
+            💤
+          </text>
+
+          {/* Tool idle */}
+          <rect
+            x={T.toolIdleStart}
+            y={LANE_Y_TOOL}
+            width={T.toolIdleEnd - T.toolIdleStart}
+            height={LANE_H}
+            rx={4}
+            fill="none"
+            stroke="var(--ifm-color-emphasis-500)"
+            strokeWidth="1.5"
+            strokeDasharray="4 3"
+            opacity="0.8"
+          />
+          <text
+            x={(T.toolIdleStart + T.toolIdleEnd) / 2}
+            y={LANE_Y_TOOL + LANE_H / 2 + 1}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill="var(--ifm-color-emphasis-700)"
+            fontSize="9"
+            fontFamily="system-ui, sans-serif"
+          >
+            💤
+          </text>
+
+          {/* Webhook arrives from external (diagonal up into tool start) */}
+          <line
+            x1={T.webhookArrives - 20}
+            y1={WEBHOOK_Y}
+            x2={T.toolWakeStart}
+            y2={LANE_Y_TOOL + LANE_H}
+            stroke={C_EVENT}
+            strokeWidth="1.5"
+            markerEnd="url(#arrow-event)"
+          />
+          <text
+            x={T.webhookArrives - 5}
+            y={(LANE_Y_TOOL + LANE_H + WEBHOOK_Y) / 2 + 4}
+            fill={C_EVENT}
+            fontSize="8"
+            fontFamily="system-ui, sans-serif"
+            dominantBaseline="central"
+          >
+            webhook
+          </text>
+
+          {/* Tool wakes to process */}
+          <rect
+            x={T.toolWakeStart}
+            y={LANE_Y_TOOL}
+            width={T.toolWakeEnd - T.toolWakeStart}
+            height={LANE_H}
+            rx={4}
+            fill={C_EVENT}
+            opacity={0.15}
+            stroke={C_EVENT}
+            strokeWidth="1.5"
+          />
+          <text
+            x={(T.toolWakeStart + T.toolWakeEnd) / 2}
+            y={LANE_Y_TOOL + LANE_H / 2 + 1}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill={C_EVENT}
+            fontSize="9"
+            fontWeight="500"
+            fontFamily="system-ui, sans-serif"
+          >
+            process
+          </text>
+
+          {/* Tool idle after processing */}
+          <rect
+            x={T.toolIdle2Start}
+            y={LANE_Y_TOOL}
+            width={T.toolIdle2End - T.toolIdle2Start}
+            height={LANE_H}
+            rx={4}
+            fill="none"
+            stroke="var(--ifm-color-emphasis-500)"
+            strokeWidth="1.5"
+            strokeDasharray="4 3"
+            opacity="0.8"
+          />
+          <text
+            x={(T.toolIdle2Start + T.toolIdle2End) / 2}
+            y={LANE_Y_TOOL + LANE_H / 2 + 1}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill="var(--ifm-color-emphasis-700)"
+            fontSize="9"
+            fontFamily="system-ui, sans-serif"
+          >
+            💤
+          </text>
+
+          {/* Tool sends event to runtime (diagonal up-right) */}
+          <line
+            x1={T.eventSent}
+            y1={LANE_Y_TOOL}
+            x2={T.llm3Start}
+            y2={LANE_Y_RUNTIME + LANE_H}
+            stroke={C_EVENT}
+            strokeWidth="1.5"
+            markerEnd="url(#arrow-event)"
+          />
+          <text
+            x={(T.eventSent + T.llm3Start) / 2 + 8}
+            y={(LANE_Y_RUNTIME + LANE_H + LANE_Y_TOOL) / 2 + 4}
+            fill={C_EVENT}
+            fontSize="8"
+            fontFamily="system-ui, sans-serif"
+            dominantBaseline="central"
+          >
+            event
+          </text>
+
+          {/* Runtime wakes to handle event */}
+          <rect
+            x={T.llm3Start}
+            y={LANE_Y_RUNTIME}
+            width={T.llm3End - T.llm3Start}
+            height={LANE_H}
+            rx={4}
+            fill={C_ACTIVE_RUNTIME}
+            opacity={0.15}
+            stroke={C_ACTIVE_RUNTIME}
+            strokeWidth="1.5"
+          />
+          <text
+            x={(T.llm3Start + T.llm3End) / 2}
+            y={LANE_Y_RUNTIME + LANE_H / 2 + 1}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill={C_PRIMARY}
+            fontSize="9"
+            fontWeight="500"
+            fontFamily="system-ui, sans-serif"
+          >
+            LLM
+          </text>
+        </g>
+
+        {/* ─── Playhead (outside clip) ─── */}
+        {active && (
+          <rect
+            x={playheadX}
+            y={LANE_Y_RUNTIME - 15}
+            width="2"
+            height={WEBHOOK_Y - LANE_Y_RUNTIME + 30}
+            fill={C_PRIMARY}
+            opacity={
+              progress > 0.9 ? 0.25 * (1 - (progress - 0.9) / 0.1) : 0.25
+            }
+            rx={1}
+          />
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/docs/src/components/RuntimeDiagram.tsx
+++ b/docs/src/components/RuntimeDiagram.tsx
@@ -1,252 +1,383 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useRef } from "react";
 
-interface ChildNode {
-  label: string;
-  x: number;
-}
+/**
+ * RuntimeDiagram — visualizes time-slicing.
+ *
+ * Phase 1 ("Traditional"): agents hold resources even while idle.
+ * Phase 2 ("Infinity"): idle gaps collapse; active blocks bin-pack into minimal rows.
+ */
 
-const CHILDREN: ChildNode[] = [
-  { label: "Review auth.ts", x: 100 },
-  { label: "Run tests", x: 300 },
-  { label: "Update docs", x: 500 },
+const COLORS = [
+  "#79c0ff",
+  "#7ee787",
+  "#b392f0",
+  "#ffa657",
+  "#f97583",
+  "#56d4dd",
+];
+const AGENT_LABELS = [
+  "Agent A",
+  "Agent B",
+  "Agent C",
+  "Agent D",
+  "Agent E",
+  "Agent F",
 ];
 
-const PARENT_X = 300;
-const PARENT_Y = 60;
-const CHILD_Y = 280;
-const NODE_W = 150;
-const NODE_H = 44;
-const CYCLE_MS = 8000;
+interface Segment {
+  start: number;
+  end: number;
+  active: boolean;
+}
 
-type Phase =
-  | "idle"
-  | "spawn0"
-  | "spawn1"
-  | "spawn2"
-  | "reporting"
-  | "done0"
-  | "done1"
-  | "done2";
-
-const PHASE_SCHEDULE: { phase: Phase; at: number }[] = [
-  { phase: "idle", at: 0 },
-  { phase: "spawn0", at: 1000 },
-  { phase: "spawn1", at: 2000 },
-  { phase: "spawn2", at: 3000 },
-  { phase: "reporting", at: 3500 },
-  { phase: "done0", at: 6000 },
-  { phase: "done1", at: 6500 },
-  { phase: "done2", at: 7000 },
+const TIMELINES: Segment[][] = [
+  // Agent A
+  [
+    { start: 0, end: 8, active: true },
+    { start: 8, end: 30, active: false },
+    { start: 30, end: 38, active: true },
+    { start: 38, end: 72, active: false },
+    { start: 72, end: 82, active: true },
+    { start: 82, end: 100, active: false },
+  ],
+  // Agent B
+  [
+    { start: 0, end: 15, active: false },
+    { start: 15, end: 25, active: true },
+    { start: 25, end: 55, active: false },
+    { start: 55, end: 65, active: true },
+    { start: 65, end: 100, active: false },
+  ],
+  // Agent C
+  [
+    { start: 0, end: 35, active: false },
+    { start: 35, end: 50, active: true },
+    { start: 50, end: 80, active: false },
+    { start: 80, end: 92, active: true },
+    { start: 92, end: 100, active: false },
+  ],
+  // Agent D
+  [
+    { start: 0, end: 5, active: false },
+    { start: 5, end: 12, active: true },
+    { start: 12, end: 60, active: false },
+    { start: 60, end: 70, active: true },
+    { start: 70, end: 85, active: false },
+    { start: 85, end: 95, active: true },
+    { start: 95, end: 100, active: false },
+  ],
+  // Agent E
+  [
+    { start: 0, end: 20, active: false },
+    { start: 20, end: 30, active: true },
+    { start: 30, end: 68, active: false },
+    { start: 68, end: 78, active: true },
+    { start: 78, end: 100, active: false },
+  ],
+  // Agent F
+  [
+    { start: 0, end: 42, active: false },
+    { start: 42, end: 52, active: true },
+    { start: 52, end: 88, active: false },
+    { start: 88, end: 100, active: true },
+  ],
 ];
 
-function phaseIndex(phase: Phase): number {
-  return PHASE_SCHEDULE.findIndex((p) => p.phase === phase);
+// Collect all active segments with metadata
+interface ActiveBlock {
+  agentIdx: number;
+  start: number;
+  end: number;
+  color: string;
+  // Computed: which packed row this block goes into
+  packedRow: number;
 }
+
+const ACTIVE_BLOCKS: ActiveBlock[] = [];
+for (let i = 0; i < TIMELINES.length; i++) {
+  for (const seg of TIMELINES[i]) {
+    if (seg.active) {
+      ACTIVE_BLOCKS.push({
+        agentIdx: i,
+        start: seg.start,
+        end: seg.end,
+        color: COLORS[i],
+        packedRow: 0,
+      });
+    }
+  }
+}
+// Sort by start time for greedy bin-packing
+ACTIVE_BLOCKS.sort((a, b) => a.start - b.start);
+// First-fit bin packing
+const rowEnds: number[] = [];
+for (const block of ACTIVE_BLOCKS) {
+  let placed = false;
+  for (let r = 0; r < rowEnds.length; r++) {
+    if (rowEnds[r] <= block.start) {
+      block.packedRow = r;
+      rowEnds[r] = block.end;
+      placed = true;
+      break;
+    }
+  }
+  if (!placed) {
+    block.packedRow = rowEnds.length;
+    rowEnds.push(block.end);
+  }
+}
+const PACKED_ROW_COUNT = rowEnds.length;
+
+// Layout constants
+const SVG_W = 800;
+const SVG_H = 300;
+const LANE_H = 28;
+const MARGIN_LEFT = 40;
+const MARGIN_RIGHT = 60;
+const TRACK_W = SVG_W - MARGIN_LEFT - MARGIN_RIGHT;
+
+const TRAD_TOP = 30;
+const TRAD_LANE_PITCH = 48;
+
+const SLICED_TOP = TRAD_TOP;
+const SLICED_LANE_PITCH = LANE_H + 6;
+
+type Phase = "initial" | "highlight" | "sliced";
 
 export default function RuntimeDiagram({
   active,
 }: {
   active: boolean;
 }): React.JSX.Element {
-  const [phase, setPhase] = useState<Phase>("idle");
-
-  const runCycle = useCallback(() => {
-    const timers: ReturnType<typeof setTimeout>[] = [];
-    for (const { phase: p, at } of PHASE_SCHEDULE) {
-      timers.push(setTimeout(() => setPhase(p), at));
-    }
-    return timers;
-  }, []);
+  const [phase, setPhase] = useState<Phase>("initial");
+  const timerRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   useEffect(() => {
+    timerRef.current.forEach(clearTimeout);
+    timerRef.current = [];
+
     if (!active) {
-      setPhase("idle");
+      setPhase("initial");
       return;
     }
-    let timers = runCycle();
+
+    setPhase("initial");
+
+    const schedule = (fn: () => void, ms: number) => {
+      timerRef.current.push(setTimeout(fn, ms));
+    };
+
+    // Phase 1: show initial (2.5s)
+    // Phase 2: highlight idle in red (3s)
+    // Phase 3: collapse to sliced (5s)
+    schedule(() => setPhase("highlight"), 2500);
+    schedule(() => setPhase("sliced"), 5500);
+    // Cycle back
+    schedule(() => setPhase("initial"), 10500);
+
     const interval = setInterval(() => {
-      timers.forEach(clearTimeout);
-      timers = runCycle();
-    }, CYCLE_MS);
+      setPhase("initial");
+      schedule(() => setPhase("highlight"), 2500);
+      schedule(() => setPhase("sliced"), 5500);
+      schedule(() => setPhase("initial"), 10500);
+    }, 11000);
+
     return () => {
-      timers.forEach(clearTimeout);
+      timerRef.current.forEach(clearTimeout);
       clearInterval(interval);
     };
-  }, [runCycle, active]);
+  }, [active]);
 
-  const currentIdx = phaseIndex(phase);
-  const childVisible = (i: number) =>
-    currentIdx >= phaseIndex(("spawn" + i) as Phase);
-  const childDone = (i: number) =>
-    currentIdx >= phaseIndex(("done" + i) as Phase);
-  const showPulses = currentIdx >= phaseIndex("reporting");
+  const isHighlight = phase === "highlight";
+  const isSliced = phase === "sliced";
 
   return (
-    <div style={{ width: "100%", maxWidth: 600, margin: "0 auto" }}>
-      <svg
-        viewBox="0 0 600 380"
-        width="100%"
-        height="100%"
-        style={{ overflow: "visible" }}
+    <div
+      style={{
+        width: "100%",
+        maxWidth: 900,
+        margin: "0 auto",
+        padding: "16px 16px",
+      }}
+    >
+      {/* Header label */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          marginBottom: 8,
+        }}
       >
-        <defs>
-          <style>{`
-            .rt-node {
-              transition: opacity 0.4s ease, transform 0.4s ease;
-            }
-            .rt-line {
-              transition: opacity 0.4s ease;
-            }
-            @keyframes rt-pulse-up {
-              0% { offset-distance: 100%; opacity: 0; }
-              10% { opacity: 1; }
-              90% { opacity: 1; }
-              100% { offset-distance: 0%; opacity: 0; }
-            }
-            @keyframes rt-glow {
-              0%, 100% { opacity: 0.4; }
-              50% { opacity: 0.8; }
-            }
-          `}</style>
-          {CHILDREN.map((child, i) => (
-            <path
-              key={`path-${i}`}
-              id={`conn-${i}`}
-              d={`M ${PARENT_X} ${PARENT_Y + NODE_H} C ${PARENT_X} ${(PARENT_Y + CHILD_Y) / 2}, ${child.x} ${(PARENT_Y + CHILD_Y) / 2}, ${child.x} ${CHILD_Y}`}
-              fill="none"
-            />
-          ))}
-        </defs>
+        <span
+          style={{
+            fontSize: 13,
+            fontWeight: 600,
+            color: isSliced
+              ? "#28c840"
+              : isHighlight
+                ? "#f85149"
+                : "var(--ifm-color-emphasis-600)",
+            fontFamily: "system-ui, sans-serif",
+            transition: "color 0.5s ease",
+          }}
+        >
+          {isSliced
+            ? "∞ Infinity — Time-Sliced"
+            : isHighlight
+              ? "Traditional — Wasted Resources"
+              : "Traditional Agent Runtime"}
+        </span>
+      </div>
 
-        {/* Connection lines */}
-        {CHILDREN.map((child, i) => (
-          <use
-            key={`line-${i}`}
-            href={`#conn-${i}`}
-            stroke="var(--ifm-color-emphasis-300)"
-            strokeWidth="2"
-            className="rt-line"
-            style={{ opacity: childVisible(i) ? 1 : 0 }}
-          />
-        ))}
+      <svg
+        viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+        width="100%"
+        style={{ overflow: "visible", display: "block" }}
+      >
+        {/* Time axis (at top) */}
+        <line
+          x1={MARGIN_LEFT}
+          y1={12}
+          x2={SVG_W - MARGIN_RIGHT}
+          y2={12}
+          stroke="var(--ifm-color-emphasis-400)"
+          strokeWidth="1"
+        />
+        <text
+          x={MARGIN_LEFT + 5}
+          y={4}
+          textAnchor="start"
+          fill="var(--ifm-color-emphasis-600)"
+          fontSize="11"
+          fontFamily="system-ui, sans-serif"
+        >
+          time →
+        </text>
 
-        {/* Pulse dots traveling up connections */}
-        {CHILDREN.map((_, i) =>
-          showPulses && childVisible(i) && !childDone(i) ? (
-            <React.Fragment key={`pulses-${i}`}>
-              <circle
-                r="5"
-                fill="var(--ifm-color-primary)"
-                style={{
-                  offsetPath: `path("M ${CHILDREN[i].x} ${CHILD_Y} C ${CHILDREN[i].x} ${(PARENT_Y + CHILD_Y) / 2}, ${PARENT_X} ${(PARENT_Y + CHILD_Y) / 2}, ${PARENT_X} ${PARENT_Y + NODE_H}")`,
-                  animation: `rt-pulse-up 1.5s ease-in-out infinite`,
-                  animationDelay: `${i * 0.4}s`,
-                }}
-              />
-              <circle
-                r="5"
-                fill="var(--ifm-color-primary)"
-                style={{
-                  offsetPath: `path("M ${CHILDREN[i].x} ${CHILD_Y} C ${CHILDREN[i].x} ${(PARENT_Y + CHILD_Y) / 2}, ${PARENT_X} ${(PARENT_Y + CHILD_Y) / 2}, ${PARENT_X} ${PARENT_Y + NODE_H}")`,
-                  animation: `rt-pulse-up 1.5s ease-in-out infinite`,
-                  animationDelay: `${i * 0.4 + 0.75}s`,
-                }}
-              />
-            </React.Fragment>
-          ) : null,
-        )}
+        {/* Resource axis label */}
+        <text
+          x={12}
+          y={TRAD_TOP + 60}
+          textAnchor="middle"
+          fill="var(--ifm-color-emphasis-600)"
+          fontSize="11"
+          fontFamily="system-ui, sans-serif"
+          transform={`rotate(-90, 12, ${TRAD_TOP + 60})`}
+        >
+          ← compute × memory
+        </text>
 
-        {/* Parent node */}
-        <g>
-          <rect
-            x={PARENT_X - NODE_W / 2}
-            y={PARENT_Y}
-            width={NODE_W}
-            height={NODE_H}
-            rx={10}
-            fill="var(--ifm-background-surface-color)"
-            stroke="var(--ifm-color-primary)"
-            strokeWidth="2"
-          />
-          {/* Gentle glow */}
-          <rect
-            x={PARENT_X - NODE_W / 2}
-            y={PARENT_Y}
-            width={NODE_W}
-            height={NODE_H}
-            rx={10}
-            fill="none"
-            stroke="var(--ifm-color-primary)"
-            strokeWidth="4"
-            style={{ animation: "rt-glow 2s ease-in-out infinite" }}
-          />
-          <text
-            x={PARENT_X}
-            y={PARENT_Y + NODE_H / 2 + 1}
-            textAnchor="middle"
-            dominantBaseline="central"
-            fill="var(--ifm-font-color-base)"
-            fontSize="14"
-            fontWeight="600"
-            fontFamily="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
-          >
-            Parent
-          </text>
-        </g>
-
-        {/* Child nodes */}
-        {CHILDREN.map((child, i) => {
-          const visible = childVisible(i);
-          const done = childDone(i);
+        {/* Traditional: idle segments (dashed outlines) */}
+        {TIMELINES.map((timeline, agentIdx) => {
+          const color = COLORS[agentIdx];
+          const tradY = TRAD_TOP + agentIdx * TRAD_LANE_PITCH;
           return (
-            <g
-              key={`child-${i}`}
-              className="rt-node"
-              style={{
-                opacity: visible ? 1 : 0,
-                transform: visible ? "translateY(0)" : "translateY(-20px)",
-              }}
-            >
-              <rect
-                x={child.x - NODE_W / 2}
-                y={CHILD_Y}
-                width={NODE_W}
-                height={NODE_H}
-                rx={10}
-                fill="var(--ifm-background-surface-color)"
-                stroke={done ? "#28c840" : "var(--ifm-color-emphasis-200)"}
-                strokeWidth="2"
-                style={{ transition: "stroke 0.3s ease" }}
-              />
-              <text
-                x={child.x}
-                y={CHILD_Y + (done ? 17 : NODE_H / 2 + 1)}
-                textAnchor="middle"
-                dominantBaseline="central"
-                fill="var(--ifm-font-color-base)"
-                fontSize="12"
-                fontWeight="500"
-                fontFamily="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
-              >
-                {child.label}
-              </text>
-              {done && (
-                <text
-                  x={child.x}
-                  y={CHILD_Y + 32}
-                  textAnchor="middle"
-                  dominantBaseline="central"
-                  fill="#28c840"
-                  fontSize="11"
-                  fontWeight="600"
-                  fontFamily="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
-                >
-                  done ✓
-                </text>
-              )}
+            <g key={`idle-${agentIdx}`}>
+              {timeline
+                .filter((seg) => !seg.active)
+                .map((seg, segIdx) => {
+                  const x = MARGIN_LEFT + (seg.start / 100) * TRACK_W;
+                  const w = ((seg.end - seg.start) / 100) * TRACK_W;
+                  return (
+                    <rect
+                      key={segIdx}
+                      x={x}
+                      y={tradY}
+                      width={w}
+                      height={LANE_H}
+                      rx={4}
+                      fill={isHighlight ? "rgba(248,81,73,0.15)" : "none"}
+                      stroke={isHighlight ? "#f85149" : color}
+                      strokeWidth="1.5"
+                      strokeDasharray={isHighlight ? "0" : "4 3"}
+                      opacity={isSliced ? 0 : isHighlight ? 0.8 : 0.3}
+                      style={{
+                        transition: "all 0.6s cubic-bezier(0.4, 0, 0.2, 1)",
+                      }}
+                    />
+                  );
+                })}
             </g>
           );
         })}
+
+        {/* Active blocks — animate between traditional position and packed position */}
+        {ACTIVE_BLOCKS.map((block, idx) => {
+          const x = MARGIN_LEFT + (block.start / 100) * TRACK_W;
+          const w = ((block.end - block.start) / 100) * TRACK_W;
+          const tradY = TRAD_TOP + block.agentIdx * TRAD_LANE_PITCH;
+          const slicedY = SLICED_TOP + block.packedRow * SLICED_LANE_PITCH;
+          const offset = isSliced ? slicedY - tradY : 0;
+
+          return (
+            <rect
+              key={idx}
+              x={x}
+              y={tradY}
+              width={w}
+              height={LANE_H}
+              rx={4}
+              fill={block.color}
+              opacity={0.85}
+              style={{
+                transform: `translateY(${offset}px)`,
+                transition: "transform 0.8s cubic-bezier(0.4, 0, 0.2, 1)",
+              }}
+            />
+          );
+        })}
+
+        {/* Agent labels (traditional view) */}
+        {AGENT_LABELS.map((label, agentIdx) => {
+          const tradY = TRAD_TOP + agentIdx * TRAD_LANE_PITCH;
+          return (
+            <text
+              key={agentIdx}
+              x={SVG_W - MARGIN_RIGHT + 8}
+              y={tradY + LANE_H / 2 + 1}
+              textAnchor="start"
+              dominantBaseline="central"
+              fill={COLORS[agentIdx]}
+              fontSize="11"
+              fontWeight="500"
+              fontFamily="system-ui, sans-serif"
+              opacity={isSliced ? 0 : 1}
+              style={{
+                transition: "opacity 0.8s cubic-bezier(0.4, 0, 0.2, 1)",
+              }}
+            >
+              {label}
+            </text>
+          );
+        })}
+
+        {/* Annotation for sliced view */}
+        {isSliced && (
+          <g>
+            <line
+              x1={SVG_W - MARGIN_RIGHT + 8}
+              y1={SLICED_TOP}
+              x2={SVG_W - MARGIN_RIGHT + 8}
+              y2={SLICED_TOP + PACKED_ROW_COUNT * SLICED_LANE_PITCH}
+              stroke="#28c840"
+              strokeWidth="1.5"
+              opacity={0.6}
+            />
+            <text
+              x={SVG_W - MARGIN_RIGHT}
+              y={SLICED_TOP + PACKED_ROW_COUNT * SLICED_LANE_PITCH + 24}
+              textAnchor="end"
+              fill="#28c840"
+              fontSize="11"
+              fontWeight="500"
+              fontFamily="system-ui, sans-serif"
+              opacity={0.8}
+            >
+              ↕ only active slices use compute
+            </text>
+          </g>
+        )}
       </svg>
     </div>
   );

--- a/docs/src/components/SwarmSection.tsx
+++ b/docs/src/components/SwarmSection.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import React from "react";
 
 export default function SwarmSection(): React.JSX.Element {
   return (
     <section className="swarm-section">
-      <h2>Designed for Swarms</h2>
+      <h2>Agent-Native Concurrency</h2>
       <p>
-        Agents spawn child threads for parallel work. Each child reports back
-        via subscriptions — the parent stays focused while the swarm fans out.
+        Threads, sleep, and yield are first-class primitives exposed directly to
+        agents. Spawn parallel work, await results, and release resources while
+        idle, all through the same tool interface agents already use.
       </p>
       <div className="comparison-grid">
         <div className="swarm-blurb">
@@ -18,12 +19,15 @@ export default function SwarmSection(): React.JSX.Element {
             subscription mechanism that powers real-time events.
           </p>
           <p>
-            The parent never blocks. Reports arrive as subscription events —
-            the parent sees them in-context and decides what to do next. Children
+            The parent never blocks. Reports arrive as subscription events and
+            the parent sees them in-context, deciding what to do next. Children
             can send multiple interim reports before closing, giving the parent
             a live view of swarm progress.
           </p>
-          <a href="/docs/infinity-runtime/threading" className="feature-learn-more">
+          <a
+            href="/docs/infinity-runtime/threading"
+            className="feature-learn-more"
+          >
             Threading docs →
           </a>
         </div>

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -2,590 +2,590 @@
 
 /* Hero */
 .hero-section {
-    max-width: 1600px;
-    margin: 0 auto;
-    padding: 5rem 2rem 4rem;
-    text-align: center;
+  max-width: 1600px;
+  margin: 0 auto;
+  padding: 5rem 2rem 4rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  text-align: center;
 }
 
 .hero-section h1 {
-    font-size: 5rem;
-    font-weight: 700;
-    line-height: 1.1;
-    margin-bottom: 1rem;
-    letter-spacing: -0.03em;
+  font-size: 5rem;
+  font-weight: 700;
+  line-height: 1.1;
+  margin-bottom: 1rem;
+  letter-spacing: -0.03em;
 }
 
 .hero-section h1 .gradient-text {
-    background: linear-gradient(135deg, #79b8ff 0%, #3a7bd5 50%, #b392f0 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  background: linear-gradient(135deg, #79b8ff 0%, #3a7bd5 50%, #b392f0 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .hero-tagline {
-    font-size: 1.35rem;
-    line-height: 1.6;
-    color: var(--ifm-color-emphasis-700);
-    margin: 0 auto 2rem;
-    max-width: 560px;
+  font-size: 1.35rem;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+  margin: 0 auto 2rem;
+  max-width: 560px;
 }
 
 .hero-buttons {
-    display: flex;
-    gap: 1rem;
-    justify-content: center;
-    flex-wrap: wrap;
-    margin-bottom: 3rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 3rem;
 }
 
 .hero-buttons a {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.75rem 1.5rem;
-    border-radius: 8px;
-    font-weight: 600;
-    font-size: 0.95rem;
-    text-decoration: none;
-    transition: all 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: all 0.15s ease;
 }
 
 .hero-buttons .primary {
-    background: var(--ifm-color-primary);
-    color: #fff;
+  background: var(--ifm-color-primary);
+  color: #fff;
 }
 
 .hero-buttons .primary:hover {
-    opacity: 0.9;
-    transform: translateY(-1px);
-    color: #fff;
-    text-decoration: none;
+  opacity: 0.9;
+  transform: translateY(-1px);
+  color: #fff;
+  text-decoration: none;
 }
 
 .hero-buttons .secondary {
-    background: transparent;
-    border: 1px solid var(--ifm-color-emphasis-300);
-    color: var(--ifm-color-emphasis-800);
+  background: transparent;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-emphasis-800);
 }
 
 .hero-buttons .secondary:hover {
-    border-color: var(--ifm-color-primary);
-    color: var(--ifm-color-primary);
-    text-decoration: none;
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  text-decoration: none;
 }
 
 /* Tab switcher */
 .tab-switcher {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: center;
-    margin-bottom: 2.5rem;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1.5rem;
 }
 
 .tab-pill {
-    position: relative;
-    padding: 0.6rem 1.25rem;
-    border-radius: 999px;
-    border: 1px solid var(--ifm-color-emphasis-200);
-    background: transparent;
-    color: var(--ifm-color-emphasis-600);
-    font-size: 0.95rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.15s ease;
-    overflow: hidden;
-    font-family: inherit;
+  position: relative;
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: transparent;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  overflow: hidden;
+  font-family: inherit;
 }
 
 .tab-pill:hover {
-    border-color: var(--ifm-color-primary);
-    color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
 }
 
 .tab-pill--active {
-    border-color: var(--ifm-color-primary);
-    color: var(--ifm-color-primary);
-    font-weight: 600;
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  font-weight: 600;
 }
 
 .tab-progress {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: var(--ifm-color-primary);
-    transform-origin: left;
-    transition: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--ifm-color-primary);
+  transform-origin: left;
+  transition: none;
 }
 
 /* Showcase */
 .showcase {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-    text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: center;
 }
 
 .showcase code {
-    background: none;
-    border: none;
-    border-radius: 0;
-    padding: 0;
+  background: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
 }
 
 .showcase p {
-    margin: 0;
+  margin: 0;
 }
 
 @media (max-width: 996px) {
-    .hero-section h1 {
-        font-size: 3.5rem;
-    }
+  .hero-section h1 {
+    font-size: 3.5rem;
+  }
 }
 
 .showcase-text h2 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    margin-bottom: 0.5rem;
-    letter-spacing: -0.01em;
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.01em;
 }
 
 .showcase-text p {
-    font-size: 1.05rem;
-    line-height: 1.6;
-    color: var(--ifm-color-emphasis-700);
-    margin: 0 auto 0.75rem;
-    max-width: 560px;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+  margin: 0 auto 0.75rem;
+  max-width: 710px;
 }
 
 .showcase-link {
-    display: inline-flex;
-    align-items: center;
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: var(--ifm-color-primary);
-    text-decoration: none;
-    transition: opacity 0.15s;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+  transition: opacity 0.15s;
 }
 
 .showcase-link:hover {
-    opacity: 0.8;
-    text-decoration: none;
+  opacity: 0.8;
+  text-decoration: none;
 }
 
 .showcase-visual {
-    min-height: 400px;
-    display: flex;
-    justify-content: center;
-    text-align: left;
+  min-height: 400px;
+  display: flex;
+  justify-content: center;
+  text-align: left;
 }
 
 .showcase-pane {
-    width: 100%;
+  width: 100%;
 }
 
 /* Terminal */
 .terminal {
-    background: #0d1117;
-    border-radius: 12px;
-    overflow: hidden;
-    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
-    border: 1px solid #21262d;
-    font-family:
-        "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
-    font-size: 0.9rem;
-    line-height: 1.6;
-    min-height: 530px;
+  background: #0d1117;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  border: 1px solid #21262d;
+  font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  min-height: 530px;
 }
 
 .terminal-header {
-    display: flex;
-    align-items: center;
-    padding: 12px 16px;
-    background: #161b22;
-    border-bottom: 1px solid #21262d;
-    gap: 8px;
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  gap: 8px;
 }
 
 .terminal-dot {
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
 }
 
 .terminal-dot.red {
-    background: #ff5f57;
+  background: #ff5f57;
 }
 .terminal-dot.yellow {
-    background: #febc2e;
+  background: #febc2e;
 }
 .terminal-dot.green {
-    background: #28c840;
+  background: #28c840;
 }
 
 .terminal-title {
-    flex: 1;
-    text-align: center;
-    color: #8b949e;
-    font-size: 0.75rem;
+  flex: 1;
+  text-align: center;
+  color: #8b949e;
+  font-size: 0.75rem;
 }
 
 .terminal-body {
-    padding: 16px;
-    color: #c9d1d9;
-    overflow-y: scroll;
-    height: 490px;
+  padding: 16px;
+  color: #c9d1d9;
+  overflow-y: scroll;
+  height: 490px;
 }
 
 .terminal-line {
-    white-space: pre-wrap;
-    word-break: break-word;
-    opacity: 0;
-    animation: fadeInLine 0.3s ease forwards;
-    margin-bottom: 2px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  opacity: 0;
+  animation: fadeInLine 0.3s ease forwards;
+  margin-bottom: 2px;
 }
 
 .terminal-line .prompt {
-    color: #a29bfe;
+  color: #a29bfe;
 }
 
 .terminal-line .command {
-    color: #f0f6fc;
+  color: #f0f6fc;
 }
 
 .terminal-line .tool-call {
-    color: #79c0ff;
+  color: #79c0ff;
 }
 
 .terminal-line .tool-type {
-    color: #8b949e;
-    font-style: italic;
+  color: #8b949e;
+  font-style: italic;
 }
 
 .terminal-line .result {
-    color: #7ee787;
+  color: #7ee787;
 }
 
 .terminal-line .event {
-    color: #ffa657;
+  color: #ffa657;
 }
 
 .terminal-line .dim {
-    color: #8b949e;
+  color: #8b949e;
 }
 
 .terminal-line .sleep-text {
-    color: #b392f0;
+  color: #b392f0;
 }
 
 @keyframes fadeInLine {
-    from {
-        opacity: 0;
-        transform: translateY(4px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .cursor-blink {
-    display: inline-block;
-    width: 8px;
-    height: 16px;
-    background: #c9d1d9;
-    animation: blink 1s step-end infinite;
-    vertical-align: text-bottom;
+  display: inline-block;
+  width: 8px;
+  height: 16px;
+  background: #c9d1d9;
+  animation: blink 1s step-end infinite;
+  vertical-align: text-bottom;
 }
 
 @keyframes blink {
-    50% {
-        opacity: 0;
-    }
+  50% {
+    opacity: 0;
+  }
 }
 
 /* Feature sections */
 .features-section {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 3rem 2rem 6rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 2rem 6rem;
 }
 
 .features-section h2 {
-    text-align: center;
-    font-size: 2rem;
-    margin-bottom: 3rem;
-    font-weight: 700;
-    letter-spacing: -0.01em;
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 3rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
 .features-tabbed {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 2rem;
-    align-items: center;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  align-items: center;
 }
 
 @media (max-width: 996px) {
-    .features-tabbed {
-        grid-template-columns: 1fr;
-    }
+  .features-tabbed {
+    grid-template-columns: 1fr;
+  }
 }
 
 .features-left {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .feature-tab {
-    display: flex;
-    align-items: flex-start;
-    gap: 1rem;
-    padding: 1.25rem 1.5rem;
-    border-radius: 12px;
-    border: 1px solid transparent;
-    background: transparent;
-    cursor: pointer;
-    text-align: left;
-    transition: all 0.15s ease;
-    color: var(--ifm-font-color-base);
-    width: 100%;
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.15s ease;
+  color: var(--ifm-font-color-base);
+  width: 100%;
 }
 
 .feature-tab:hover {
-    background: var(--ifm-background-surface-color);
+  background: var(--ifm-background-surface-color);
 }
 
 .feature-tab--active {
-    background: var(--ifm-background-surface-color);
-    border-color: var(--ifm-color-primary);
+  background: var(--ifm-background-surface-color);
+  border-color: var(--ifm-color-primary);
 }
 
 .feature-tab-icon {
-    font-size: 1.5rem;
-    flex-shrink: 0;
-    margin-top: 2px;
+  font-size: 1.5rem;
+  flex-shrink: 0;
+  margin-top: 2px;
 }
 
 .feature-tab h3 {
-    font-size: 1.1rem;
-    margin: 0 0 0.4rem;
-    font-weight: 600;
+  font-size: 1.1rem;
+  margin: 0 0 0.4rem;
+  font-weight: 600;
 }
 
 .feature-tab p {
-    color: var(--ifm-color-emphasis-600);
-    line-height: 1.5;
-    margin: 0;
-    font-size: 1rem;
+  color: var(--ifm-color-emphasis-600);
+  line-height: 1.5;
+  margin: 0;
+  font-size: 1rem;
 }
 
 .feature-tab--active p {
-    color: var(--ifm-color-emphasis-700);
+  color: var(--ifm-color-emphasis-700);
 }
 
 .features-right pre {
-    margin: 0;
-    border-radius: 12px;
-    padding: 1.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    line-height: 1.7;
-    overflow-x: auto;
-    min-height: 340px;
+  margin: 0;
+  border-radius: 12px;
+  padding: 1.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.7;
+  overflow-x: auto;
+  min-height: 340px;
 }
 
 .features-right pre code {
-    font-weight: 500;
-    background: none;
-    padding: 0;
+  font-weight: 500;
+  background: none;
+  padding: 0;
 }
 
 .feature-learn-more {
-    display: inline-flex;
-    align-items: center;
-    margin-top: 1rem;
-    padding: 0.6rem 1.25rem;
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: var(--ifm-color-primary);
-    border: 1px solid var(--ifm-color-primary);
-    border-radius: 8px;
-    text-decoration: none;
-    transition: all 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  margin-top: 1rem;
+  padding: 0.6rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  border: 1px solid var(--ifm-color-primary);
+  border-radius: 8px;
+  text-decoration: none;
+  transition: all 0.15s ease;
 }
 
 .feature-learn-more:hover {
-    background: var(--ifm-color-primary);
-    color: #fff;
-    text-decoration: none;
+  background: var(--ifm-color-primary);
+  color: #fff;
+  text-decoration: none;
 }
 
 /* Landing page layout */
 .landing-page {
-    overflow-x: hidden;
+  overflow-x: hidden;
 }
 
 .landing-page .navbar {
-    background: transparent;
-    box-shadow: none;
+  background: transparent;
+  box-shadow: none;
 }
 
 /* Protocol comparison section */
 .comparison-section {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 2rem 2rem 4rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 2rem 4rem;
 }
 
 .comparison-section h2 {
-    text-align: center;
-    font-size: 2rem;
-    margin-bottom: 1rem;
-    font-weight: 700;
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  font-weight: 700;
 }
 
 .comparison-section > p {
-    text-align: center;
-    color: var(--ifm-color-emphasis-700);
-    max-width: 600px;
-    margin: 0 auto 3rem;
-    font-size: 1.05rem;
-    line-height: 1.6;
+  text-align: center;
+  color: var(--ifm-color-emphasis-700);
+  max-width: 600px;
+  margin: 0 auto 3rem;
+  font-size: 1.05rem;
+  line-height: 1.6;
 }
 
 .comparison-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 2rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
 }
 
 @media (max-width: 768px) {
-    .comparison-grid {
-        grid-template-columns: 1fr;
-    }
+  .comparison-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .comparison-card {
-    background: var(--ifm-background-surface-color);
-    border: 1px solid var(--ifm-color-emphasis-200);
-    border-radius: 12px;
-    padding: 2rem;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  padding: 2rem;
 }
 
 .comparison-card h3 {
-    font-size: 1.1rem;
-    margin-bottom: 1rem;
-    font-weight: 600;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+  font-weight: 600;
 }
 
 .comparison-card pre {
-    margin: 0;
-    font-size: 0.9rem;
-    background: #0d1117;
-    border-radius: 8px;
-    padding: 1rem;
-    overflow-x: auto;
-    color: #c9d1d9;
+  margin: 0;
+  font-size: 0.9rem;
+  background: #0d1117;
+  border-radius: 8px;
+  padding: 1rem;
+  overflow-x: auto;
+  color: #c9d1d9;
 }
 
 .comparison-card pre code {
-    color: #c9d1d9;
-    background: none;
-    padding: 0;
+  color: #c9d1d9;
+  background: none;
+  padding: 0;
 }
 
 .comparison-card .label {
-    display: inline-block;
-    font-size: 0.7rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    padding: 3px 8px;
-    border-radius: 4px;
-    margin-bottom: 0.75rem;
-    border: 1px solid gray;
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 3px 8px;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+  border: 1px solid gray;
 }
 
 .comparison-card .label.mcp {
-    background: transparent;
+  background: transparent;
 }
 
 .comparison-card .label.rap {
-    background: transparent;
-    color: var(--ifm-color-primary);
+  background: transparent;
+  color: var(--ifm-color-primary);
 }
 
 /* Swarm section */
 .swarm-section {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 2rem 2rem 6rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 2rem 6rem;
 }
 
 .swarm-section h2 {
-    text-align: center;
-    font-size: 2rem;
-    margin-bottom: 1rem;
-    font-weight: 700;
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  font-weight: 700;
 }
 
 .swarm-section > p {
-    text-align: center;
-    color: var(--ifm-color-emphasis-700);
-    max-width: 600px;
-    margin: 0 auto 3rem;
-    font-size: 1.05rem;
-    line-height: 1.6;
+  text-align: center;
+  color: var(--ifm-color-emphasis-700);
+  max-width: 600px;
+  margin: 0 auto 3rem;
+  font-size: 1.05rem;
+  line-height: 1.6;
 }
 
 .swarm-blurb {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .swarm-blurb h3 {
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin-bottom: 1rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
 }
 
 .swarm-blurb p {
-    color: var(--ifm-color-emphasis-700);
-    line-height: 1.6;
-    font-size: 1rem;
-    margin-bottom: 1rem;
+  color: var(--ifm-color-emphasis-700);
+  line-height: 1.6;
+  font-size: 1rem;
+  margin-bottom: 1rem;
 }
 
 .swarm-code pre {
-    margin: 0;
-    font-size: 0.85rem;
-    background: #0d1117;
-    border-radius: 12px;
-    padding: 1.5rem;
-    overflow-x: auto;
-    color: #c9d1d9;
-    line-height: 1.6;
-    border: 1px solid #21262d;
+  margin: 0;
+  font-size: 0.85rem;
+  background: #0d1117;
+  border-radius: 12px;
+  padding: 1.5rem;
+  overflow-x: auto;
+  color: #c9d1d9;
+  line-height: 1.6;
+  border: 1px solid #21262d;
 }
 
 .swarm-code pre code {
-    color: #c9d1d9;
-    background: none;
-    padding: 0;
+  color: #c9d1d9;
+  background: none;
+  padding: 0;
 }
 
 /* (Infinity Code showcase removed — now part of hero tab vignette) */
 
 /* Sidebar section headers */
 .menu__list-item > h4 {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 .menu__list-item > h4.with-border {
-    border-top: 2px solid var(--ifm-color-emphasis-500);
-    padding-top: 0.75rem;
-    margin-top: 0.5rem;
+  border-top: 2px solid var(--ifm-color-emphasis-500);
+  padding-top: 0.75rem;
+  margin-top: 0.5rem;
 }

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import Layout from "@theme/Layout";
-import AnimatedTerminal from "../components/AnimatedTerminal";
+import ProtocolDiagram from "../components/ProtocolDiagram";
 import RuntimeDiagram from "../components/RuntimeDiagram";
 import DesktopMini from "../components/DesktopMini";
 import FeatureCards from "../components/FeatureCards";
@@ -19,16 +19,6 @@ interface Tab {
 
 const TABS: Tab[] = [
   {
-    id: "code",
-    label: "∞ Code",
-    heading: "Infinity Code",
-    description:
-      "An AI coding agent for your terminal and desktop. Concurrent sessions, sandboxed execution, background agents, and live thread visualization — all powered by the Infinity Runtime.",
-    link: "/docs/infinity-code/overview",
-    linkLabel: "Get started →",
-    duration: 25000,
-  },
-  {
     id: "protocol",
     label: "∞ Protocol",
     heading: "Reactive Agent Protocol",
@@ -36,7 +26,7 @@ const TABS: Tab[] = [
       "The tool protocol for agents that live in the real world. Subscribe to real-time events, execute operations that take hours, and hibernate with zero compute cost. MCP-compatible.",
     link: "/docs/rap/what-is-rap",
     linkLabel: "Specification →",
-    duration: 18000,
+    duration: 15000,
   },
   {
     id: "runtime",
@@ -46,7 +36,17 @@ const TABS: Tab[] = [
       "A principled agent runtime with first-class concurrency. Spawn threads, hibernate between tasks, and pay nothing while idle. Agents can run for years at near-zero cost.",
     link: "/docs/infinity-runtime/overview",
     linkLabel: "Learn more →",
-    duration: 8000,
+    duration: 14000,
+  },
+  {
+    id: "code",
+    label: "∞ Code",
+    heading: "Infinity Code",
+    description:
+      "An AI coding agent for your terminal and desktop. Concurrent sessions, sandboxed execution, background agents, and live thread visualization — all powered by the Infinity Runtime.",
+    link: "/docs/infinity-code/overview",
+    linkLabel: "Get started →",
+    duration: 25000,
   },
 ];
 
@@ -97,20 +97,20 @@ function Showcase({ active }: { active: number }) {
           className="showcase-pane"
           style={{ display: active === 0 ? "block" : "none" }}
         >
-          <DesktopMini active={active === 0} />
+          <ProtocolDiagram active={active === 0} />
         </div>
-          <div
-            className="showcase-pane"
-            style={{ display: active === 1 ? "block" : "none" }}
-          >
-            <AnimatedTerminal active={active === 1} />
-          </div>
-          <div
-            className="showcase-pane"
-            style={{ display: active === 2 ? "block" : "none" }}
-          >
-            <RuntimeDiagram active={active === 2} />
-          </div>
+        <div
+          className="showcase-pane"
+          style={{ display: active === 1 ? "block" : "none" }}
+        >
+          <RuntimeDiagram active={active === 1} />
+        </div>
+        <div
+          className="showcase-pane"
+          style={{ display: active === 2 ? "block" : "none" }}
+        >
+          <DesktopMini active={active === 2} />
+        </div>
       </div>
     </div>
   );
@@ -120,30 +120,40 @@ export default function Home(): React.JSX.Element {
   const [active, setActive] = useState(0);
   const [progress, setProgress] = useState(0);
   const [locked, setLocked] = useState(false);
+  const [paused, setPaused] = useState(false);
   const startRef = useRef(Date.now());
   const rafRef = useRef<number>(0);
+  const elapsedBeforePauseRef = useRef(0);
 
   const selectTab = useCallback((i: number) => {
     setActive(i);
     setProgress(0);
     startRef.current = Date.now();
+    elapsedBeforePauseRef.current = 0;
     setLocked(true);
   }, []);
 
   // Auto-rotation + progress bar
   useEffect(() => {
+    if (paused) {
+      cancelAnimationFrame(rafRef.current);
+      return;
+    }
+
     if (locked) {
+      startRef.current = Date.now() - elapsedBeforePauseRef.current;
       // Unlock and advance to next tab after one full cycle
+      const remaining = TABS[active].duration - elapsedBeforePauseRef.current;
       const timer = setTimeout(() => {
         setLocked(false);
         setActive((prev) => (prev + 1) % TABS.length);
         setProgress(0);
         startRef.current = Date.now();
-      }, TABS[active].duration);
-      // Still animate progress while locked
-      startRef.current = Date.now();
+        elapsedBeforePauseRef.current = 0;
+      }, remaining);
       function tick() {
         const elapsed = Date.now() - startRef.current;
+        elapsedBeforePauseRef.current = elapsed;
         const p = Math.min(1, elapsed / TABS[active].duration);
         setProgress(p);
         if (p < 1) rafRef.current = requestAnimationFrame(tick);
@@ -155,9 +165,10 @@ export default function Home(): React.JSX.Element {
       };
     }
 
-    startRef.current = Date.now();
+    startRef.current = Date.now() - elapsedBeforePauseRef.current;
     function tick() {
       const elapsed = Date.now() - startRef.current;
+      elapsedBeforePauseRef.current = elapsed;
       const duration = TABS[active].duration;
       const p = Math.min(1, elapsed / duration);
       setProgress(p);
@@ -165,12 +176,13 @@ export default function Home(): React.JSX.Element {
         setActive((prev) => (prev + 1) % TABS.length);
         setProgress(0);
         startRef.current = Date.now();
+        elapsedBeforePauseRef.current = 0;
       }
       rafRef.current = requestAnimationFrame(tick);
     }
     rafRef.current = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafRef.current);
-  }, [active, locked]);
+  }, [active, locked, paused]);
 
   return (
     <Layout
@@ -196,12 +208,17 @@ export default function Home(): React.JSX.Element {
               GitHub →
             </a>
           </div>
-          <TabSwitcher
-            active={active}
-            onSelect={selectTab}
-            progress={progress}
-          />
-          <Showcase active={active} />
+          <div
+            onMouseEnter={() => setPaused(true)}
+            onMouseLeave={() => setPaused(false)}
+          >
+            <TabSwitcher
+              active={active}
+              onSelect={selectTab}
+              progress={progress}
+            />
+            <Showcase active={active} />
+          </div>
         </section>
 
         <FeatureCards />

--- a/docs/src/theme/Navbar/Content/index.tsx
+++ b/docs/src/theme/Navbar/Content/index.tsx
@@ -1,28 +1,28 @@
-import React, {type ReactNode} from 'react';
-import clsx from 'clsx';
+import React, { type ReactNode } from "react";
+import clsx from "clsx";
 import {
   useThemeConfig,
   ErrorCauseBoundary,
   ThemeClassNames,
-} from '@docusaurus/theme-common';
+} from "@docusaurus/theme-common";
 import {
   splitNavbarItems,
   useNavbarMobileSidebar,
-} from '@docusaurus/theme-common/internal';
-import NavbarItem, {type Props as NavbarItemConfig} from '@theme/NavbarItem';
-import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle';
-import SearchBar from '@theme/SearchBar';
-import NavbarMobileSidebarToggle from '@theme/Navbar/MobileSidebar/Toggle';
-import NavbarSearch from '@theme/Navbar/Search';
-import {ProjectSwitcher, HydroBadge} from '@hydro-project/docusaurus-theme';
+} from "@docusaurus/theme-common/internal";
+import NavbarItem, { type Props as NavbarItemConfig } from "@theme/NavbarItem";
+import NavbarColorModeToggle from "@theme/Navbar/ColorModeToggle";
+import SearchBar from "@theme/SearchBar";
+import NavbarMobileSidebarToggle from "@theme/Navbar/MobileSidebar/Toggle";
+import NavbarSearch from "@theme/Navbar/Search";
+import { ProjectSwitcher, HydroBadge } from "@hydro-project/docusaurus-theme";
 
-import styles from './styles.module.css';
+import styles from "./styles.module.css";
 
 function useNavbarItems() {
   return useThemeConfig().navbar.items as NavbarItemConfig[];
 }
 
-function NavbarItems({items}: {items: NavbarItemConfig[]}): ReactNode {
+function NavbarItems({ items }: { items: NavbarItemConfig[] }): ReactNode {
   return (
     <>
       {items.map((item, i) => (
@@ -33,9 +33,10 @@ function NavbarItems({items}: {items: NavbarItemConfig[]}): ReactNode {
               `A theme navbar item failed to render.
 Please double-check the following navbar item (themeConfig.navbar.items) of your Docusaurus config:
 ${JSON.stringify(item, null, 2)}`,
-              {cause: error},
+              { cause: error },
             )
-          }>
+          }
+        >
           <NavbarItem {...item} />
         </ErrorCauseBoundary>
       ))}
@@ -55,15 +56,17 @@ function NavbarContentLayout({
       <div
         className={clsx(
           ThemeClassNames.layout.navbar.containerLeft,
-          'navbar__items',
-        )}>
+          "navbar__items",
+        )}
+      >
         {left}
       </div>
       <div
         className={clsx(
           ThemeClassNames.layout.navbar.containerRight,
-          'navbar__items navbar__items--right',
-        )}>
+          "navbar__items navbar__items--right",
+        )}
+      >
         {right}
       </div>
     </div>
@@ -74,7 +77,7 @@ export default function NavbarContent(): ReactNode {
   const mobileSidebar = useNavbarMobileSidebar();
   const items = useNavbarItems();
   const [leftItems, rightItems] = splitNavbarItems(items);
-  const searchBarItem = items.find((item) => item.type === 'search');
+  const searchBarItem = items.find((item) => item.type === "search");
 
   return (
     <NavbarContentLayout

--- a/infinity-ui/package.json
+++ b/infinity-ui/package.json
@@ -4,6 +4,10 @@
   "license": "Apache-2.0",
   "type": "module",
   "main": "src/index.ts",
+  "scripts": {
+    "format": "prettier --write \"src/**/*.{tsx,ts,css}\"",
+    "format:check": "prettier --check \"src/**/*.{tsx,ts,css}\""
+  },
   "dependencies": {
     "@pierre/diffs": "^1.2.1",
     "@pierre/trees": "^0.0.1-beta.4",

--- a/infinity-ui/src/components/ChatPanel.module.css
+++ b/infinity-ui/src/components/ChatPanel.module.css
@@ -1,95 +1,97 @@
 /* ── Chat right panel ── */
 
 .chatPanel {
-    position: fixed;
-    top: 12px;
-    right: 12px;
-    bottom: 12px;
-    width: var(--chat-panel-width, 420px);
-    z-index: 200;
-    display: flex;
-    flex-direction: column;
-    border-radius: 16px;
-    overflow: hidden;
-    transition:
-        transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-        opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  bottom: 12px;
+  width: var(--chat-panel-width, 420px);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  overflow: hidden;
+  transition:
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 
-    background: var(--glass-bg);
-    backdrop-filter: blur(24px) saturate(1.4);
-    -webkit-backdrop-filter: blur(24px) saturate(1.4);
-    border: 1px solid var(--glass-border);
-    box-shadow:
-        0 8px 32px var(--glass-shadow),
-        inset 0 0.5px 0 rgba(255, 255, 255, 0.06);
+  background: var(--glass-bg);
+  backdrop-filter: blur(24px) saturate(1.4);
+  -webkit-backdrop-filter: blur(24px) saturate(1.4);
+  border: 1px solid var(--glass-border);
+  box-shadow:
+    0 8px 32px var(--glass-shadow),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.06);
 }
 
 .chatPanelHidden {
-    transform: translateX(110%);
-    opacity: 0;
-    pointer-events: none;
+  transform: translateX(110%);
+  opacity: 0;
+  pointer-events: none;
 }
 
 .chatPanelHeader {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 14px 16px;
-    border-bottom: 1px solid var(--glass-border);
-    background: var(--bg-surface);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--glass-border);
+  background: var(--bg-surface);
 }
 
 .chatPanelTitle {
-    font-weight: 600;
-    font-size: 14px;
+  font-weight: 600;
+  font-size: 14px;
 }
 
 .chatPanelClose {
-    background: none;
-    border: 1px solid var(--glass-border);
-    color: var(--text-dim);
-    font-size: 14px;
-    padding: 4px 8px;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background 0.15s, opacity 0.15s;
+  background: none;
+  border: 1px solid var(--glass-border);
+  color: var(--text-dim);
+  font-size: 14px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    opacity 0.15s;
 }
 .chatPanelClose:hover {
-    background: var(--bg-hover);
+  background: var(--bg-hover);
 }
 .chatPanelClose[data-pinned="true"] {
-    opacity: 1;
+  opacity: 1;
 }
 .chatPanelClose[data-pinned="false"] {
-    opacity: 0.4;
+  opacity: 0.4;
 }
 
 .chatPanelBody {
-    flex: 1;
-    overflow: hidden;
-    position: relative;
+  flex: 1;
+  overflow: hidden;
+  position: relative;
 }
 
 .chatPanelResize {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 8px;
-    cursor: col-resize;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 8px;
+  cursor: col-resize;
 }
 .chatPanelResize:hover {
-    background: var(--accent);
-    opacity: 0.2;
-    border-radius: 4px;
+  background: var(--accent);
+  opacity: 0.2;
+  border-radius: 4px;
 }
 
 .chatPanelEmbedded {
-    composes: chatPanel;
-    position: relative;
-    top: unset;
-    right: unset;
-    bottom: unset;
-    height: 100%;
-    flex-shrink: 0;
+  composes: chatPanel;
+  position: relative;
+  top: unset;
+  right: unset;
+  bottom: unset;
+  height: 100%;
+  flex-shrink: 0;
 }

--- a/infinity-ui/src/components/ChatView.module.css
+++ b/infinity-ui/src/components/ChatView.module.css
@@ -1,14 +1,14 @@
 .container {
-    display: flex;
-    flex-direction: column;
-    position: absolute;
-    inset: 0;
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  inset: 0;
 }
 
 .inputArea {
-    z-index: 100;
-    max-width: var(--max-width);
-    width: 100%;
-    margin: 0 auto;
-    padding: 8px 12px 16px;
+  z-index: 100;
+  max-width: var(--max-width);
+  width: 100%;
+  margin: 0 auto;
+  padding: 8px 12px 16px;
 }

--- a/infinity-ui/src/components/ChoicePicker.module.css
+++ b/infinity-ui/src/components/ChoicePicker.module.css
@@ -1,67 +1,69 @@
 .picker {
-    width: 100%;
-    outline: none;
+  width: 100%;
+  outline: none;
 }
 
 .inner {
-    background: var(--glass-bg);
-    backdrop-filter: blur(24px) saturate(1.4);
-    -webkit-backdrop-filter: blur(24px) saturate(1.4);
-    border: 1px solid var(--glass-border);
-    box-shadow:
-        0 8px 32px var(--glass-shadow),
-        inset 0 0.5px 0 rgba(255, 255, 255, 0.06);
-    border-radius: 16px;
-    padding: 12px 14px;
+  background: var(--glass-bg);
+  backdrop-filter: blur(24px) saturate(1.4);
+  -webkit-backdrop-filter: blur(24px) saturate(1.4);
+  border: 1px solid var(--glass-border);
+  box-shadow:
+    0 8px 32px var(--glass-shadow),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  padding: 12px 14px;
 }
 
 .prompt {
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--accent-orange);
-    margin-bottom: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent-orange);
+  margin-bottom: 6px;
 }
 
 .choices {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .choice {
-    display: block;
-    width: 100%;
-    text-align: left;
-    background: none;
-    border: none;
-    border-radius: 8px;
-    padding: 6px 10px;
-    font-family: var(--font-sans);
-    font-size: 14px;
-    color: var(--text-muted);
-    cursor: pointer;
-    transition: background 0.1s, color 0.1s;
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    background 0.1s,
+    color 0.1s;
 }
 
 .choice:hover {
-    background: var(--bg-hover);
-    color: var(--text);
+  background: var(--bg-hover);
+  color: var(--text);
 }
 
 .choiceSelected {
-    composes: choice;
-    background: var(--accent);
-    color: white;
+  composes: choice;
+  background: var(--accent);
+  color: white;
 }
 
 .choiceSelected:hover {
-    background: var(--accent);
-    color: white;
+  background: var(--accent);
+  color: white;
 }
 
 .defaultTag {
-    font-size: 11px;
-    color: var(--text-muted);
-    margin-left: 6px;
-    font-weight: normal;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: 6px;
+  font-weight: normal;
 }

--- a/infinity-ui/src/components/DiffView.module.css
+++ b/infinity-ui/src/components/DiffView.module.css
@@ -1,58 +1,58 @@
 .root {
-    display: flex;
-    height: 100%;
-    overflow: hidden;
+  display: flex;
+  height: 100%;
+  overflow: hidden;
 }
 
 .sidebar {
-    margin-top: 16px;
-    margin-right: 16px;
-    width: 240px;
-    min-width: 200px;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
+  margin-top: 16px;
+  margin-right: 16px;
+  width: 240px;
+  min-width: 200px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebarHeader {
-    padding: 12px 16px 8px;
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-dim);
+  padding: 12px 16px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
 }
 
 .diffPaneWrapper {
-    flex: 1;
-    min-height: 0;
-    display: grid;
-    border-radius: 16px 16px 0 0;
-    overflow: hidden;
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  border-radius: 16px 16px 0 0;
+  overflow: hidden;
 }
 
 .diffPane {
-    overflow-y: auto;
-    overflow-x: clip;
+  overflow-y: auto;
+  overflow-x: clip;
 }
 
 .diffPane diffs-container {
-    contain: layout paint style;
-    overflow: clip;
-    border-radius: 16px;
+  contain: layout paint style;
+  overflow: clip;
+  border-radius: 16px;
 }
 
 .sidebar file-tree-container {
-    --trees-bg: transparent;
-    --trees-bg-muted: transparent;
-    --trees-fg: inherit;
+  --trees-bg: transparent;
+  --trees-bg-muted: transparent;
+  --trees-fg: inherit;
 }
 
 .empty {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    color: var(--text-muted);
-    font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-muted);
+  font-size: 14px;
 }

--- a/infinity-ui/src/components/InputBar.module.css
+++ b/infinity-ui/src/components/InputBar.module.css
@@ -1,66 +1,66 @@
 .bar {
-    width: 100%;
+  width: 100%;
 }
 
 .inner {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    background: var(--glass-bg);
-    backdrop-filter: blur(24px) saturate(1.4);
-    -webkit-backdrop-filter: blur(24px) saturate(1.4);
-    box-sizing: border-box;
-    border: 1px solid var(--glass-border);
-    box-shadow:
-        0 8px 32px var(--glass-shadow),
-        inset 0 0.5px 0 rgba(255, 255, 255, 0.06);
-    border-radius: 16px;
-    padding: 10px 14px;
-    transition: border-color 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--glass-bg);
+  backdrop-filter: blur(24px) saturate(1.4);
+  -webkit-backdrop-filter: blur(24px) saturate(1.4);
+  box-sizing: border-box;
+  border: 1px solid var(--glass-border);
+  box-shadow:
+    0 8px 32px var(--glass-shadow),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  padding: 10px 14px;
+  transition: border-color 0.15s;
 }
 
 .inner:focus-within {
-    border-color: var(--accent);
+  border-color: var(--accent);
 }
 
 .textarea {
-    flex: 1;
-    background: none;
-    border: none;
-    outline: none;
-    color: var(--text);
-    font-family: var(--font-sans);
-    font-size: 14px;
-    line-height: 1.5;
-    resize: none;
-    min-height: 21px;
-    max-height: 200px;
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  resize: none;
+  min-height: 21px;
+  max-height: 200px;
 }
 
 .textarea::placeholder {
-    color: var(--text-muted);
+  color: var(--text-muted);
 }
 
 .sendBtn {
-    flex-shrink: 0;
-    width: 32px;
-    height: 32px;
-    border-radius: 8px;
-    border: none;
-    background: var(--accent);
-    color: white;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: opacity 0.15s;
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: none;
+  background: var(--accent);
+  color: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.15s;
 }
 
 .sendBtn:disabled {
-    opacity: 0.3;
-    cursor: default;
+  opacity: 0.3;
+  cursor: default;
 }
 
 .sendBtn:not(:disabled):hover {
-    opacity: 0.85;
+  opacity: 0.85;
 }

--- a/infinity-ui/src/components/MessageItem.module.css
+++ b/infinity-ui/src/components/MessageItem.module.css
@@ -1,268 +1,268 @@
 /* ── Message items ── */
 
 .user {
-    padding: 10px 0;
-    margin-top: 16px;
-    font-weight: 600;
-    word-break: break-word;
-    color: var(--text);
+  padding: 10px 0;
+  margin-top: 16px;
+  font-weight: 600;
+  word-break: break-word;
+  color: var(--text);
 }
 
 .userSep {
-    border-top: 1px solid var(--border);
-    padding-top: 16px;
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
 }
 
 .assistant {
-    padding: 8px 0;
-    word-break: break-word;
+  padding: 8px 0;
+  word-break: break-word;
 }
 
 .markdown :global(ul),
 .markdown :global(ol) {
-    padding-left: 2em;
+  padding-left: 2em;
 }
 
 .markdown :global(.block) {
-    display: block;
+  display: block;
 }
 
 .markdown :global(.text-muted-foreground) {
-    color: var(--text-muted);
+  color: var(--text-muted);
 }
 
 .markdown :global(.italic) {
-    font-style: italic;
+  font-style: italic;
 }
 
 .markdown :global(hr) {
-    margin: 1.5em 0;
+  margin: 1.5em 0;
 }
 
 .markdown :global(.w-full) {
-    width: 100%;
+  width: 100%;
 }
 
 .markdown :global(.divide-y) > * + * {
-    border-top: 1px solid;
+  border-top: 1px solid;
 }
 
 .markdown :global(.divide-border) > * + * {
-    border-color: var(--border);
+  border-color: var(--border);
 }
 
 .markdown :global(table) {
-    border-collapse: collapse;
+  border-collapse: collapse;
 }
 
 .markdown :global(img.hidden) {
-    display: none;
+  display: none;
 }
 
 .markdown :global(.inline-block) {
-    display: inline-block;
+  display: inline-block;
 }
 
 .markdown :global([data-streamdown="table-wrapper"]) {
-    border-radius: 8px;
-    border: 1px solid var(--border);
-    padding: 12px;
-    margin-top: 0.6em;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  padding: 12px;
+  margin-top: 0.6em;
 }
 
 .markdown :global(p) {
-    margin-top: 0.6em;
+  margin-top: 0.6em;
 }
 
 .markdown :global(p:first-child) {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 .markdown div[data-streamdown="code-block"] {
-    margin-top: 10px;
-    padding: 10px;
-    border-radius: 5px;
-    border: 1px solid var(--border);
+  margin-top: 10px;
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid var(--border);
 }
 
 .markdown div[data-streamdown="code-block-header"] {
-    display: none;
+  display: none;
 }
 
 .markdown div[data-streamdown="code-block-body"] {
-    overflow-x: auto;
+  overflow-x: auto;
 }
 
 .toolCall {
-    padding: 6px 0;
-    color: #6ea8fe;
-    font-family: var(--font-mono);
-    font-size: 13px;
-    display: flex;
-    gap: 6px;
-    align-items: baseline;
+  padding: 6px 0;
+  color: #6ea8fe;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
 }
 
 .toolIcon {
-    color: #6ea8fe;
-    flex-shrink: 0;
+  color: #6ea8fe;
+  flex-shrink: 0;
 }
 
 .toolName {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .toolName:hover {
-    white-space: normal;
-    overflow-wrap: break-word;
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 .toolResult {
-    padding: 8px 0 2px;
-    color: var(--accent-green);
-    font-family: var(--font-mono);
-    font-size: 13px;
-    display: flex;
-    gap: 6px;
-    align-items: baseline;
-    max-height: 300px;
-    overflow-y: auto;
+  padding: 8px 0 2px;
+  color: var(--accent-green);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 .checkIcon {
-    flex-shrink: 0;
+  flex-shrink: 0;
 }
 
 .toolResultMulti {
-    padding: 8px 0 2px;
-    max-height: 300px;
-    overflow-y: auto;
+  padding: 8px 0 2px;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 .toolResultDiff {
-    margin-left: -12px;
-    margin-right: -12px;
-    margin-bottom: -4px;
+  margin-left: -12px;
+  margin-right: -12px;
+  margin-bottom: -4px;
 }
 
 .toolResultPre {
-    margin: 4px 0 4px 20px;
-    font-family: var(--font-mono);
-    font-size: 12px;
-    color: var(--text-dim);
-    white-space: pre-wrap;
-    word-break: break-word;
-    line-height: 1.5;
+  margin: 4px 0 4px 20px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-dim);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
 }
 
 .info {
-    padding: 4px 0;
-    color: var(--text-dim);
-    font-size: 13px;
+  padding: 4px 0;
+  color: var(--text-dim);
+  font-size: 13px;
 }
 
 .error {
-    padding: 6px 10px;
-    color: var(--accent-red);
-    background: rgba(224, 64, 64, 0.08);
-    border-radius: 6px;
-    font-size: 13px;
+  padding: 6px 10px;
+  color: var(--accent-red);
+  background: rgba(224, 64, 64, 0.08);
+  border-radius: 6px;
+  font-size: 13px;
 }
 
 .subHeader {
-    padding: 6px 0;
-    color: #f0a040;
-    font-family: var(--font-mono);
-    font-size: 13px;
-    display: flex;
-    gap: 6px;
-    align-items: baseline;
+  padding: 6px 0;
+  color: #f0a040;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
 }
 
 .subIcon {
-    flex-shrink: 0;
+  flex-shrink: 0;
 }
 
 .subName {
-    font-weight: 600;
+  font-weight: 600;
 }
 
 .subBody {
-    font-family: var(--font-mono);
-    font-size: 12px;
-    color: var(--text-dim);
-    white-space: pre-wrap;
-    word-break: break-word;
-    line-height: 1.5;
-    margin: 0;
-    padding: 8px 0 2px;
-    max-height: 300px;
-    overflow-y: auto;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-dim);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+  margin: 0;
+  padding: 8px 0 2px;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 .compaction {
-    padding: 4px 0;
-    color: #c084fc;
-    font-size: 13px;
+  padding: 4px 0;
+  color: #c084fc;
+  font-size: 13px;
 }
 
 .thinking {
-    padding: 4px 0;
+  padding: 4px 0;
 }
 
 .thinkingToggle {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    background: none;
-    border: none;
-    color: var(--text-muted);
-    font-size: 12px;
-    font-style: italic;
-    cursor: pointer;
-    padding: 2px 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-style: italic;
+  cursor: pointer;
+  padding: 2px 0;
 }
 .thinkingToggle:hover {
-    color: var(--text-dim);
+  color: var(--text-dim);
 }
 
 .thinkingChevron {
-    display: inline-block;
-    transition: transform 0.2s ease;
-    font-style: normal;
-    font-size: 10px;
+  display: inline-block;
+  transition: transform 0.2s ease;
+  font-style: normal;
+  font-size: 10px;
 }
 
 .chevronCollapsed {
-    transform: rotate(-90deg);
+  transform: rotate(-90deg);
 }
 
 .thinkingLabel {
-    user-select: none;
+  user-select: none;
 }
 
 .thinkingBody {
-    display: grid;
-    grid-template-rows: 1fr;
-    transition:
-        grid-template-rows 0.3s ease,
-        opacity 0.3s ease;
-    opacity: 1;
+  display: grid;
+  grid-template-rows: 1fr;
+  transition:
+    grid-template-rows 0.3s ease,
+    opacity 0.3s ease;
+  opacity: 1;
 }
 
 .thinkingBodyInner {
-    font-size: 12px;
-    font-style: italic;
-    color: var(--text-muted);
-    white-space: pre-wrap;
-    word-break: break-word;
-    line-height: 1.5;
-    overflow: hidden;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+  overflow: hidden;
 }
 
 .thinkingCollapsed {
-    grid-template-rows: 0fr;
-    opacity: 0;
+  grid-template-rows: 0fr;
+  opacity: 0;
 }

--- a/infinity-ui/src/components/MessageList.module.css
+++ b/infinity-ui/src/components/MessageList.module.css
@@ -1,33 +1,33 @@
 .container {
-    display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-    overflow-x: hidden;
-    flex: 1;
-    min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  overflow-x: hidden;
+  flex: 1;
+  min-height: 0;
 }
 
 .inner {
-    flex: 1;
-    max-width: var(--max-width);
-    width: 100%;
-    margin: 0 auto;
-    padding: 0px 12px 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
+  flex: 1;
+  max-width: var(--max-width);
+  width: 100%;
+  margin: 0 auto;
+  padding: 0px 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .toolBox {
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 4px 12px;
-    margin: 4px 0;
-    overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 4px 12px;
+  margin: 4px 0;
+  overflow: hidden;
 }
 
 .toolDivider {
-    border: none;
-    border-top: 1px solid var(--border);
-    margin: 0 -12px;
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 0 -12px;
 }

--- a/infinity-ui/src/components/MigratePicker.module.css
+++ b/infinity-ui/src/components/MigratePicker.module.css
@@ -51,21 +51,21 @@
   background: var(--bg-hover);
 }
 
-.item[data-disabled='true'] {
+.item[data-disabled="true"] {
   opacity: 0.4;
   cursor: default;
 }
 
-.item[data-disabled='true']:hover {
+.item[data-disabled="true"]:hover {
   background: none;
 }
 
-.item[data-current='true'] {
+.item[data-current="true"] {
   opacity: 0.5;
   cursor: default;
 }
 
-.item[data-current='true']:hover {
+.item[data-current="true"]:hover {
   background: none;
 }
 
@@ -76,16 +76,16 @@
   flex-shrink: 0;
 }
 
-.dot[data-status='connected'] {
+.dot[data-status="connected"] {
   background: var(--accent-green);
 }
 
-.dot[data-status='connecting'] {
+.dot[data-status="connecting"] {
   background: var(--accent-orange);
   animation: pulse 1s ease-in-out infinite;
 }
 
-.dot[data-status='disconnected'] {
+.dot[data-status="disconnected"] {
   background: var(--accent-red);
 }
 
@@ -170,11 +170,16 @@
   background: var(--bg-hover);
 }
 
-.completionItem[data-selected='true'] {
+.completionItem[data-selected="true"] {
   background: var(--bg-hover);
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 0.4; }
-  50% { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
 }

--- a/infinity-ui/src/components/SessionSidebar.module.css
+++ b/infinity-ui/src/components/SessionSidebar.module.css
@@ -1,305 +1,307 @@
 .sidebar {
-    position: fixed;
-    top: 12px;
-    left: 12px;
-    bottom: 12px;
-    z-index: 200;
-    display: flex;
-    flex-direction: column;
-    border-radius: 16px;
-    overflow: visible;
-    transition:
-        transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-        opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  bottom: 12px;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  overflow: visible;
+  transition:
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 
-    /* Liquid glass */
-    background: var(--glass-bg);
-    backdrop-filter: blur(24px) saturate(1.4);
-    -webkit-backdrop-filter: blur(24px) saturate(1.4);
-    border: 1px solid var(--glass-border);
-    box-shadow:
-        0 8px 32px var(--glass-shadow),
-        inset 0 0.5px 0 rgba(255, 255, 255, 0.06);
+  /* Liquid glass */
+  background: var(--glass-bg);
+  backdrop-filter: blur(24px) saturate(1.4);
+  -webkit-backdrop-filter: blur(24px) saturate(1.4);
+  border: 1px solid var(--glass-border);
+  box-shadow:
+    0 8px 32px var(--glass-shadow),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.06);
 }
 
 .resizeHandle {
-    position: absolute;
-    top: 0;
-    right: -4px;
-    bottom: 0;
-    width: 8px;
-    cursor: col-resize;
+  position: absolute;
+  top: 0;
+  right: -4px;
+  bottom: 0;
+  width: 8px;
+  cursor: col-resize;
 }
 .resizeHandle:hover {
-    background: var(--accent);
-    opacity: 0.2;
-    border-radius: 4px;
+  background: var(--accent);
+  opacity: 0.2;
+  border-radius: 4px;
 }
 
 .sidebar.hidden {
-    transform: translateX(-110%);
-    opacity: 0;
-    pointer-events: none;
+  transform: translateX(-110%);
+  opacity: 0;
+  pointer-events: none;
 }
 
 .header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 14px 16px;
-    border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--glass-border);
 }
 
 .title {
-    font-weight: 600;
-    font-size: 14px;
+  font-weight: 600;
+  font-size: 14px;
 }
 
 .headerActions {
-    display: flex;
-    gap: 6px;
+  display: flex;
+  gap: 6px;
 }
 
 .newBtn,
 .collapseBtn {
-    background: none;
-    border: 1px solid var(--glass-border);
-    color: var(--accent);
-    font-size: 12px;
-    padding: 4px 10px;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background 0.15s;
+  background: none;
+  border: 1px solid var(--glass-border);
+  color: var(--accent);
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
 }
 .newBtn:hover,
 .collapseBtn:hover {
-    background: var(--bg-hover);
+  background: var(--bg-hover);
 }
 .collapseBtn {
-    color: var(--text-dim);
-    padding: 4px 8px;
-    font-size: 14px;
-    transition: background 0.15s, opacity 0.15s;
+  color: var(--text-dim);
+  padding: 4px 8px;
+  font-size: 14px;
+  transition:
+    background 0.15s,
+    opacity 0.15s;
 }
 .collapseBtn[data-pinned="true"] {
-    opacity: 1;
+  opacity: 1;
 }
 .collapseBtn[data-pinned="false"] {
-    opacity: 0.4;
+  opacity: 0.4;
 }
 
 .list {
-    flex: 1;
-    overflow-y: auto;
-    overflow-x: hidden;
-    padding: 8px;
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 8px;
 }
 
 .item {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    width: 100%;
-    text-align: left;
-    background: none;
-    border: none;
-    color: var(--text);
-    padding: 10px 12px;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: background 0.15s;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--text);
+  padding: 10px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
 }
 .item:hover {
-    background: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.06);
 }
 .item.active {
-    background: rgba(0, 150, 255, 0.12);
+  background: rgba(0, 150, 255, 0.12);
 }
 
 .itemTitle {
-    font-size: 13px;
-    font-weight: 500;
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    min-width: 0;
+  font-size: 13px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
 }
 
 .itemTitleText {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .remotePill {
-    flex-shrink: 0;
-    font-size: 10px;
-    font-weight: 500;
-    padding: 1px 6px;
-    border-radius: 9999px;
-    background: rgba(0, 150, 255, 0.15);
-    color: var(--accent);
-    margin-left: auto;
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 9999px;
+  background: rgba(0, 150, 255, 0.15);
+  color: var(--accent);
+  margin-left: auto;
 }
 
 .itemMeta {
-    font-size: 11px;
-    color: var(--text-muted);
-    display: flex;
-    align-items: center;
-    gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .statusDot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 .statusDot[data-status="Running"] {
-    background: var(--accent-green);
+  background: var(--accent-green);
 }
 .statusDot[data-status="Idle"] {
-    background: var(--accent-yellow);
+  background: var(--accent-yellow);
 }
 .statusDot[data-status="Stopped"] {
-    background: var(--accent-red);
+  background: var(--accent-red);
 }
 .statusDot[data-status="WaitingForChoice"] {
-    background: var(--accent-orange);
+  background: var(--accent-orange);
 }
 
 .empty {
-    padding: 20px;
-    text-align: center;
-    color: var(--text-muted);
-    font-size: 13px;
+  padding: 20px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
 }
 
 .remoteBanner {
-    padding: 6px 12px;
-    border-bottom: 1px solid var(--glass-border);
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--glass-border);
 }
 
 .remoteBannerItem {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 11px;
-    padding: 3px 0;
-    color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  padding: 3px 0;
+  color: var(--text-muted);
 }
 .remoteBannerItem[data-status="disconnected"] {
-    color: var(--accent-red);
+  color: var(--accent-red);
 }
 .remoteBannerItem[data-status="connecting"] {
-    color: var(--accent-yellow);
+  color: var(--accent-yellow);
 }
 
 .remoteBannerDot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 .remoteBannerDot[data-status="disconnected"] {
-    background: var(--accent-red);
+  background: var(--accent-red);
 }
 .remoteBannerDot[data-status="connecting"] {
-    background: var(--accent-yellow);
+  background: var(--accent-yellow);
 }
 
 .threadList {
-    padding-left: 16px;
-    margin: 2px 0 4px;
+  padding-left: 16px;
+  margin: 2px 0 4px;
 }
 
 .threadItem {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    width: 100%;
-    text-align: left;
-    background: none;
-    border: none;
-    color: var(--text-muted);
-    padding: 5px 10px;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 12px;
-    transition:
-        background 0.15s,
-        color 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 .threadItem:hover {
-    background: rgba(255, 255, 255, 0.06);
-    color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
 }
 .threadItem.active {
-    background: rgba(0, 150, 255, 0.12);
-    color: var(--text);
+  background: rgba(0, 150, 255, 0.12);
+  color: var(--text);
 }
 
 .threadLine {
-    width: 8px;
-    height: 1px;
-    background: var(--text-muted);
-    opacity: 0.4;
-    flex-shrink: 0;
+  width: 8px;
+  height: 1px;
+  background: var(--text-muted);
+  opacity: 0.4;
+  flex-shrink: 0;
 }
 
 .threadTitle {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .threadId {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    gap: 2px;
-    flex-shrink: 0;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
 }
 
 .threadIdText {
-    font-size: 10px;
-    font-family: var(--font-mono, monospace);
-    color: var(--text-muted);
-    opacity: 0.7;
+  font-size: 10px;
+  font-family: var(--font-mono, monospace);
+  color: var(--text-muted);
+  opacity: 0.7;
 }
 
 .threadIdCopy {
-    background: none;
-    border: none;
-    color: var(--text-muted);
-    font-size: 10px;
-    padding: 0 2px;
-    cursor: pointer;
-    opacity: 0.5;
-    transition: opacity 0.15s;
-    line-height: 1;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 10px;
+  padding: 0 2px;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 0.15s;
+  line-height: 1;
 }
 .threadIdCopy:hover {
-    opacity: 1;
+  opacity: 1;
 }
 
 .archivedToggle {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    width: 100%;
-    background: none;
-    border: none;
-    border-top: 1px solid var(--glass-border);
-    color: var(--text-muted);
-    font-size: 12px;
-    padding: 8px 12px;
-    margin-top: 4px;
-    cursor: pointer;
-    transition: color 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--glass-border);
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 8px 12px;
+  margin-top: 4px;
+  cursor: pointer;
+  transition: color 0.15s;
 }
 .archivedToggle:hover {
-    color: var(--text-dim);
+  color: var(--text-dim);
 }

--- a/infinity-ui/src/theme.css
+++ b/infinity-ui/src/theme.css
@@ -1,69 +1,69 @@
 /* ── Infinity UI theme variables ── */
 
 :root {
-    --font-sans: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
-    --font-mono: "JetBrains Mono", "Fira Code", monospace;
-    --max-width: 800px;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", monospace;
+  --max-width: 800px;
 
-    /* Dark theme (default) */
-    --bg: #0a0a0a;
-    --bg-surface: #141414;
-    --bg-hover: #1a1a1a;
-    --bg-user: #1a1a2e;
-    --border: #222;
-    --text: #e0e0e0;
-    --text-dim: #888;
-    --text-muted: #555;
-    --accent: #0096ff;
-    --accent-green: #0fdba2;
-    --accent-yellow: #f0d050;
-    --accent-orange: #f0a040;
-    --accent-red: #e04040;
-    --glass-bg: rgba(20, 20, 20, 0.7);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-shadow: rgba(0, 0, 0, 0.4);
+  /* Dark theme (default) */
+  --bg: #0a0a0a;
+  --bg-surface: #141414;
+  --bg-hover: #1a1a1a;
+  --bg-user: #1a1a2e;
+  --border: #222;
+  --text: #e0e0e0;
+  --text-dim: #888;
+  --text-muted: #555;
+  --accent: #0096ff;
+  --accent-green: #0fdba2;
+  --accent-yellow: #f0d050;
+  --accent-orange: #f0a040;
+  --accent-red: #e04040;
+  --glass-bg: rgba(20, 20, 20, 0.7);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --glass-shadow: rgba(0, 0, 0, 0.4);
 
-    /* Streamdown design tokens (dark) */
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --border-sd: oklch(0.269 0 0);
-    --input: oklch(0.269 0 0);
-    --primary: oklch(0.985 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --radius: 0.5rem;
+  /* Streamdown design tokens (dark) */
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --border-sd: oklch(0.269 0 0);
+  --input: oklch(0.269 0 0);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --radius: 0.5rem;
 }
 
 [data-theme="light"] {
-    --bg: #f5f5f7;
-    --bg-surface: #ffffff;
-    --bg-hover: #eee;
-    --bg-user: #e8eaf6;
-    --border: #ddd;
-    --text: #1a1a1a;
-    --text-dim: #666;
-    --text-muted: #999;
-    --accent: #0071e3;
-    --accent-green: #09b87e;
-    --accent-yellow: #e0c030;
-    --accent-orange: #d48a20;
-    --accent-red: #d03030;
-    --glass-bg: rgba(255, 255, 255, 0.6);
-    --glass-border: rgba(0, 0, 0, 0.08);
-    --glass-shadow: rgba(0, 0, 0, 0.1);
+  --bg: #f5f5f7;
+  --bg-surface: #ffffff;
+  --bg-hover: #eee;
+  --bg-user: #e8eaf6;
+  --border: #ddd;
+  --text: #1a1a1a;
+  --text-dim: #666;
+  --text-muted: #999;
+  --accent: #0071e3;
+  --accent-green: #09b87e;
+  --accent-yellow: #e0c030;
+  --accent-orange: #d48a20;
+  --accent-red: #d03030;
+  --glass-bg: rgba(255, 255, 255, 0.6);
+  --glass-border: rgba(0, 0, 0, 0.08);
+  --glass-shadow: rgba(0, 0, 0, 0.1);
 
-    /* Streamdown design tokens (light) */
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --border-sd: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
+  /* Streamdown design tokens (light) */
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --border-sd: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
 }


### PR DESCRIPTION
## Tab order & navigation

* Reorder slider tabs to Protocol → Runtime → Code
* Reorder navbar items to match: Reactive Agent Protocol → Infinity Runtime → Infinity Code

## New Protocol Diagram

* Replace `AnimatedTerminal` with `ProtocolDiagram` component
* Horizontal swim-lane timeline (Agent Runtime, RAP Tool, External)
* Animated subscription flow: LLM subscribes → tool registers → both hibernate → webhook → tool processes → event → runtime wakes
* Diagonal arrows show async message passing with time progression
* SVG mask-based left-to-right reveal with soft 15px gradient edge
* Playhead fades out at end; single-run animation (no loop)
* Theme-compatible via CSS variables

## New Runtime Diagram

* Replace parent/child spawning animation with time-slicing visualization
* 6 color-coded agents with three phases: initial → highlight idle in red → bin-pack active blocks
* First-fit bin-packing compresses active blocks into minimal rows
* Blocks animate upward with CSS transitions
* Axes: "time →" top-left, "← compute × memory" rotated left

## Layout & styling

* Reduce showcase gap to 1rem
* Add `border-bottom` to hero section
* Increase showcase text `max-width` to 710px
* Reduce tab-switcher `margin-bottom` to 1.5rem

## Content

* Replace em dashes with commas/colons across `FeatureCards`, `ProtocolComparison`, `SwarmSection`
* Rename "Designed for Swarms" → "Agent-Native Concurrency" with rewritten subtitle
* Remove `AnimatedTerminal` import from `index.tsx`

Co-authored-by: Infinity 🤖 <infinity@hydro.run>