### PR TITLE
feat(infinity-daemon): pass CLI-selected model to new sessions

### DIFF
--- a/crates/infinity-agent-cli/src/acp_server.rs
+++ b/crates/infinity-agent-cli/src/acp_server.rs
@@ -508,6 +508,7 @@ async fn run_session_connection(
             let msg = ClientMessage::CreateSession {
                 cwd,
                 location: None,
+                model_id: None,
             };
             send(&mut framed, &msg).await?;
             // Wait for Connected to get daemon ID, then send input.

--- a/crates/infinity-agent-cli/src/daemon_client.rs
+++ b/crates/infinity-agent-cli/src/daemon_client.rs
@@ -185,6 +185,7 @@ pub async fn run_headless(message: String) -> Result<(), BoxError> {
     let msg = ClientMessage::CreateSession {
         cwd,
         location: None,
+        model_id: None,
     };
     framed.send(Bytes::from(serde_json::to_vec(&msg)?)).await?;
 
@@ -416,6 +417,9 @@ async fn run_client(
 
     let mut active_session: Option<String> = None;
     let mut pending_input: Vec<String> = Vec::new();
+    // The model id most recently selected via the model picker. Stored locally so
+    // it can be passed when creating new sessions, even if no session is active.
+    let mut selected_model_id: Option<String> = None;
     let mut terminal_result: Option<Result<Result<bool, BoxError>, tokio::task::JoinError>> = None;
     let mut pending_soft_detach = false;
 
@@ -517,10 +521,14 @@ async fn run_client(
 
                 idx = model_switch_rx.recv() => {
                     let Some(idx) = idx else { break };
-                    if let (Some(sid), Some(entry)) = (&active_session, models_for_switch.get(idx)) {
-                        let _ = to_daemon.send(ClientMessage::SwitchModel {
-                            session_id: sid.clone(), model_id: entry.model_id.clone(),
-                        });
+                    if let Some(entry) = models_for_switch.get(idx) {
+                        // Remember the selection locally so new sessions use it.
+                        selected_model_id = Some(entry.model_id.clone());
+                        if let Some(sid) = &active_session {
+                            let _ = to_daemon.send(ClientMessage::SwitchModel {
+                                session_id: sid.clone(), model_id: entry.model_id.clone(),
+                            });
+                        }
                     }
                 }
 
@@ -547,7 +555,7 @@ async fn run_client(
                         }
                     } else {
                         pending_input.push(text);
-                        let _ = to_daemon.send(ClientMessage::CreateSession { cwd: cwd.clone(), location: None });
+                        let _ = to_daemon.send(ClientMessage::CreateSession { cwd: cwd.clone(), location: None, model_id: selected_model_id.clone() });
                     }
                 }
             }

--- a/crates/infinity-daemon/src/client_handler.rs
+++ b/crates/infinity-daemon/src/client_handler.rs
@@ -398,7 +398,7 @@ pub async fn handle_client_channels(
                 }
 
                 match msg {
-                    ClientMessage::CreateSession { cwd, location } => {
+                    ClientMessage::CreateSession { cwd, location, model_id } => {
                         if let Some(rname) = location {
                             let rd = {
                                 let mgr = session_manager.lock().await;
@@ -407,7 +407,7 @@ pub async fn handle_client_channels(
                             if let Some(rd) = rd {
                                 match rd.open_raw_connection(&rname).await {
                                     Ok((tx, rx)) => {
-                                        let _ = tx.send(ClientMessage::CreateSession { cwd, location: None });
+                                        let _ = tx.send(ClientMessage::CreateSession { cwd, location: None, model_id });
                                         remote_proxy_tx = Some(tx);
                                         remote_proxy_rx = Some(rx);
                                         active_remote_name = Some(rname);
@@ -431,7 +431,7 @@ pub async fn handle_client_channels(
                             let mut emit = async |msg: DaemonMessage| {
                                 let _ = daemon_tx.send(msg);
                             };
-                            match mgr.create_session(&cwd, &mut emit).await {
+                            match mgr.create_session(&cwd, model_id, &mut emit).await {
                                 Ok(sid) => {
                                     mgr.attach_client(&sid, client_tx.clone(), false).await;
                                     attached_session_id = Some(sid);

--- a/crates/infinity-daemon/src/session/mod.rs
+++ b/crates/infinity-daemon/src/session/mod.rs
@@ -215,8 +215,16 @@ impl SessionManager {
     pub async fn create_session(
         &mut self,
         cwd: &Path,
+        model_id: Option<String>,
         emit: &mut impl AsyncFnMut(DaemonMessage),
     ) -> Result<String, BoxError> {
+        // If a specific model was requested, it must be one of the available
+        // models — otherwise surface an error rather than silently falling back.
+        if let Some(ref id) = model_id
+            && !self.available_models.iter().any(|m| &m.model_id == id)
+        {
+            return Err(format!("unknown model id: {id}").into());
+        }
         let session_id = uuid::Uuid::new_v4().to_string();
         {
             let mut store = self.session_store.lock().await;
@@ -232,8 +240,9 @@ impl SessionManager {
             .map_err(|e| format!("failed to ensure root thread: {e}"))?;
         self.conversation_store
             .set_last_updated(&session_id, &chrono::Utc::now().to_rfc3339());
-        emit(self.build_connected(&session_id, &session_id)).await;
-        self.start_session(session_id.clone(), cwd, emit).await?;
+        emit(self.build_connected_with_model(&session_id, &session_id, model_id.as_deref())).await;
+        self.start_session(session_id.clone(), cwd, model_id, emit)
+            .await?;
         Ok(session_id)
     }
 
@@ -251,14 +260,38 @@ impl SessionManager {
     }
 
     fn build_connected(&self, session_id: &str, thread_id: &str) -> DaemonMessage {
+        self.build_connected_with_model(session_id, thread_id, None)
+    }
+
+    fn build_connected_with_model(
+        &self,
+        session_id: &str,
+        thread_id: &str,
+        model_id: Option<&str>,
+    ) -> DaemonMessage {
+        let model = self.select_model(model_id);
         DaemonMessage::Connected {
             session_id: session_id.to_owned(),
             thread_id: thread_id.to_owned(),
-            model_name: self.default_model_name.clone(),
-            context_window: self.default_context_window,
+            model_name: model.display_name.clone(),
+            context_window: model.context_window,
             title: self.conversation_store.get_thread_title(session_id),
             total_tokens_used: self.conversation_store.get_total_tokens_used(session_id),
         }
+    }
+
+    /// Select the model entry for an optional model id, falling back to the
+    /// default model (index 0) when `model_id` is `None`. A `Some` model id is
+    /// expected to have been validated by the caller (see `create_session`).
+    fn select_model(&self, model_id: Option<&str>) -> &model_picker::ModelEntry {
+        model_id
+            .map(|id| {
+                self.available_models
+                    .iter()
+                    .find(|m| m.model_id == id)
+                    .expect("bug: model id should be validated in create_session")
+            })
+            .unwrap_or(&self.available_models[0])
     }
 
     /// Internal: spin up the agent loop for a session.
@@ -266,6 +299,7 @@ impl SessionManager {
         &mut self,
         session_id: String,
         cwd: &Path,
+        model_id: Option<String>,
         emit: &mut impl AsyncFnMut(DaemonMessage),
     ) -> Result<(), BoxError> {
         if self.sessions.contains_key(&session_id) {
@@ -368,6 +402,7 @@ impl SessionManager {
                 active_threads.clone(),
                 shutdown_rx,
                 spawned_servers,
+                model_id,
             )?;
 
         let session = Session {
@@ -476,7 +511,10 @@ impl SessionManager {
                 let _ = store.save();
             }
             let cwd = self.session_store.lock().await.get_cwd(session_id).clone();
-            if let Err(e) = self.start_session(session_id.to_owned(), &cwd, emit).await {
+            if let Err(e) = self
+                .start_session(session_id.to_owned(), &cwd, None, emit)
+                .await
+            {
                 tracing::error!("failed to restart session: {e}");
                 return false;
             }
@@ -619,6 +657,7 @@ impl SessionManager {
         active_threads: ActiveThreads,
         shutdown_rx: oneshot::Receiver<()>,
         spawned_servers: Vec<tokio::process::Child>,
+        model_id: Option<String>,
     ) -> Result<
         (
             String,
@@ -629,13 +668,15 @@ impl SessionManager {
         ),
         BoxError,
     > {
-        let default = &self.available_models[0]; // already validated in new()
-        let model_name = default.display_name.clone();
-        let context_window = default.context_window;
+        // Select the requested model, falling back to the default (index 0).
+        // A `Some` model id is already validated in `create_session`.
+        let selected = self.select_model(model_id.as_deref());
+        let model_name = selected.display_name.clone();
+        let context_window = selected.context_window;
 
         let (idle_tx, handle, subscriber_map) = {
             let client = rig_bedrock::client::Client::from_env();
-            let model = client.completion_model(&default.model_id);
+            let model = client.completion_model(&selected.model_id);
 
             spawn_agent_loop(
                 session_id,
@@ -649,7 +690,7 @@ impl SessionManager {
                 rap_tools,
                 tool_server_urls,
                 extra_system_prompt,
-                default.additional_request_params.clone(),
+                selected.additional_request_params.clone(),
                 active_threads,
                 shutdown_rx,
                 spawned_servers,

--- a/crates/infinity-protocol/src/lib.rs
+++ b/crates/infinity-protocol/src/lib.rs
@@ -44,6 +44,10 @@ pub enum ClientMessage {
         /// Otherwise, the name of a remote.
         #[serde(default)]
         location: Option<String>,
+        /// Optional model id to use for the new session. `None` uses the
+        /// daemon's default model.
+        #[serde(default)]
+        model_id: Option<String>,
     },
     /// Connect to an existing session (optionally a specific thread).
     Connect {

--- a/infinity-ui/src/types.ts
+++ b/infinity-ui/src/types.ts
@@ -143,7 +143,13 @@ export type DaemonMessage =
 /* ── Client → Daemon messages ── */
 
 export type ClientMessage =
-  | { CreateSession: { cwd: string; location: string | null } }
+  | {
+      CreateSession: {
+        cwd: string;
+        location: string | null;
+        model_id?: string | null;
+      };
+    }
   | { Connect: { session_id: string; thread_id: string | null } }
   | { UserInput: { session_id: string; text: string } }
   | "Disconnect"


### PR DESCRIPTION
When a user switched models in the CLI and then started a new session, the
selection was ignored: the picker only sent `SwitchModel` (which needs an
active session) and new sessions always booted with the daemon's default
model.

## Protocol (`infinity-protocol`)

* Add optional `model_id` to `ClientMessage::CreateSession` (`#[serde(default)]`
  for backward compatibility).

## CLI (`infinity-agent-cli`)

* Track the most recently picked model id in a `selected_model_id` local in
  `daemon_client.rs`; store it on every selection regardless of whether a
  session is active, and still forward `SwitchModel` when one is.
* Pass `selected_model_id` when sending `CreateSession`.
* Set `model_id: None` on the headless and ACP `CreateSession` constructions.

## Daemon (`infinity-daemon`)

* `client_handler` threads `model_id` through `CreateSession` (local branch
  into `create_session` and the remote-proxy forward).
* `SessionManager::create_session` accepts an optional `model_id`, validates
  it against `available_models` (returns an error for an unknown id instead of
  silently falling back), and threads it through `start_session` ->
  `start_agent_loop`.
* Add a shared `select_model` helper resolving an optional model id to a
  `ModelEntry` (default index 0), used by both `build_connected` and
  `start_agent_loop`. `Connected` now reports the chosen model's name and
  context window.

## UI (`infinity-ui`)

* Add the optional `model_id` field to the `CreateSession` TypeScript type.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>