### PR TITLE
fix(infinity-agent-cli): update displayed model when loading an existing session

### DIFF
--- a/crates/infinity-agent-cli/src/daemon_client.rs
+++ b/crates/infinity-agent-cli/src/daemon_client.rs
@@ -529,9 +529,9 @@ async fn run_client(
                         break;
                     };
                     match msg {
-                        DaemonMessage::Connected { session_id, title, total_tokens_used, .. } => {
+                        DaemonMessage::Connected { session_id, title, total_tokens_used, model_name, context_window, .. } => {
                             active_session = Some(session_id.clone());
-                            let _ = session_tx.send(SessionChanged { session_id, title, total_tokens_used });
+                            let _ = session_tx.send(SessionChanged { session_id, title, total_tokens_used, model_name, context_window });
                             for text in pending_input.drain(..) {
                                 let sid = active_session.as_ref().expect("bug: active_session should be set after Connected").clone();
                                 let _ = to_daemon.send(ClientMessage::UserInput { session_id: sid, text });

--- a/crates/infinity-agent-cli/src/terminal.rs
+++ b/crates/infinity-agent-cli/src/terminal.rs
@@ -70,6 +70,10 @@ pub struct SessionChanged {
     pub session_id: String,
     pub title: Option<String>,
     pub total_tokens_used: usize,
+    /// Display name of the model associated with the session's root thread.
+    pub model_name: String,
+    /// Context window of that model, used for the token-usage gauge.
+    pub context_window: usize,
 }
 
 /// Result of a SoftDetach attempt, sent back from daemon_client to terminal.
@@ -213,6 +217,8 @@ where
 
                 thread_id = Some(change.session_id.clone());
                 total_tokens_used = change.total_tokens_used;
+                model_name = change.model_name;
+                context_window = change.context_window;
                 thread_buffers.clear(); // for now, we can't properly restore themn
                 set_terminal_title(viewport.term_mut(), change.title.as_deref().unwrap_or(""));
                 viewport.print_line_above(Line::from(""))?;

--- a/crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
+++ b/crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
@@ -37,6 +37,8 @@ fn send_session(h: &TuiHarness, id: &str, title: &str, tokens: usize) {
             session_id: id.to_owned(),
             title: Some(title.to_owned()),
             total_tokens_used: tokens,
+            model_name: "mock-model".to_owned(),
+            context_window: 100_000,
         })
         .expect("bug: UI task dropped session channel");
 }

--- a/crates/infinity-agent-cli/tests/tui_snapshots.rs
+++ b/crates/infinity-agent-cli/tests/tui_snapshots.rs
@@ -191,6 +191,8 @@ async fn session_loaded_updates_title_and_status() {
             session_id: "f00dcafe-1234-5678-9abc-def012345678".to_owned(),
             title: Some("My fancy session".to_owned()),
             total_tokens_used: 42_000,
+            model_name: "mock-model".to_owned(),
+            context_window: 100_000,
         })
         .expect("UI task dropped session channel");
     h.settle().await;


### PR DESCRIPTION
The daemon's `Connected` message already carries the resolved `model_name` and
`context_window` for the session's root thread (resolved via
`get_thread_model` in `build_connected`), but the CLI client dropped both
fields when translating it into the terminal's `SessionChanged` event. As a
result, the TUI status bar kept showing the previous/default model after
loading an existing session, and the token-usage gauge used the wrong context
window.

* Add `model_name` and `context_window` to `terminal::SessionChanged`
* Forward both fields from `DaemonMessage::Connected` in `daemon_client.rs`
* Apply them to the terminal's `model_name` / `context_window` state when a
  session change arrives, so the status bar and context gauge reflect the
  loaded session's model

Co-authored-by: Infinity 🤖 <infinity@hydro.run>