### PR TITLE
feat!: run model providers as configurable separate processes over Unix sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,9 +2178,11 @@ dependencies = [
  "rhai",
  "rig-core",
  "rig-mock",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
  "uuid",
@@ -2235,7 +2237,6 @@ dependencies = [
  "include_dir",
  "infinity-agent-core",
  "infinity-protocol",
- "infinity-provider-bedrock",
  "insta",
  "nix",
  "rap-client",
@@ -2273,6 +2274,8 @@ dependencies = [
  "rig-bedrock",
  "rig-core",
  "serde_json",
+ "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rig-core = { version = "0.31", default-features = false }
 rig-bedrock = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+schemars = "1"
 tokio = { version = "1", features = ["macros", "sync"] }
 futures-util = "0.3"
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Prerequisites: [Rust](https://rustup.rs), [Ripgrep](https://github.com/BurntSush
 # Install the CLI
 cargo install infinity-agent-cli --git https://github.com/hydro-project/infinity --features bundled-web
 
+# Install the AWS Bedrock model provider (uses your AWS credentials)
+infinity provider install bedrock --git https://github.com/hydro-project/infinity --crate infinity-provider-bedrock
+
 # Install the local sandbox RAP server
 infinity rap install --user --git https://github.com/hydro-project/infinity --crate sandbox-local
 

--- a/crates/infinity-agent-cli/Cargo.toml
+++ b/crates/infinity-agent-cli/Cargo.toml
@@ -21,7 +21,7 @@ infinity-daemon = { path = "../infinity-daemon" }
 rig-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "io-util", "io-std", "sync", "process", "net"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "io-util", "io-std", "sync", "process", "net", "time"] }
 futures-util = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }

--- a/crates/infinity-agent-cli/src/daemon_client.rs
+++ b/crates/infinity-agent-cli/src/daemon_client.rs
@@ -8,6 +8,7 @@ use futures_util::{SinkExt, StreamExt};
 use infinity_agent_core::batch_processor::DisplayEvent;
 use infinity_protocol::{ClientMessage, DaemonMessage, ModelRef, SessionInfo, TokenUsage};
 use rig::completion::GetTokenUsage;
+use tokio::io::AsyncBufReadExt;
 use tokio::net::UnixStream;
 use tokio::sync::mpsc;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
@@ -130,29 +131,122 @@ pub(crate) async fn ensure_daemon_running() -> Result<UnixStream, BoxError> {
     if let Ok(stream) = UnixStream::connect(&infinity_protocol::socket_path()).await {
         return Ok(stream);
     }
-    launch_daemon()?;
-    for _ in 0..50 {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        if let Ok(stream) = UnixStream::connect(&infinity_protocol::socket_path()).await {
-            return Ok(stream);
-        }
-    }
-    Err("daemon failed to start within 5 seconds".into())
+    launch_daemon().await?;
+    // The daemon binds its socket before announcing readiness, so a single
+    // connect attempt suffices.
+    UnixStream::connect(&infinity_protocol::socket_path())
+        .await
+        .map_err(|e| {
+            format!("daemon reported ready but connecting to its socket failed: {e}").into()
+        })
 }
 
-fn launch_daemon() -> Result<(), BoxError> {
+/// How long to wait for a launched daemon to either report readiness or
+/// exit. Generous because daemon startup spawns model provider processes.
+const DAEMON_STARTUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Launch the daemon as a background process and wait until it prints its
+/// ready line on stdout. If the daemon exits first (e.g. a configuration
+/// error), the error includes everything it printed to stdout/stderr, which
+/// would otherwise be invisible for a detached process.
+async fn launch_daemon() -> Result<(), BoxError> {
     let current_exe = std::env::current_exe()?;
-    std::process::Command::new(&current_exe)
+    let mut child = tokio::process::Command::new(&current_exe)
         .arg("daemon")
         .env(
             "RUST_LOG",
             std::env::var_os("RUST_LOG").unwrap_or("debug".into()),
         )
         .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
         .spawn()?;
-    Ok(())
+
+    let stdout = child
+        .stdout
+        .take()
+        .expect("bug: piped child stdout missing");
+    let stderr = child
+        .stderr
+        .take()
+        .expect("bug: piped child stderr missing");
+    let mut stdout_lines = tokio::io::BufReader::new(stdout).lines();
+
+    // Accumulate stderr in the background for the failure report.
+    let stderr_task = tokio::task::spawn(async move {
+        use tokio::io::AsyncReadExt;
+        let mut out = String::new();
+        let mut reader = tokio::io::BufReader::new(stderr);
+        let _ = reader.read_to_string(&mut out).await;
+        out
+    });
+
+    let timeout = tokio::time::sleep(DAEMON_STARTUP_TIMEOUT);
+    tokio::pin!(timeout);
+
+    // Race the ready line against the daemon exiting.
+    let mut stdout_so_far = String::new();
+    let exit_status = loop {
+        tokio::select! {
+            line = stdout_lines.next_line() => match line {
+                Ok(Some(line)) if line == infinity_daemon::DAEMON_READY_LINE => {
+                    // Leave the daemon running detached; dropping the child
+                    // handle and pipes does not kill it.
+                    stderr_task.abort();
+                    return Ok(());
+                }
+                Ok(Some(line)) => {
+                    stdout_so_far.push_str(&line);
+                    stdout_so_far.push('\n');
+                }
+                // stdout closed without the ready line: the daemon is
+                // exiting; reap it below (with a timeout in case it
+                // lingers with closed pipes).
+                Ok(None) | Err(_) => {
+                    match tokio::time::timeout(std::time::Duration::from_secs(5), child.wait())
+                        .await
+                    {
+                        Ok(status) => break status?,
+                        Err(_) => {
+                            let _ = child.start_kill();
+                            break child.wait().await?;
+                        }
+                    }
+                }
+            },
+            status = child.wait() => break status?,
+            _ = &mut timeout => {
+                // Still booting: leave it running (it may just be slow) but
+                // stop waiting.
+                return Err(format!(
+                    "daemon did not report ready within {}s; check ~/.infinity/daemon.log",
+                    DAEMON_STARTUP_TIMEOUT.as_secs()
+                ).into());
+            }
+        }
+    };
+
+    // Drain anything still buffered on stdout, then collect stderr.
+    while let Ok(Some(line)) = stdout_lines.next_line().await {
+        stdout_so_far.push_str(&line);
+        stdout_so_far.push('\n');
+    }
+    let stderr_so_far = stderr_task.await.unwrap_or_default();
+
+    let mut report = format!("daemon exited during startup ({exit_status})");
+    if !stdout_so_far.trim().is_empty() {
+        report.push_str(&format!(
+            "\n--- daemon stdout ---\n{}",
+            stdout_so_far.trim_end()
+        ));
+    }
+    if !stderr_so_far.trim().is_empty() {
+        report.push_str(&format!(
+            "\n--- daemon stderr ---\n{}",
+            stderr_so_far.trim_end()
+        ));
+    }
+    Err(report.into())
 }
 
 /// Send a task to the daemon and exit without opening the TUI.

--- a/crates/infinity-agent-cli/src/install.rs
+++ b/crates/infinity-agent-cli/src/install.rs
@@ -25,7 +25,17 @@ pub struct InstallArgs {
     pub path: Option<String>,
 }
 
-pub use infinity_daemon::config::{load_config, user_config_path};
+/// Arguments for `infinity provider install <id> --crate ...`.
+pub struct ProviderInstallArgs {
+    /// Provider id to register in providers.json (e.g. "bedrock").
+    pub id: String,
+    pub crate_name: String,
+    pub git: Option<String>,
+    pub path: Option<String>,
+}
+
+pub use infinity_daemon::config::{load_config, providers_config_path, user_config_path};
+use infinity_daemon::models::{ProviderConfig, ProvidersConfig, load_providers_config};
 
 fn draw_spinner(
     viewport: &mut InlineViewport,
@@ -203,6 +213,89 @@ pub async fn run_install(args: InstallArgs) -> Result<(), BoxError> {
     Ok(())
 }
 
+/// Install a model provider crate and register it under the given id in
+/// `~/.infinity/providers.json`. The crate's binary (assumed to share the
+/// crate's name) becomes the provider's command.
+pub async fn run_provider_install(args: ProviderInstallArgs) -> Result<(), BoxError> {
+    cterm::enable_raw_mode()?;
+    let mut viewport = InlineViewport::new(2)?;
+
+    viewport.print_line_above(Line::from(Span::styled(
+        format!(
+            "Installing {} as provider '{}'...",
+            args.crate_name, args.id
+        ),
+        Style::default().fg(Color::Yellow),
+    )))?;
+
+    if let Err(e) = run_cargo_install(
+        &mut viewport,
+        &args.crate_name,
+        args.git.as_deref(),
+        args.path.as_deref(),
+        &[],
+    )
+    .await
+    {
+        viewport.print_line_above(Line::from(Span::styled(
+            format!("✗ {e}"),
+            Style::default().fg(Color::Red),
+        )))?;
+        viewport.draw(2, |_| {})?;
+        terminal::cleanup()?;
+        return Err(e);
+    }
+
+    // Update user providers.json (created on first install).
+    let config_path = providers_config_path()?;
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut config = if config_path.exists() {
+        load_providers_config(&config_path)?
+    } else {
+        ProvidersConfig::default()
+    };
+
+    if config.get(&args.id).is_some() {
+        viewport.print_line_above(Line::from(Span::styled(
+            format!("Replacing existing entry for provider '{}'", args.id),
+            Style::default().fg(Color::Yellow),
+        )))?;
+    }
+    let canonical_path = match args.path {
+        Some(p) => Some(
+            std::fs::canonicalize(&p)
+                .map_err(|e| format!("failed to canonicalize install path {p}: {e}"))?
+                .to_string_lossy()
+                .to_string(),
+        ),
+        None => None,
+    };
+    config.upsert(
+        args.id.clone(),
+        ProviderConfig {
+            command: vec![args.crate_name.clone()],
+            crate_name: Some(args.crate_name.clone()),
+            git: args.git.clone(),
+            path: canonical_path,
+        },
+    );
+    std::fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+
+    viewport.print_line_above(Line::from(Span::styled(
+        format!(
+            "✓ Installed and registered provider '{}' in {}",
+            args.id,
+            config_path.display()
+        ),
+        Style::default().fg(Color::Green),
+    )))?;
+    viewport.draw(2, |_| {})?;
+    terminal::cleanup()?;
+    Ok(())
+}
+
 /// Update RAP tools, printing progress into an existing viewport. Returns names of failures.
 async fn update_rap_tools(viewport: &mut InlineViewport) -> Result<Vec<String>, BoxError> {
     let config_path = user_config_path()?;
@@ -259,6 +352,103 @@ async fn update_rap_tools(viewport: &mut InlineViewport) -> Result<Vec<String>, 
         viewport.draw(2, |_| {})?;
     }
     Ok(failed)
+}
+
+/// Update model providers that have a recorded source, printing progress
+/// into an existing viewport. Returns ids of failures.
+async fn update_providers(viewport: &mut InlineViewport) -> Result<Vec<String>, BoxError> {
+    let config_path = providers_config_path()?;
+    if !config_path.exists() {
+        viewport.print_line_above(Line::from(Span::styled(
+            "No model providers configuration found",
+            Style::default().fg(Color::DarkGray),
+        )))?;
+        return Ok(vec![]);
+    }
+    let config = load_providers_config(&config_path)?;
+    let installable: Vec<(String, String, Option<String>, Option<String>)> = config
+        .providers
+        .iter()
+        .filter_map(|(id, provider)| {
+            provider.crate_name.as_ref().map(|crate_name| {
+                (
+                    id.clone(),
+                    crate_name.clone(),
+                    provider.git.clone(),
+                    provider.path.clone(),
+                )
+            })
+        })
+        .collect();
+
+    if installable.is_empty() {
+        viewport.print_line_above(Line::from(Span::styled(
+            format!(
+                "No model providers with recorded sources in {}",
+                config_path.display()
+            ),
+            Style::default().fg(Color::DarkGray),
+        )))?;
+        return Ok(vec![]);
+    }
+
+    viewport.print_line_above(Line::from(Span::styled(
+        format!("Updating {} model provider(s)...", installable.len()),
+        Style::default().fg(Color::Yellow),
+    )))?;
+
+    let mut failed = Vec::new();
+    for (id, crate_name, git, path) in &installable {
+        viewport.print_line_above(Line::from(Span::styled(
+            format!("→ Updating provider '{id}' ({crate_name})..."),
+            Style::default().fg(Color::Cyan),
+        )))?;
+        viewport.draw(2, |_| {})?;
+
+        match run_cargo_install(viewport, crate_name, git.as_deref(), path.as_deref(), &[]).await {
+            Ok(()) => {
+                viewport.print_line_above(Line::from(Span::styled(
+                    format!("  ✓ {id}"),
+                    Style::default().fg(Color::Green),
+                )))?;
+            }
+            Err(e) => {
+                viewport.print_line_above(Line::from(Span::styled(
+                    format!("  ✗ {id}: {e}"),
+                    Style::default().fg(Color::Red),
+                )))?;
+                failed.push(id.clone());
+            }
+        }
+        viewport.draw(2, |_| {})?;
+    }
+    Ok(failed)
+}
+
+/// `infinity provider update` — re-install all providers with recorded sources.
+pub async fn run_provider_update() -> Result<(), BoxError> {
+    cterm::enable_raw_mode()?;
+    let mut viewport = InlineViewport::new(2)?;
+
+    let failed = update_providers(&mut viewport).await?;
+
+    let summary = if failed.is_empty() {
+        Span::styled("✓ All providers updated", Style::default().fg(Color::Green))
+    } else {
+        Span::styled(
+            format!("✗ {} provider(s) failed to update", failed.len()),
+            Style::default().fg(Color::Red),
+        )
+    };
+    viewport.print_line_above(Line::from(summary))?;
+    viewport.draw(2, |_| {})?;
+    terminal::cleanup()?;
+
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        Err("some providers failed to update".into())
+    }
 }
 
 /// Returns the list of cargo features this binary was compiled with.
@@ -387,12 +577,14 @@ pub async fn run_self_update(features_override: Option<&str>) -> Result<(), BoxE
     }
 
     let rap_failed = update_rap_tools(&mut viewport).await?;
