### PR TITLE
fix(infinity-agent-cli): context usage resets to zero after session replay

### DIFF
--- a/crates/infinity-agent-cli/src/daemon_client.rs
+++ b/crates/infinity-agent-cli/src/daemon_client.rs
@@ -543,7 +543,10 @@ async fn run_client(
                                     let _ = display_tx.send(evt);
                                 }
                             }
-                            let _ = display_tx.send((None, DisplayEvent::ResponseDone(Some(DaemonTokenUsage(None)))));
+                            // End-of-replay marker: closes any open stream/spinner
+                            // state. Deliberately carries no usage info so it does
+                            // not clobber the total from the Connected message.
+                            let _ = display_tx.send((None, DisplayEvent::ResponseDone(None)));
                             for m in pending_choices {
                                 if let Some(evt) = daemon_msg_to_display(m) {
                                     let _ = display_tx.send(evt);

--- a/crates/infinity-agent-cli/src/terminal.rs
+++ b/crates/infinity-agent-cli/src/terminal.rs
@@ -418,8 +418,13 @@ where
                     }
                     DisplayEvent::ResponseDone(r) => {
                         if is_root {
-                            if let Some(r) = r {
-                                total_tokens_used = r.token_usage().map_or(0, |u| u.total_tokens as usize);
+                            // Only update the counter when the response actually
+                            // reports usage: a usage-less ResponseDone (e.g. the
+                            // marker appended after a session replay, or a provider
+                            // that omitted usage metadata) must not reset the
+                            // context indicator to zero.
+                            if let Some(u) = r.and_then(|r| r.token_usage()) {
+                                total_tokens_used = u.total_tokens as usize;
                             }
                             if spinner_state != Some(SpinnerState::WaitingToolCall) {
                                 spinner_state = None;

--- a/crates/infinity-agent-cli/tests/snapshots/tui_flow_snapshots__replay_keeps_context_usage.snap
+++ b/crates/infinity-agent-cli/tests/snapshots/tui_flow_snapshots__replay_keeps_context_usage.snap
@@ -1,0 +1,22 @@
+---
+source: crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
+expression: h.screen()
+---
+┌────────────────────────────────────────────────────────────────────────────────┐
+│Infinity Agent CLI                                                              │
+│Type your messages below. /help for commands. Ctrl+C to exit.                   │
+│                                                                                │
+│                                                                                │
+│✦ Loading session — thread replayed-session-0001                                │
+│> replayed question                                                             │
+│replayed answer                                                                 │
+│                                                                                │
+│                                                                                │
+│────────────────────────────────────────────────────────────────────────────────│
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│mock-model (/help for commands)                      replayed | 42% context used│
+└────────────────────────────────────────────────────────────────────────────────┘
+cursor: row=11 col=1
+title: Replayed session

--- a/crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
+++ b/crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
@@ -108,6 +108,30 @@ async fn session_replay_burst() {
     insta::assert_snapshot!("replay_then_live", h.screen_with_scrollback());
 }
 
+/// Loading a session populates the context indicator from the session info
+/// in the Connected message; the replayed history carries no usage data and
+/// ends with a usage-less ResponseDone marker. Neither that marker nor a
+/// live response without usage metadata may reset the indicator to zero.
+#[tokio::test(start_paused = true)]
+async fn replay_keeps_context_usage() {
+    let h = TuiHarness::spawn(80, 14).await;
+
+    send_session(&h, "replayed-session-0001", "Replayed session", 42_000);
+    h.display(Evt::UserInput("replayed question".to_owned()));
+    h.display(Evt::StartOutput);
+    h.display(Evt::TextChunk {
+        chunk: "replayed answer".to_owned(),
+    });
+    // The end-of-replay marker daemon_client appends after the history.
+    h.display(Evt::ResponseDone(None));
+    // A response whose provider reported no usage must not reset it either.
+    h.display(Evt::ResponseDone(Some(MockStreamingResponse {
+        usage: None,
+    })));
+    h.settle().await;
+    insta::assert_snapshot!("replay_keeps_context_usage", h.screen());
+}
+
 /// Tool results rendered as a unified diff (Diff segment branch) and with
 /// no segments at all (bare " ✓" branch).
 #[tokio::test(start_paused = true)]

--- a/crates/infinity-daemon/src/session/thread_worker.rs
+++ b/crates/infinity-daemon/src/session/thread_worker.rs
@@ -94,8 +94,13 @@ pub async fn thread_worker(
                     && let Some(r) = r
                 {
                     use rig::completion::GetTokenUsage;
-                    let tokens = r.token_usage().map_or(0, |u| u.total_tokens as usize);
-                    fwd_conversation_store.set_total_tokens_used(&fwd_group_id, tokens);
+                    // Only persist usage the provider actually reported; a
+                    // response without usage metadata must not reset the
+                    // stored total to zero.
+                    if let Some(usage) = r.token_usage() {
+                        fwd_conversation_store
+                            .set_total_tokens_used(&fwd_group_id, usage.total_tokens as usize);
+                    }
                     fwd_conversation_store
                         .set_last_updated(&fwd_group_id, &chrono::Utc::now().to_rfc3339());
                 }


### PR DESCRIPTION
## Root cause

When loading a session, the CLI sets the context counter from the
`Connected` message (`total_tokens_used` from session info). But after
forwarding the replayed history, `daemon_client` appended a synthesized
`ResponseDone(Some(DaemonTokenUsage(None)))` marker, and the terminal's
`ResponseDone` handler did:

```rust
if let Some(r) = r {
    total_tokens_used = r.token_usage().map_or(0, ...);
}
```

Since the marker carries no usage, `map_or(0, ...)` reset the counter to
zero right after the replay. (Not a daemon or Bedrock bug — though the
same pattern existed daemon-side, see below.)

## Changes

* `terminal.rs`: only update `total_tokens_used` when the response
  actually reports usage; a usage-less `ResponseDone` (post-replay
  marker, or a provider that omits usage metadata) keeps the last known
  value instead of zeroing it.
* `daemon_client.rs`: send the end-of-replay marker as
  `ResponseDone(None)` instead of wrapping an empty usage, making the
  "no usage info" intent explicit.
* `infinity-daemon/thread_worker.rs` (defensive, same bug class): the
  display-event forwarder no longer persists `total_tokens_used = 0`
  when a response has no usage metadata (e.g. a Bedrock stream that ends
  without a usage `Metadata` event); `last_updated` is still refreshed.

## Tests

* New snapshot test `replay_keeps_context_usage` modeling the real load
  flow: `SessionChanged` with 42k tokens → replayed history →
  `ResponseDone(None)` → `ResponseDone` with `usage: None`. Status bar
  must still show `42% context used` (previously showed `0%`).

Co-authored-by: Infinity 🤖 <infinity@hydro.run>