### PR TITLE
ci: use locked local prettier via npm scripts instead of `npx`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,11 @@ jobs:
 
       - name: Check docs formatting
         run: |
-          cd docs && npm ci && npx prettier --check "src/**/*.{tsx,ts,css}" "docusaurus.config.ts"
+          cd docs && npm ci && npm run format:check
 
       - name: Check infinity-ui formatting
         run: |
-          cd infinity-ui && npm ci && npx prettier --check "src/**/*.{tsx,ts,css}"
+          cd infinity-ui && npm ci && npm run format:check
 
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings

--- a/check.bash
+++ b/check.bash
@@ -27,7 +27,7 @@ pass "All Rust code is formatted"
 
 step "Docs formatting"
 if [ -f docs/node_modules/.bin/prettier ]; then
-    (cd docs && npx prettier --check "src/**/*.{tsx,ts,css}" "docusaurus.config.ts") || fail "docs formatting issues found (run 'cd docs && npm run format' to fix)"
+    (cd docs && npm run format:check) || fail "docs formatting issues found (run 'cd docs && npm run format' to fix)"
     pass "All docs code is formatted"
 else
     echo "  (skipped: docs node_modules not installed)"
@@ -35,7 +35,7 @@ fi
 
 step "infinity-ui formatting"
 if [ -f infinity-ui/node_modules/.bin/prettier ]; then
-    (cd infinity-ui && npx prettier --check "src/**/*.{tsx,ts,css}") || fail "infinity-ui formatting issues found (run 'cd infinity-ui && npm run format' to fix)"
+    (cd infinity-ui && npm run format:check) || fail "infinity-ui formatting issues found (run 'cd infinity-ui && npm run format' to fix)"
     pass "All infinity-ui code is formatted"
 else
     echo "  (skipped: infinity-ui node_modules not installed)"


### PR DESCRIPTION
* Replace `npx prettier --check ...` with `npm run format:check` in `check.bash` and `.github/workflows/ci.yml` for the `docs` and `infinity-ui` packages
* The `format:check` scripts already exist in each `package.json` and resolve prettier from `node_modules/.bin`, ensuring the lockfile-pinned dev dependency version is used rather than whatever version `npx` might fetch
* Deduplicates the glob patterns, which now live only in the `package.json` scripts

Co-authored-by: Infinity 🤖 <infinity@hydro.run>