+    let provider_failed = update_providers(&mut viewport).await?;
 
-    let summary = if rap_failed.is_empty() {
+    let failed_count = rap_failed.len() + provider_failed.len();
+    let summary = if failed_count == 0 {
         Span::styled("✓ Everything updated", Style::default().fg(Color::Green))
     } else {
         Span::styled(
-            format!("✗ {} RAP tool(s) failed to update", rap_failed.len()),
+            format!("✗ {failed_count} component(s) failed to update"),
             Style::default().fg(Color::Red),
         )
     };
@@ -400,9 +592,9 @@ pub async fn run_self_update(features_override: Option<&str>) -> Result<(), BoxE
     viewport.draw(2, |_| {})?;
     terminal::cleanup()?;
 
-    if rap_failed.is_empty() {
+    if failed_count == 0 {
         Ok(())
     } else {
-        Err("some tools failed to update".into())
+        Err("some components failed to update".into())
     }
 }

--- a/crates/infinity-agent-cli/src/main.rs
+++ b/crates/infinity-agent-cli/src/main.rs
@@ -41,6 +41,11 @@ enum Commands {
         #[command(subcommand)]
         action: RapCommands,
     },
+    /// Model provider management
+    Provider {
+        #[command(subcommand)]
+        action: ProviderCommands,
+    },
     /// Update the CLI itself
     Update {
         /// Comma-separated list of features to pass to cargo install (overrides auto-detected features)
@@ -107,8 +112,31 @@ enum RapCommands {
     },
 }
 
+#[derive(clap::Subcommand, Debug)]
+enum ProviderCommands {
+    /// Install a model provider crate and register it in ~/.infinity/providers.json
+    Install {
+        /// Provider id to register under (e.g. "bedrock")
+        id: String,
+
+        /// Crate name to install (its binary becomes the provider command)
+        #[arg(long = "crate")]
+        crate_name: String,
+
+        /// Git repository URL (passed to cargo install --git)
+        #[arg(long)]
+        git: Option<String>,
+
+        /// Local path (passed to cargo install --path)
+        #[arg(long)]
+        path: Option<String>,
+    },
+    /// Re-install all model providers that have a recorded source
+    Update,
+}
+
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), BoxError> {
+async fn main() -> std::process::ExitCode {
     // Parse CLI arguments via clap.
     let cli = Cli::parse();
 
@@ -130,7 +158,17 @@ async fn main() -> Result<(), BoxError> {
     }
 
     let local = tokio::task::LocalSet::new();
-    local.run_until(async_main(cli)).await
+    match local.run_until(async_main(cli)).await {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        // Print errors with Display formatting: the default `main` error
+        // handling uses Debug, which escapes newlines in string-based
+        // errors and mangles multi-line reports (e.g. captured daemon
+        // startup output).
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
 }
 
 async fn async_main(cli: Cli) -> Result<(), BoxError> {
@@ -153,7 +191,7 @@ async fn async_main(cli: Cli) -> Result<(), BoxError> {
                     println!("sent SIGTERM to daemon (pid {pid})");
                     Ok(())
                 }
-                None => infinity_daemon::run_daemon().await,
+                None => infinity_daemon::run_daemon(true).await,
             },
             Commands::Rap { action } => match action {
                 RapCommands::Install {
@@ -178,6 +216,23 @@ async fn async_main(cli: Cli) -> Result<(), BoxError> {
                     }
                     install::run_update().await
                 }
+            },
+            Commands::Provider { action } => match action {
+                ProviderCommands::Install {
+                    id,
+                    crate_name,
+                    git,
+                    path,
+                } => {
+                    install::run_provider_install(install::ProviderInstallArgs {
+                        id,
+                        crate_name,
+                        git,
+                        path,
+                    })
+                    .await
+                }
+                ProviderCommands::Update => install::run_provider_update().await,
             },
             Commands::Remote { action } => match action {
                 RemoteCommands::Add { name, args } => {

--- a/crates/infinity-agent-core/Cargo.toml
+++ b/crates/infinity-agent-core/Cargo.toml
@@ -10,7 +10,9 @@ rap-protocol = { path = "../rap-protocol" }
 rig-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+schemars = { workspace = true }
+tokio = { workspace = true, features = ["net", "rt", "time"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 futures-util = { workspace = true }
 async-trait = { workspace = true }
 async-stream = "0.3"

--- a/crates/infinity-agent-core/src/model_provider/mod.rs
+++ b/crates/infinity-agent-core/src/model_provider/mod.rs
@@ -19,6 +19,9 @@ use rig::streaming::{
 };
 use serde::{Deserialize, Serialize};
 
+#[cfg(unix)]
+pub mod remote;
+
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 /// Type-erased final streaming response yielded by [`ModelProvider::invoke_model`].

--- a/crates/infinity-agent-core/src/model_provider/remote.rs
+++ b/crates/infinity-agent-core/src/model_provider/remote.rs
@@ -1,0 +1,581 @@
+//! Unix-socket transport for [`ModelProvider`]s.
+//!
+//! This module lets any [`ModelProvider`] implementation run in a separate
+//! process and be consumed remotely:
+//!
+//! * [`serve_provider`] exposes a provider over a Unix domain socket at a
+//!   freshly generated temp path. Provider binaries call this, print the
+//!   returned path on stdout, and then run the returned server future.
+//! * [`RemoteModelProvider`] is the client side: it implements
+//!   [`ModelProvider`] by forwarding calls over the socket.
+//!
+//! ## Protocol
+//!
+//! Newline-delimited JSON. Each request opens a fresh connection (so
+//! concurrent invocations simply use concurrent connections): the client
+//! sends one [`ProviderRequest`] line, then reads [`ProviderResponse`] lines.
+//!
+//! * `ListModels` → exactly one response: `Models` or `Error`.
+//! * `InvokeModel` → either a single `Error` (the invocation failed), or
+//!   `InvokeStarted` followed by zero or more `Chunk`s and a final
+//!   `StreamEnd`. Mid-stream provider errors are forwarded as
+//!   [`WireStreamItem::Error`] chunks without ending the stream, mirroring
+//!   the in-process behavior where a stream may yield `Err` items.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use rig::OneOrMany;
+use rig::completion::{CompletionError, CompletionRequest, Document, ToolDefinition};
+use rig::message::{Message, ReasoningContent, ToolChoice};
+use rig::streaming::{
+    RawStreamingChoice, RawStreamingToolCall, StreamedAssistantContent,
+    StreamingCompletionResponse, ToolCallDeltaContent,
+};
+use serde::{Deserialize, Serialize};
+use tokio::net::{UnixListener, UnixStream};
+use tokio_util::codec::{Framed, LinesCodec};
+
+use super::{ModelEntry, ModelProvider, ProviderCompletionResponse, ProviderStreamingResponse};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// A connection carrying one JSON value per line, in both directions.
+type JsonLines = Framed<UnixStream, LinesCodec>;
+
+// ── Wire types ──
+
+/// A request sent from the client to the provider server. One request is
+/// sent per connection.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ProviderRequest {
+    /// List the models offered by the provider.
+    ListModels,
+    /// Invoke a model, streaming the completion response back as
+    /// [`ProviderResponse::Chunk`]s.
+    InvokeModel {
+        model_id: String,
+        request: Box<WireCompletionRequest>,
+    },
+}
+
+/// A response line sent from the provider server to the client.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ProviderResponse {
+    /// Reply to [`ProviderRequest::ListModels`].
+    Models(Vec<ModelEntry>),
+    /// The invocation succeeded; `Chunk`s follow.
+    InvokeStarted,
+    /// One streamed item of an invocation.
+    Chunk(WireStreamItem),
+    /// The invocation stream finished; the connection will close.
+    StreamEnd,
+    /// The request failed (sent in place of `Models` / `InvokeStarted`).
+    Error(String),
+}
+
+/// Serializable mirror of rig's [`CompletionRequest`] (which doesn't derive
+/// serde itself, although all of its fields are serializable).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WireCompletionRequest {
+    pub model: Option<String>,
+    pub preamble: Option<String>,
+    pub chat_history: OneOrMany<Message>,
+    pub documents: Vec<Document>,
+    pub tools: Vec<ToolDefinition>,
+    pub temperature: Option<f64>,
+    pub max_tokens: Option<u64>,
+    pub tool_choice: Option<ToolChoice>,
+    pub additional_params: Option<serde_json::Value>,
+    pub output_schema: Option<schemars::Schema>,
+}
+
+impl From<CompletionRequest> for WireCompletionRequest {
+    fn from(r: CompletionRequest) -> Self {
+        Self {
+            model: r.model,
+            preamble: r.preamble,
+            chat_history: r.chat_history,
+            documents: r.documents,
+            tools: r.tools,
+            temperature: r.temperature,
+            max_tokens: r.max_tokens,
+            tool_choice: r.tool_choice,
+            additional_params: r.additional_params,
+            output_schema: r.output_schema,
+        }
+    }
+}
+
+impl From<WireCompletionRequest> for CompletionRequest {
+    fn from(r: WireCompletionRequest) -> Self {
+        Self {
+            model: r.model,
+            preamble: r.preamble,
+            chat_history: r.chat_history,
+            documents: r.documents,
+            tools: r.tools,
+            temperature: r.temperature,
+            max_tokens: r.max_tokens,
+            tool_choice: r.tool_choice,
+            additional_params: r.additional_params,
+            output_schema: r.output_schema,
+        }
+    }
+}
+
+/// Serializable mirror of [`RawStreamingChoice<ProviderStreamingResponse>`],
+/// plus an `Error` variant carrying mid-stream provider errors.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum WireStreamItem {
+    /// A text chunk.
+    Message(String),
+    /// A complete tool call.
+    ToolCall {
+        id: String,
+        internal_call_id: String,
+        call_id: Option<String>,
+        name: String,
+        arguments: serde_json::Value,
+        signature: Option<String>,
+        additional_params: Option<serde_json::Value>,
+    },
+    /// A tool call partial/delta.
+    ToolCallDelta {
+        id: String,
+        internal_call_id: String,
+        content: ToolCallDeltaContent,
+    },
+    /// A reasoning block (in its entirety).
+    Reasoning {
+        id: Option<String>,
+        content: ReasoningContent,
+    },
+    /// A reasoning partial/delta.
+    ReasoningDelta {
+        id: Option<String>,
+        reasoning: String,
+    },
+    /// The final response carrying token usage.
+    Final(ProviderStreamingResponse),
+    /// A mid-stream error from the underlying provider.
+    Error(String),
+}
+
+/// Convert one streamed item from the server-side provider into wire items.
+/// `Reasoning` fans out into one item per content block, mirroring
+/// [`super::erase_streaming_response`].
+fn content_to_wire(
+    item: Result<StreamedAssistantContent<ProviderStreamingResponse>, CompletionError>,
+) -> Vec<WireStreamItem> {
+    match item {
+        Ok(StreamedAssistantContent::Text(t)) => vec![WireStreamItem::Message(t.text)],
+        Ok(StreamedAssistantContent::ToolCall {
+            tool_call,
+            internal_call_id,
+        }) => vec![WireStreamItem::ToolCall {
+            id: tool_call.id,
+            internal_call_id,
+            call_id: tool_call.call_id,
+            name: tool_call.function.name,
+            arguments: tool_call.function.arguments,
+            signature: tool_call.signature,
+            additional_params: tool_call.additional_params,
+        }],
+        Ok(StreamedAssistantContent::ToolCallDelta {
+            id,
+            internal_call_id,
+            content,
+        }) => vec![WireStreamItem::ToolCallDelta {
+            id,
+            internal_call_id,
+            content,
+        }],
+        Ok(StreamedAssistantContent::Reasoning(reasoning)) => reasoning
+            .content
+            .into_iter()
+            .map(|content| WireStreamItem::Reasoning {
+                id: reasoning.id.clone(),
+                content,
+            })
+            .collect(),
+        Ok(StreamedAssistantContent::ReasoningDelta { id, reasoning }) => {
+            vec![WireStreamItem::ReasoningDelta { id, reasoning }]
+        }
+        Ok(StreamedAssistantContent::Final(r)) => vec![WireStreamItem::Final(r)],
+        Err(e) => vec![WireStreamItem::Error(e.to_string())],
+    }
+}
+
+/// Convert a wire item back into a client-side streaming choice.
+fn wire_to_choice(
+    item: WireStreamItem,
+) -> Result<RawStreamingChoice<ProviderStreamingResponse>, CompletionError> {
+    Ok(match item {
+        WireStreamItem::Message(text) => RawStreamingChoice::Message(text),
+        WireStreamItem::ToolCall {
+            id,
+            internal_call_id,
+            call_id,
+            name,
+            arguments,
+            signature,
+            additional_params,
+        } => RawStreamingChoice::ToolCall(RawStreamingToolCall {
+            id,
+            internal_call_id,
+            call_id,
+            name,
+            arguments,
+            signature,
+            additional_params,
+        }),
+        WireStreamItem::ToolCallDelta {
+            id,
+            internal_call_id,
+            content,
+        } => RawStreamingChoice::ToolCallDelta {
+            id,
+            internal_call_id,
+            content,
+        },
+        WireStreamItem::Reasoning { id, content } => RawStreamingChoice::Reasoning { id, content },
+        WireStreamItem::ReasoningDelta { id, reasoning } => {
+            RawStreamingChoice::ReasoningDelta { id, reasoning }
+        }
+        WireStreamItem::Final(r) => RawStreamingChoice::FinalResponse(r),
+        WireStreamItem::Error(e) => return Err(CompletionError::ProviderError(e)),
+    })
+}
+
+// ── Framing ──
+//
+// Connections are framed with tokio's [`LinesCodec`]: one JSON value per
+// line in each direction.
+
+/// Serialize `value` as JSON and send it as one line.
+async fn send_json<T: Serialize>(framed: &mut JsonLines, value: &T) -> std::io::Result<()> {
+    let line = serde_json::to_string(value).map_err(std::io::Error::other)?;
+    framed.send(line).await.map_err(std::io::Error::other)
+}
+
+/// Receive one line and parse it as JSON. Returns `Ok(None)` on a clean EOF.
+async fn recv_json<T: for<'de> Deserialize<'de>>(
+    framed: &mut JsonLines,
+) -> std::io::Result<Option<T>> {
+    match framed.next().await {
+        None => Ok(None),
+        Some(Ok(line)) => serde_json::from_str(&line)
+            .map(Some)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        Some(Err(e)) => Err(std::io::Error::other(e)),
+    }
+}
+
+// ── Server ──
+
+/// Generate a fresh socket path in the system temp directory. Kept short
+/// because Unix socket paths have a low length limit (~104 bytes on macOS).
+fn new_socket_path() -> PathBuf {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    std::env::temp_dir().join(format!("inf-provider-{}.sock", &suffix[..12]))
+}
+
+/// Expose a [`ModelProvider`] over a Unix domain socket at a freshly
+/// generated temp path.
+///
+/// Returns the socket path and the server future. Provider binaries should
+/// print the path on stdout (so a supervisor like the daemon can discover
+/// it) and then await the future, which serves connections forever.
+///
+/// Must be called from within a tokio runtime.
+pub fn serve_provider(
+    provider: Arc<dyn ModelProvider>,
+) -> std::io::Result<(PathBuf, impl Future<Output = ()> + Send)> {
+    let path = new_socket_path();
+    let listener = UnixListener::bind(&path)?;
+    let serve = async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    let provider = provider.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_connection(provider, stream).await {
+                            tracing::warn!("model provider connection error: {e}");
+                        }
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!("model provider accept error: {e}");
+                    // Avoid spinning hot on persistent accept failures.
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+            }
+        }
+    };
+    Ok((path, serve))
+}
+
+/// Serve a single connection: read one request, write the response(s).
+async fn handle_connection(
+    provider: Arc<dyn ModelProvider>,
+    stream: UnixStream,
+) -> std::io::Result<()> {
+    let mut framed = Framed::new(stream, LinesCodec::new());
+
+    let request = match recv_json::<ProviderRequest>(&mut framed).await {
+        // Client disconnected without sending a request.
+        Ok(None) => return Ok(()),
+        Ok(Some(request)) => request,
+        Err(e) => {
+            send_json(
+                &mut framed,
+                &ProviderResponse::Error(format!("invalid request: {e}")),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    match request {
+        ProviderRequest::ListModels => {
+            let response = match provider.list_models().await {
+                Ok(models) => ProviderResponse::Models(models),
+                Err(e) => ProviderResponse::Error(e.to_string()),
+            };
+            send_json(&mut framed, &response).await?;
+        }
+        ProviderRequest::InvokeModel { model_id, request } => {
+            handle_invoke(provider, &model_id, (*request).into(), &mut framed).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Invoke the model and forward its stream as `Chunk` lines.
+async fn handle_invoke(
+    provider: Arc<dyn ModelProvider>,
+    model_id: &str,
+    request: CompletionRequest,
+    framed: &mut JsonLines,
+) -> std::io::Result<()> {
+    let mut response = match provider.invoke_model(model_id, request).await {
+        Ok(response) => response,
+        Err(e) => {
+            send_json(framed, &ProviderResponse::Error(e.to_string())).await?;
+            return Ok(());
+        }
+    };
+    send_json(framed, &ProviderResponse::InvokeStarted).await?;
+    while let Some(item) = response.next().await {
+        for wire in content_to_wire(item) {
+            send_json(framed, &ProviderResponse::Chunk(wire)).await?;
+        }
+    }
+    send_json(framed, &ProviderResponse::StreamEnd).await
+}
+
+// ── Client ──
+
+/// A [`ModelProvider`] that forwards all calls to a provider process served
+/// over a Unix domain socket (see [`serve_provider`]).
+pub struct RemoteModelProvider {
+    socket_path: PathBuf,
+}
+
+impl RemoteModelProvider {
+    pub fn new(socket_path: impl Into<PathBuf>) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+        }
+    }
+
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    /// Open a fresh connection and send a single request line.
+    async fn connect_and_send(&self, request: &ProviderRequest) -> std::io::Result<JsonLines> {
+        let stream = UnixStream::connect(&self.socket_path).await?;
+        let mut framed = Framed::new(stream, LinesCodec::new());
+        send_json(&mut framed, request).await?;
+        Ok(framed)
+    }
+}
+
+#[async_trait]
+impl ModelProvider for RemoteModelProvider {
+    async fn list_models(&self) -> Result<Vec<ModelEntry>, BoxError> {
+        let mut framed = self.connect_and_send(&ProviderRequest::ListModels).await?;
+        match recv_json::<ProviderResponse>(&mut framed).await? {
+            Some(ProviderResponse::Models(models)) => Ok(models),
+            Some(ProviderResponse::Error(e)) => Err(e.into()),
+            Some(_) => Err("unexpected response from model provider".into()),
+            None => Err("model provider closed the connection without responding".into()),
+        }
+    }
+
+    async fn invoke_model(
+        &self,
+        model_id: &str,
+        request: CompletionRequest,
+    ) -> Result<ProviderCompletionResponse, CompletionError> {
+        let mut framed = self
+            .connect_and_send(&ProviderRequest::InvokeModel {
+                model_id: model_id.to_owned(),
+                request: Box::new(request.into()),
+            })
+            .await
+            .map_err(|e| {
+                CompletionError::ProviderError(format!(
+                    "failed to reach model provider at {}: {e}",
+                    self.socket_path.display()
+                ))
+            })?;
+
+        match recv_json::<ProviderResponse>(&mut framed)
+            .await
+            .map_err(|e| {
+                CompletionError::ResponseError(format!("failed reading from model provider: {e}"))
+            })? {
+            Some(ProviderResponse::InvokeStarted) => {}
+            Some(ProviderResponse::Error(e)) => return Err(CompletionError::ProviderError(e)),
+            Some(_) => {
+                return Err(CompletionError::ResponseError(
+                    "unexpected response from model provider".to_owned(),
+                ));
+            }
+            None => {
+                return Err(CompletionError::ResponseError(
+                    "model provider closed the connection without responding".to_owned(),
+                ));
+            }
+        }
+
+        let stream = async_stream::stream! {
+            loop {
+                match recv_json::<ProviderResponse>(&mut framed).await {
+                    Ok(Some(ProviderResponse::Chunk(item))) => yield wire_to_choice(item),
+                    Ok(Some(ProviderResponse::StreamEnd)) => break,
+                    Ok(Some(_)) => {
+                        yield Err(CompletionError::ResponseError(
+                            "unexpected mid-stream response from model provider".to_owned(),
+                        ));
+                        break;
+                    }
+                    Ok(None) => {
+                        yield Err(CompletionError::ResponseError(
+                            "model provider closed the connection mid-stream".to_owned(),
+                        ));
+                        break;
+                    }
+                    Err(e) => {
+                        yield Err(CompletionError::ResponseError(format!(
+                            "failed reading from model provider: {e}"
+                        )));
+                        break;
+                    }
+                }
+            }
+        };
+        Ok(StreamingCompletionResponse::stream(Box::pin(stream)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_provider::SingleModelProvider;
+    use rig::completion::Usage;
+    use rig::message::UserContent;
+    use rig_mock::mock_model;
+
+    fn test_entry() -> ModelEntry {
+        ModelEntry {
+            model_id: "mock".to_owned(),
+            display_name: "mock".to_owned(),
+            context_window: 100,
+            max_output_tokens: None,
+        }
+    }
+
+    fn test_request(prompt: &str) -> CompletionRequest {
+        CompletionRequest {
+            model: None,
+            preamble: Some("system prompt".to_owned()),
+            chat_history: OneOrMany::one(Message::User {
+                content: OneOrMany::one(UserContent::text(prompt)),
+            }),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: Some(42),
+            tool_choice: None,
+            additional_params: None,
+            output_schema: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trip_over_unix_socket() {
+        let (model, mut ctrl) = mock_model();
+        let provider = Arc::new(SingleModelProvider::new(test_entry(), model));
+        let (path, server) = serve_provider(provider).expect("bind provider socket");
+        tokio::spawn(server);
+
+        let remote = RemoteModelProvider::new(&path);
+
+        // list_models round-trips the provider's entries.
+        let models = remote.list_models().await.expect("list models");
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].model_id, "mock");
+        assert_eq!(models[0].context_window, 100);
+
+        // invoke_model forwards the request and streams the response back.
+        let mut response = remote
+            .invoke_model("mock", test_request("hello"))
+            .await
+            .expect("invoke model");
+
+        let request = ctrl.next_request().await;
+        assert_eq!(request.preamble.as_deref(), Some("system prompt"));
+        assert_eq!(request.max_tokens, Some(42));
+
+        ctrl.send_text("hello ");
+        ctrl.send_text("world");
+        ctrl.finish_with_usage(Some(Usage {
+            input_tokens: 7,
+            output_tokens: 3,
+            ..Usage::new()
+        }));
+
+        let mut text = String::new();
+        let mut usage = None;
+        while let Some(item) = response.next().await {
+            match item.expect("stream item") {
+                StreamedAssistantContent::Text(t) => text.push_str(&t.text),
+                StreamedAssistantContent::Final(r) => usage = r.usage,
+                other => panic!("unexpected stream item: {other:?}"),
+            }
+        }
+        assert_eq!(text, "hello world");
+        let usage = usage.expect("final usage");
+        assert_eq!(usage.input_tokens, 7);
+        assert_eq!(usage.output_tokens, 3);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn connecting_to_missing_socket_fails_cleanly() {
+        let remote = RemoteModelProvider::new("/nonexistent/provider.sock");
+        match remote.invoke_model("mock", test_request("hi")).await {
+            Err(CompletionError::ProviderError(_)) => {}
+            Err(other) => panic!("unexpected error variant: {other}"),
+            Ok(_) => panic!("connect should fail"),
+        }
+        assert!(remote.list_models().await.is_err());
+    }
+}

--- a/crates/infinity-daemon/Cargo.toml
+++ b/crates/infinity-daemon/Cargo.toml
@@ -15,14 +15,13 @@ path = "src/main.rs"
 [dependencies]
 infinity-agent-core = { path = "../infinity-agent-core" }
 infinity-protocol = { path = "../infinity-protocol" }
-infinity-provider-bedrock = { path = "../infinity-provider-bedrock" }
 rap-client = { path = "../rap-client" }
 rap-protocol = { path = "../rap-protocol" }
 
 rig-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "io-util", "sync", "process", "net", "signal", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "io-util", "sync", "process", "net", "signal", "macros", "time"] }
 uuid = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/infinity-daemon/src/config.rs
+++ b/crates/infinity-daemon/src/config.rs
@@ -8,6 +8,12 @@ pub fn user_config_path() -> Result<PathBuf, BoxError> {
     Ok(home.join(".infinity").join("rap.json"))
 }
 
+/// Path to the model providers config: `~/.infinity/providers.json`.
+pub fn providers_config_path() -> Result<PathBuf, BoxError> {
+    let home = dirs::home_dir().ok_or("could not determine home directory")?;
+    Ok(home.join(".infinity").join("providers.json"))
+}
+
 pub fn load_config(path: &std::path::Path) -> Result<ToolsConfig, BoxError> {
     ToolsConfig::from_file(path)
 }

--- a/crates/infinity-daemon/src/lib.rs
+++ b/crates/infinity-daemon/src/lib.rs
@@ -18,7 +18,19 @@ use infinity_protocol::socket_path;
 use tokio::net::{TcpListener, UnixListener};
 use tracing_subscriber::EnvFilter;
 
-pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// Line printed to stdout when `run_daemon` is called with
+/// `announce_ready = true`, once initialization has succeeded and the daemon
+/// is serving. A supervising process (the CLI auto-launch) races this line
+/// against daemon exit to detect startup failures. It must remain the
+/// daemon's only stdout output.
+pub const DAEMON_READY_LINE: &str = "infinity-daemon ready";
+
+/// Run the daemon until it receives a shutdown signal. When `announce_ready`
+/// is true, prints [`DAEMON_READY_LINE`] to stdout after all initialization
+/// (including the session manager and its model providers) has succeeded.
+pub async fn run_daemon(
+    announce_ready: bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let state_dir = infinity_protocol::state_dir();
     std::fs::create_dir_all(&state_dir)?;
 
@@ -90,6 +102,10 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error + Send + Sync>
         }
         tracing::info!("received shutdown signal");
     };
+
+    if announce_ready {
+        println!("{DAEMON_READY_LINE}");
+    }
 
     tokio::select! {
         _ = async {

--- a/crates/infinity-daemon/src/main.rs
+++ b/crates/infinity-daemon/src/main.rs
@@ -3,5 +3,5 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), BoxError> {
     let local = tokio::task::LocalSet::new();
-    local.run_until(infinity_daemon::run_daemon()).await
+    local.run_until(infinity_daemon::run_daemon(false)).await
 }

--- a/crates/infinity-daemon/src/models.rs
+++ b/crates/infinity-daemon/src/models.rs
@@ -3,14 +3,266 @@
 //! Providers are stored in a map keyed by their stable unique id (e.g.
 //! `"bedrock"`). Models are identified globally by a [`ModelRef`]
 //! (provider id + provider-scoped model id).
+//!
+//! Providers run as separate processes configured in
+//! `~/.infinity/providers.json` (see [`ProvidersConfig`]): each entry maps a
+//! provider id to the command that serves that provider over a Unix socket.
+//! The daemon spawns each command, reads the socket path the process prints
+//! on stdout, and talks to it through a
+//! [`RemoteModelProvider`](infinity_agent_core::model_provider::remote::RemoteModelProvider).
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
+use infinity_agent_core::model_provider::remote::RemoteModelProvider;
 use infinity_agent_core::model_provider::{ModelEntry, ModelProvider};
 use infinity_protocol::ModelRef;
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncBufReadExt;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// How long to wait for a spawned provider process to print its socket path.
+const PROVIDER_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Configuration for a single model provider process in `providers.json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderConfig {
+    /// Command (argv) that serves this provider over a Unix socket and
+    /// prints the socket path on stdout.
+    pub command: Vec<String>,
+    /// Installation source info (mirroring rap.json toolset commands) so the
+    /// provider can be re-installed by `infinity provider update`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub crate_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+/// The providers configured in `~/.infinity/providers.json`: a JSON object
+/// mapping provider id to a [`ProviderConfig`], e.g.:
+///
+/// ```json
+/// {
+///   "bedrock": { "command": ["infinity-provider-bedrock"] },
+///   "custom": { "command": ["my-provider", "--flag"], "crate_name": "my-provider" }
+/// }
+/// ```
+///
+/// Stored as a `Vec` of `(id, config)` pairs because the JSON object's
+/// insertion order is significant — providers are registered in config
+/// order, and the first model of the first provider is the global default.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProvidersConfig {
+    pub providers: Vec<(String, ProviderConfig)>,
+}
+
+impl ProvidersConfig {
+    pub fn get(&self, id: &str) -> Option<&ProviderConfig> {
+        self.providers
+            .iter()
+            .find(|(pid, _)| pid == id)
+            .map(|(_, config)| config)
+    }
+
+    /// Insert or replace the config for `id`, preserving its position when
+    /// it already exists.
+    pub fn upsert(&mut self, id: String, config: ProviderConfig) {
+        if let Some((_, existing)) = self.providers.iter_mut().find(|(pid, _)| *pid == id) {
+            *existing = config;
+        } else {
+            self.providers.push((id, config));
+        }
+    }
+}
+
+// Serialize as a JSON object (entries in `providers` order).
+impl Serialize for ProvidersConfig {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(self.providers.len()))?;
+        for (id, config) in &self.providers {
+            map.serialize_entry(id, config)?;
+        }
+        map.end()
+    }
+}
+
+// Deserialize from a JSON object, preserving the document's entry order
+// (serde visits map entries in the order they appear in the input).
+impl<'de> Deserialize<'de> for ProvidersConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct OrderedMapVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for OrderedMapVisitor {
+            type Value = ProvidersConfig;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a map from provider id to provider config")
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut access: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut providers = Vec::new();
+                while let Some((id, config)) = access.next_entry::<String, ProviderConfig>()? {
+                    providers.push((id, config));
+                }
+                Ok(ProvidersConfig { providers })
+            }
+        }
+
+        deserializer.deserialize_map(OrderedMapVisitor)
+    }
+}
+
+/// Load the providers config from `path`. There is no implicit default: at
+/// least one provider must be configured (e.g. via
+/// `infinity provider install`) for the daemon to start.
+pub fn load_providers_config(path: &Path) -> Result<ProvidersConfig, BoxError> {
+    if !path.exists() {
+        return Err(format!(
+            "no model providers configured ({} not found); \
+             run `infinity provider install <id> --crate <name>` to install one \
+             (e.g. `infinity provider install bedrock --crate infinity-provider-bedrock`)",
+            path.display()
+        )
+        .into());
+    }
+    let json = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    let config: ProvidersConfig = serde_json::from_str(&json)
+        .map_err(|e| format!("failed to parse {}: {e}", path.display()))?;
+    if config.providers.is_empty() {
+        return Err(format!("no providers configured in {}", path.display()).into());
+    }
+    let mut seen = std::collections::HashSet::new();
+    for (provider_id, provider) in &config.providers {
+        if provider_id.is_empty() {
+            return Err(format!("empty provider id in {}", path.display()).into());
+        }
+        if !seen.insert(provider_id) {
+            return Err(
+                format!("duplicate provider id {provider_id} in {}", path.display()).into(),
+            );
+        }
+        if provider.command.is_empty() {
+            return Err(format!(
+                "provider {provider_id} in {} has an empty command",
+                path.display()
+            )
+            .into());
+        }
+    }
+    Ok(config)
+}
+
+/// Forward a child output stream to the daemon's tracing log, line by line.
+/// Also keeps the pipe drained so the child never blocks on a full pipe.
+fn forward_output_to_log(
+    provider_id: &str,
+    stream_name: &'static str,
+    stream: impl tokio::io::AsyncRead + Unpin + Send + 'static,
+) {
+    let id = provider_id.to_owned();
+    tokio::spawn(async move {
+        let mut lines = tokio::io::BufReader::new(stream).lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => tracing::info!("provider {id} {stream_name}: {line}"),
+                Ok(None) => break,
+                Err(e) => {
+                    tracing::warn!("failed reading {stream_name} of provider {id}: {e}");
+                    break;
+                }
+            }
+        }
+    });
+}
+
+/// Spawn a provider process and wait for it to print its socket path on
+/// stdout. The returned [`Child`](tokio::process::Child) kills the process
+/// when dropped; callers must keep it alive for as long as the provider is
+/// in use.
+///
+/// The child gets a null stdin and piped stdout/stderr — never the daemon's
+/// own handles, which can be closed pipes when the daemon was auto-launched
+/// in the background. Everything the provider prints (beyond the initial
+/// socket path line) is forwarded to the daemon's log.
+pub async fn spawn_provider(
+    provider_id: &str,
+    command: &[String],
+) -> Result<(RemoteModelProvider, tokio::process::Child), BoxError> {
+    let mut child = tokio::process::Command::new(&command[0])
+        .args(&command[1..])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| {
+            format!(
+                "failed to spawn provider {provider_id} ({}): {e}",
+                command[0]
+            )
+        })?;
+
+    // Forward stderr to the log right away so startup logs are captured and
+    // a chatty provider can't fill the pipe while we wait for the socket
+    // path below.
+    let stderr = child
+        .stderr
+        .take()
+        .expect("bug: piped child stderr missing");
+    forward_output_to_log(provider_id, "stderr", stderr);
+
+    let stdout = child
+        .stdout
+        .take()
+        .expect("bug: piped child stdout missing");
+    let mut lines = tokio::io::BufReader::new(stdout).lines();
+    let socket_path = tokio::time::timeout(PROVIDER_STARTUP_TIMEOUT, lines.next_line())
+        .await
+        .map_err(|_| format!("provider {provider_id} did not print a socket path in time"))?
+        .map_err(|e| format!("failed reading socket path from provider {provider_id}: {e}"))?
+        .ok_or_else(|| format!("provider {provider_id} exited without printing a socket path"))?;
+
+    // Forward any further stdout output to the log as well.
+    forward_output_to_log(provider_id, "stdout", lines.into_inner());
+
+    Ok((RemoteModelProvider::new(socket_path.trim()), child))
+}
+
+/// Spawn every provider in the config. Returns the `(provider_id, provider)`
+/// pairs for [`ModelCatalog::new`] plus the child process handles, which
+/// must be kept alive for as long as the providers are in use.
+pub async fn spawn_configured_providers(
+    config: &ProvidersConfig,
+) -> Result<
+    (
+        Vec<(String, Arc<dyn ModelProvider>)>,
+        Vec<tokio::process::Child>,
+    ),
+    BoxError,
+> {
+    let mut providers: Vec<(String, Arc<dyn ModelProvider>)> = Vec::new();
+    let mut children = Vec::new();
+    for (provider_id, provider_config) in &config.providers {
+        let (provider, child) = spawn_provider(provider_id, &provider_config.command).await?;
+        tracing::info!(
+            "provider {provider_id} serving on {}",
+            provider.socket_path().display()
+        );
+        providers.push((provider_id.clone(), Arc::new(provider) as _));
+        children.push(child);
+    }
+    Ok((providers, children))
+}
 
 /// A model in the catalog, tagged with the provider that offers it.
 #[derive(Clone)]
@@ -112,5 +364,134 @@ impl ModelCatalog {
             .find(&self.default)
             .expect("bug: default model missing from catalog");
         (self.default.clone(), entry, true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_providers_config_is_an_error() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let Err(err) = load_providers_config(&dir.path().join("providers.json")) else {
+            panic!("missing config should be an error");
+        };
+        assert!(
+            err.to_string().contains("infinity provider install"),
+            "error should point at `infinity provider install`: {err}"
+        );
+    }
+
+    #[test]
+    fn providers_config_parses_entries_and_preserves_order() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("providers.json");
+        // Note: ids deliberately not in alphabetical order — the document
+        // order must be preserved (it determines the default provider).
+        std::fs::write(
+            &path,
+            r#"{
+                "zeta": { "command": ["zeta-provider"] },
+                "bedrock": {
+                    "command": ["infinity-provider-bedrock"],
+                    "crate_name": "infinity-provider-bedrock"
+                },
+                "custom": {
+                    "command": ["/usr/local/bin/my-provider", "--flag", "value"],
+                    "crate_name": "my-provider",
+                    "git": "https://example.com/my-provider.git"
+                }
+            }"#,
+        )
+        .expect("write config");
+        let config = load_providers_config(&path).expect("load config");
+        let ids: Vec<&str> = config.providers.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, ["zeta", "bedrock", "custom"]);
+        let custom = config.get("custom").expect("custom provider");
+        assert_eq!(
+            custom.command,
+            vec![
+                "/usr/local/bin/my-provider".to_owned(),
+                "--flag".to_owned(),
+                "value".to_owned()
+            ]
+        );
+        assert_eq!(custom.crate_name.as_deref(), Some("my-provider"));
+        assert_eq!(
+            custom.git.as_deref(),
+            Some("https://example.com/my-provider.git")
+        );
+        assert_eq!(custom.path, None);
+    }
+
+    #[test]
+    fn providers_config_round_trips_in_order() {
+        let mut config = ProvidersConfig::default();
+        config.upsert(
+            "zeta".to_owned(),
+            ProviderConfig {
+                command: vec!["zeta-provider".to_owned()],
+                crate_name: None,
+                git: None,
+                path: None,
+            },
+        );
+        config.upsert(
+            "alpha".to_owned(),
+            ProviderConfig {
+                command: vec!["alpha-provider".to_owned()],
+                crate_name: Some("alpha-provider".to_owned()),
+                git: None,
+                path: Some("/src/alpha".to_owned()),
+            },
+        );
+        let json = serde_json::to_string_pretty(&config).expect("serialize");
+        // "zeta" must come before "alpha" in the serialized object.
+        assert!(json.find("zeta").expect("zeta") < json.find("alpha").expect("alpha"));
+        let parsed: ProvidersConfig = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed, config);
+    }
+
+    #[test]
+    fn providers_config_upsert_replaces_in_place() {
+        let mut config = ProvidersConfig::default();
+        let entry = |cmd: &str| ProviderConfig {
+            command: vec![cmd.to_owned()],
+            crate_name: None,
+            git: None,
+            path: None,
+        };
+        config.upsert("first".to_owned(), entry("first-v1"));
+        config.upsert("second".to_owned(), entry("second-v1"));
+        config.upsert("first".to_owned(), entry("first-v2"));
+        let ids: Vec<&str> = config.providers.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, ["first", "second"]);
+        assert_eq!(
+            config.get("first").map(|p| p.command.clone()),
+            Some(vec!["first-v2".to_owned()])
+        );
+    }
+
+    #[test]
+    fn providers_config_rejects_invalid_entries() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("providers.json");
+
+        std::fs::write(&path, "{}").expect("write config");
+        assert!(load_providers_config(&path).is_err(), "empty config");
+
+        std::fs::write(&path, r#"{"bedrock": {"command": []}}"#).expect("write config");
+        assert!(load_providers_config(&path).is_err(), "empty command");
+
+        std::fs::write(
+            &path,
+            r#"{"a": {"command": ["x"]}, "a": {"command": ["y"]}}"#,
+        )
+        .expect("write config");
+        assert!(load_providers_config(&path).is_err(), "duplicate ids");
+
+        std::fs::write(&path, "not json").expect("write config");
+        assert!(load_providers_config(&path).is_err(), "invalid json");
     }
 }

--- a/crates/infinity-daemon/src/session/mod.rs
+++ b/crates/infinity-daemon/src/session/mod.rs
@@ -17,7 +17,7 @@ use tokio::task::JoinHandle;
 use crate::config;
 use crate::mcp_proxy;
 use crate::memory_store::{InMemoryConversationStore, InMemoryMessageSender, InMemoryStateStore};
-use crate::models::ModelCatalog;
+use crate::models::{self, ModelCatalog};
 use crate::rap_tools;
 use crate::session_store;
 use crate::set_title_tool;
@@ -77,6 +77,9 @@ pub struct SessionManager {
     state_store: InMemoryStateStore,
     /// Registered model providers and their available models.
     pub catalog: Arc<ModelCatalog>,
+    /// Spawned model provider processes. Held so the providers stay alive
+    /// for the daemon's lifetime (the processes are killed on drop).
+    _provider_processes: Vec<tokio::process::Child>,
     /// Connected clients that receive broadcast updates.
     broadcast_clients: Arc<std::sync::Mutex<Vec<mpsc::UnboundedSender<DaemonMessage>>>>,
     /// Remote daemon connections.
@@ -85,15 +88,14 @@ pub struct SessionManager {
 
 impl SessionManager {
     pub async fn new(state_dir: PathBuf, callback_url: String) -> Result<Self, BoxError> {
-        // Register model providers. Each provider gets a stable unique id;
-        // the first model of the first provider is the global default.
-        let catalog = Arc::new(
-            ModelCatalog::new(vec![(
-                "bedrock".to_owned(),
-                Arc::new(infinity_provider_bedrock::BedrockProvider::from_env()) as _,
-            )])
-            .await?,
-        );
+        // Spawn the model providers configured in `~/.infinity/providers.json`
+        // (each runs as a separate process serving a Unix socket) and register
+        // them. Provider ids are the config keys; the first model of the
+        // first provider is the global default.
+        let providers_config = models::load_providers_config(&config::providers_config_path()?)?;
+        let (providers, provider_processes) =
+            models::spawn_configured_providers(&providers_config).await?;
+        let catalog = Arc::new(ModelCatalog::new(providers).await?);
 
         std::fs::create_dir_all(&state_dir).ok();
         let sessions_path = state_dir.join("sessions.json");
@@ -154,6 +156,7 @@ impl SessionManager {
             conversation_store,
             state_store,
             catalog,
+            _provider_processes: provider_processes,
             broadcast_clients,
             remote_daemons: None,
         })

--- a/crates/infinity-provider-bedrock/Cargo.toml
+++ b/crates/infinity-provider-bedrock/Cargo.toml
@@ -10,6 +10,8 @@ rig-core = { workspace = true }
 rig-bedrock = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/infinity-provider-bedrock/src/main.rs
+++ b/crates/infinity-provider-bedrock/src/main.rs
@@ -1,0 +1,34 @@
+//! Standalone binary serving the Bedrock [`ModelProvider`] over a Unix
+//! socket (see `infinity_agent_core::model_provider::remote`).
+//!
+//! Prints the generated socket path as the first (and only) stdout line so a
+//! supervisor (e.g. `infinity-daemon`) can discover it; logs go to stderr.
+
+use std::io::Write;
+use std::sync::Arc;
+
+use infinity_agent_core::model_provider::remote::serve_provider;
+use infinity_provider_bedrock::BedrockProvider;
+use tracing_subscriber::EnvFilter;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    // stdout is reserved for the socket path; log to stderr (captured into
+    // the supervising daemon's log, so no ANSI styling).
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    let provider = Arc::new(BedrockProvider::from_env());
+    let (socket_path, server) = serve_provider(provider)?;
+
+    println!("{}", socket_path.display());
+    std::io::stdout().flush()?;
+
+    server.await;
+    Ok(())
+}

--- a/docs/docs/infinity-code/model-providers.md
+++ b/docs/docs/infinity-code/model-providers.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 4
+title: Model Providers
+---
+
+# Model Providers
+
+Infinity Code doesn't talk to any LLM API directly — all model inference goes through **model providers**: separate processes that the daemon launches and manages. Each provider exposes one or more models (for example, the Bedrock provider exposes the Claude models available on AWS Bedrock).
+
+At least one provider must be installed before the agent can start.
+
+## Installing a provider
+
+Providers are installed with `infinity provider install`, which `cargo install`s the provider crate and registers it in `~/.infinity/providers.json`:
+
+```bash
+infinity provider install bedrock --git https://github.com/hydro-project/infinity --crate infinity-provider-bedrock
+```
+
+- The first argument (`bedrock`) is the **provider id** — a name you choose. Models are tracked as `provider id + model id`, so pick a stable name.
+- `--crate` is the crate to install; its binary becomes the provider's command.
+- `--git` / `--path` record where the crate comes from, exactly like `infinity rap install`, so the provider can be updated later.
+
+### The Bedrock provider
+
+`infinity-provider-bedrock` serves the Claude models available on AWS Bedrock. It uses your ambient AWS configuration — the standard SDK credential chain (`AWS_PROFILE`, environment variables, SSO, instance profiles) — and requires Bedrock model access to be enabled on the account.
+
+## Configuration
+
+Providers live in `~/.infinity/providers.json`, a JSON object mapping provider id to its configuration:
+
+```json
+{
+  "bedrock": {
+    "command": ["infinity-provider-bedrock"],
+    "crate_name": "infinity-provider-bedrock",
+    "git": "https://github.com/hydro-project/infinity"
+  },
+  "my-provider": {
+    "command": ["/usr/local/bin/my-provider", "--some-flag"]
+  }
+}
+```
+
+- **`command`** — the command (argv) the daemon runs to start the provider. Bare names are looked up on `PATH`; absolute paths are used as-is.
+- **`crate_name`**, **`git`**, **`path`** *(optional)* — installation source, recorded by `infinity provider install` and used by `infinity provider update`. Hand-written entries without these still work; they just can't be auto-updated.
+
+**Order matters**: providers are registered in the order they appear in the file, and the first model of the first provider is the default model for new sessions. You can edit the file by hand — the daemon reads it at startup, so restart the daemon (`infinity daemon stop`) after changes.
+
+## Switching models
+
+The model picker (`/model` or `Ctrl+M` in the TUI) lists every model from every configured provider. Each thread remembers its own selection; if a selected model disappears from the configuration, the thread falls back to the default model with a warning.
+
+## Updating
+
+```bash
+infinity provider update
+```
+
+re-installs every provider that has a recorded source (`crate_name` plus optional `git`/`path`). Providers are also updated as part of a full
+
+```bash
+infinity update
+```
+
+which updates the CLI binary, model providers, and RAP servers in one go.
+
+## Troubleshooting
+
+When the CLI launches the daemon in the background, it waits for the daemon to report readiness; if the daemon exits during startup instead, the CLI prints everything the daemon wrote to stdout/stderr, so configuration errors surface directly:
+
+- **"no model providers configured"** — the daemon refuses to start without `~/.infinity/providers.json`. Install a provider (see above).
+- **Provider fails to start** — if a configured provider can't be spawned (e.g. its binary was removed) or doesn't come up, the daemon exits with the provider's error. Details are also logged to `~/.infinity/daemon.log`.
+
+## Building your own provider
+
+Any process that implements the provider protocol can serve models — see [Model Providers in the Infinity Runtime docs](/docs/infinity-runtime/model-providers) for the `ModelProvider` trait and a guide to writing a provider crate.

--- a/docs/docs/infinity-code/overview.md
+++ b/docs/docs/infinity-code/overview.md
@@ -28,8 +28,13 @@ Then install:
 # Install the CLI (includes the desktop web UI; remove --features bundled-web if you don't have npm)
 cargo install infinity-agent-cli --git https://github.com/hydro-project/infinity --features bundled-web
 
+# Install a model provider — Bedrock invokes models with your AWS credentials
+infinity provider install bedrock --git https://github.com/hydro-project/infinity --crate infinity-provider-bedrock
+
 infinity rap install --user --git https://github.com/hydro-project/infinity --crate sandbox-local
 ```
+
+[Model providers](./model-providers.md) run as separate processes managed by the daemon and are registered in `~/.infinity/providers.json`; at least one must be installed. The Bedrock provider uses your ambient AWS configuration (e.g. `AWS_PROFILE` or environment credentials).
 
 To update later:
 
@@ -37,7 +42,7 @@ To update later:
 infinity update
 ```
 
-This updates both the CLI binary and any installed RAP servers.
+This updates the CLI binary, installed model providers, and any installed RAP servers.
 
 ### First run
 
@@ -75,6 +80,7 @@ Both modes connect to the same daemon as the CLI, so you can use all three inter
 ## Key Features
 
 - **Sandboxed editing** — changes happen in isolated workspaces. Supports [Jujutsu](./coding-with-jj.md) (recommended) and [Git](./coding-with-git.md).
+- **Pluggable models** — models come from [model provider](./model-providers.md) processes; install, mix, and switch between providers.
 - **Parallel threads** — the agent spawns child threads for independent sub-tasks. Each thread gets its own sandbox and reports back when done.
 - **Background sessions** — detach from a busy agent and reconnect later. Multiple sessions can run concurrently via the [daemon](./background-agents.md).
 - **Remote sessions** — connect to agents running on other machines over SSH. See [Configuring Remotes](./configuring-remotes.md).
@@ -100,5 +106,6 @@ The TUI runs anywhere you have a terminal. Start it with `infinity` in any repo.
 
 - [Coding with Jujutsu](./coding-with-jj.md) — the recommended workflow
 - [Coding with Git](./coding-with-git.md) — for plain git repos
+- [Model Providers](./model-providers.md) — install, configure, and update model backends
 - [Background Agents](./background-agents.md) — run multiple agents concurrently
 - [Configuring MCP](./configuring-mcp.md) — add MCP servers as tool sets

--- a/docs/docs/infinity-runtime/getting-started.md
+++ b/docs/docs/infinity-runtime/getting-started.md
@@ -68,8 +68,13 @@ cd InfinityAgents
 Build and run the CLI:
 
 ```bash
+# One-time setup: install the Bedrock model provider and register it
+cargo run -p infinity-agent-cli -- provider install bedrock --crate infinity-provider-bedrock --path crates/infinity-provider-bedrock
+
 cargo run -p infinity-agent-cli
 ```
+
+The agent invokes models through [provider processes](/docs/infinity-runtime/model-providers) registered in `~/.infinity/providers.json` — the first command installs the Bedrock provider binary and registers it there. At least one provider must be installed before the agent can start.
 
 The first build will take a few minutes while Cargo downloads and compiles dependencies. Subsequent runs are fast.
 
@@ -161,6 +166,7 @@ Now that you have a local agent running with a tool, here are good next steps:
 
 - **[Build a RAP Tool](/docs/rap/using-rap/building-a-rap-tool)** — create your own tool server that speaks RAP
 - **[Architecture](/docs/rap/about/architecture)** — understand the full message flow, callback lifecycle, and hibernation model
+- **[Model Providers](/docs/infinity-runtime/model-providers)** — how the runtime invokes models, and how to write your own provider
 - **[Built-in Tools](/docs/infinity-runtime/built-in-tools)** — sleep, threading, and utility tools available to every agent
 - **[RAP Specification](/docs/rap/spec/overview)** — the full protocol reference
 - **[Cloud Deployment](/docs/infinity-runtime/cloud-deployment)** — deploy your agent to AWS Lambda for persistent state and real hibernation

--- a/docs/docs/infinity-runtime/model-providers.md
+++ b/docs/docs/infinity-runtime/model-providers.md
@@ -1,0 +1,113 @@
+---
+sidebar_position: 4
+title: Model Providers
+---
+
+# Model Providers
+
+The Infinity Runtime never calls an LLM API directly. All inference goes through the `ModelProvider` trait, an abstraction that decouples the agent loop from any particular model backend. A provider:
+
+- **lists the models it offers** — each with a display name, context window, and output token limit — and
+- **invokes a model by id**, streaming the completion response back.
+
+Everything else in the runtime (the agent loop, threading, compaction, token accounting) is written against this trait. The daemon registers each provider under a stable **provider id**, and models are referenced globally as `provider id + model id`, so multiple providers can coexist and even offer models with the same name.
+
+Providers own all backend-specific behavior. Callers hand them a plain [rig](https://docs.rs/rig-core) `CompletionRequest`; the provider is responsible for backend-specific request parameters — thinking configuration, beta feature flags, per-model output token limits, and so on. For example, the Bedrock provider injects Anthropic's adaptive thinking configuration and the 1M-context beta flag for the models that need them, without the agent loop knowing those exist.
+
+## The `ModelProvider` trait
+
+Defined in `infinity_agent_core::model_provider`:
+
+```rust
+#[async_trait]
+pub trait ModelProvider: Send + Sync {
+    /// List the models available from this provider. The first entry is the
+    /// provider's default model.
+    async fn list_models(&self) -> Result<Vec<ModelEntry>, BoxError>;
+
+    /// Invoke a model by its provider-scoped id, streaming the completion
+    /// response. Behaves exactly like rig's `CompletionModel::stream`, with
+    /// the streaming response type erased.
+    async fn invoke_model(
+        &self,
+        model_id: &str,
+        request: CompletionRequest,
+    ) -> Result<ProviderCompletionResponse, CompletionError>;
+}
+```
+
+A `ModelEntry` describes one model:
+
+```rust
+pub struct ModelEntry {
+    /// Provider-scoped identifier. Unique within the provider, but need not
+    /// match the upstream API's model id.
+    pub model_id: String,
+    /// Human-readable name shown in pickers.
+    pub display_name: String,
+    /// Context window size in tokens (used for compaction thresholds).
+    pub context_window: usize,
+    /// Max output tokens per request (None = backend default).
+    pub max_output_tokens: Option<u64>,
+}
+```
+
+Because `model_id` is provider-scoped rather than the upstream id, a provider can expose **multiple configurations of the same upstream model** as separate entries — the Bedrock provider offers `claude-opus-4-6` both as a standard 200K-context model and as a 1M-context variant that enables a beta flag on every request.
+
+## Writing a provider
+
+A provider typically wraps a rig `CompletionModel` internally:
+
+1. Implement `list_models` to return your catalog (often a static list).
+2. Implement `invoke_model`: resolve the `model_id` to your backend's model, apply any backend-specific request parameters, call the underlying model's `stream`, and erase the response with the `erase_streaming_response` helper:
+
+```rust
+async fn invoke_model(
+    &self,
+    model_id: &str,
+    mut request: CompletionRequest,
+) -> Result<ProviderCompletionResponse, CompletionError> {
+    // ...apply backend-specific parameters to `request`...
+    let model = self.client.completion_model(model_id);
+    Ok(erase_streaming_response(model.stream(request).await?))
+}
+```
+
+For tests or single-model setups there's a ready-made adapter, `SingleModelProvider`, which exposes one rig `CompletionModel` as a provider.
+
+The trait is dyn-compatible, which requires erasing the backend-specific streaming response type: streams yield the usual text / tool call / reasoning chunks, and the final response is reduced to a `ProviderStreamingResponse` carrying the token usage — all that downstream code needs.
+
+## The provider process transport
+
+The local daemon (Infinity Code) runs each provider as a separate process configured in `~/.infinity/providers.json` (see [Model Providers in the Infinity Code docs](/docs/infinity-code/model-providers) for installing and configuring them) and aggregates their models into one catalog, with the first model of the first configured provider as the default. These provider processes are served over a **Unix domain socket**. You rarely need the details — `infinity_agent_core::model_provider::remote` provides both sides — but they matter when packaging a provider as an installable crate.
+
+A provider binary does three things:
+
+```rust
+use std::sync::Arc;
+use infinity_agent_core::model_provider::remote::serve_provider;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let provider = Arc::new(MyProvider::new());
+    let (socket_path, server) = serve_provider(provider)?;
+
+    // stdout contract: the first line is the socket path.
+    println!("{}", socket_path.display());
+
+    server.await;
+    Ok(())
+}
+```
+
+1. `serve_provider` binds a listener on a freshly generated temp socket path and serves the provider on it.
+2. The binary prints the socket path as its **first stdout line** — that's how the supervising daemon discovers it. Anything else (logging, diagnostics) should go to stderr; the daemon captures both streams and forwards every later line to its own log.
+3. It then awaits the server future forever. The daemon owns the process lifecycle: it spawns the binary at startup and kills it on shutdown.
+
+On the wire, the protocol is newline-delimited JSON with one request per connection (concurrent invocations simply use concurrent connections): a `ListModels` request gets a single response, while `InvokeModel` streams the completion back as chunk lines terminated by a stream-end marker. The daemon side is `RemoteModelProvider` — itself a `ModelProvider` implementation that forwards every call over the socket, so in-process and out-of-process providers are indistinguishable to the runtime.
+
+Once your provider crate is published (or available in a git repo), users install it with:
+
+```bash
+infinity provider install my-provider --git https://github.com/you/my-provider --crate my-provider
+```


### PR DESCRIPTION
The Bedrock provider is no longer hardcoded and linked into the daemon.
Providers now run as standalone processes that serve the `ModelProvider`
trait over a Unix domain socket, configured in `~/.infinity/providers.json`
and managed with new `infinity provider` CLI commands. The CLI also gained
a readiness handshake so daemon startup failures surface directly.

## `infinity-agent-core`: `model_provider::remote` submodule

New Unix-socket transport for any `ModelProvider` implementor
(`model_provider.rs` moved to `model_provider/mod.rs` to host it):

* **Protocol**: newline-delimited JSON, one request per connection
  (concurrent invocations = concurrent connections).
  `ProviderRequest::{ListModels, InvokeModel}` →
  `ProviderResponse::{Models, InvokeStarted, Chunk…, StreamEnd, Error}`.
  `WireCompletionRequest` / `WireStreamItem` are serializable mirrors of
  rig's `CompletionRequest` and `RawStreamingChoice`.
* **Server**: `serve_provider(provider)` binds a fresh temp socket path and
  returns `(path, server_future)` for provider binaries to run.
* **Client**: `RemoteModelProvider` implements the full trait over the
  socket, including streaming with mid-stream error forwarding.
* Tests: socket round trip (list + streamed invocation with usage) against
  a mock model; clean failure on a missing socket.

## `infinity-provider-bedrock`: new binary

Serves `BedrockProvider::from_env()` via `serve_provider` and prints the
socket path as its only stdout line (logs go to stderr).

## `infinity-daemon`: config-driven provider registry

* **BREAKING**: the daemon no longer links the Bedrock provider. Providers
  come from `~/.infinity/providers.json` — a JSON object mapping provider
  id to `{ "command": [...], "crate_name"?, "git"?, "path"? }`. There is no
  implicit default: a missing/empty config is a startup error pointing at
  `infinity provider install`.
* `ProvidersConfig` preserves the JSON document's entry order via custom
  serde impls backed by a `Vec` (config order = registration order; the
  first model of the first provider is the global default). Duplicate ids,
  empty ids, and empty commands are rejected.
* `models::spawn_provider` launches each command with piped stdout, waits
  (30s timeout) for the socket path line, forwards later stdout to the
  log, and kills the process on drop; bare program names resolve `PATH`. `SessionManager` builds the
  `ModelCatalog` from `RemoteModelProvider`s and keeps the child handles
  alive for the daemon's lifetime.
* `run_daemon(announce_ready: bool)` prints the new `DAEMON_READY_LINE` to
  stdout after all initialization succeeds (passed as true by the
  `infinity daemon` subcommand; the standalone binary keeps it off).

## `infinity-agent-cli`: provider management + launch supervision

* `infinity provider install <id> --crate <name> [--git URL | --path DIR]`
  — cargo-installs the provider crate (sharing the `run_cargo_install` TUI
  plumbing with `rap install`) and registers it in providers.json,
  replacing existing entries in place to preserve ordering.
* `infinity provider update` re-installs all providers with recorded
  sources; full `infinity update` now also updates providers.
* `launch_daemon` spawns `{bin} daemon` with piped stdout/stderr and races
  (`tokio::select!`) the ready line against process exit (60s outer
  timeout). If the daemon exits during startup, the CLI reports everything
  it printed to stdout/stderr — previously discarded for the detached
  process. The post-launch connect retry loop is gone: the socket is bound
  before readiness is announced, so a single connect suffices.
* CLI `main` returns `ExitCode` and prints errors with Display formatting,
  so multi-line failure reports keep real newlines instead of Debug-escaped
  `\n`s.

## Docs

* Quickstarts (README, Infinity Code overview, runtime getting-started)
  now include installing the Bedrock provider.
* New `infinity-code/model-providers.md`: installing / configuring /
  switching / updating providers, providers.json reference, and
  troubleshooting based on the captured startup output.
* New `infinity-runtime/model-providers.md`: the `ModelProvider` trait and
  `ModelEntry` semantics, writing a provider, with the Unix-socket process
  transport (stdout contract, ndjson protocol, `RemoteModelProvider`)
  covered at the end.

The lambda crate intentionally keeps linking `BedrockProvider` in-process.

BREAKING CHANGE: the daemon requires `~/.infinity/providers.json` with at
least one provider; run
`infinity provider install bedrock --crate infinity-provider-bedrock` (or
install from the repo with `--git`/`--path`) before starting.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>