### PR TITLE
fix(infinity-daemon): persist in-flight tool results when a session is stopped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4753,6 +4753,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/infinity-daemon/Cargo.toml
+++ b/crates/infinity-daemon/Cargo.toml
@@ -33,7 +33,7 @@ chrono-tz = { workspace = true }
 hyper = { version = "1", features = ["client", "http1", "http2", "server"] }
 hyper-util = { version = "0.1", features = ["tokio", "http1"] }
 http-body-util = "0.1"
-tokio-util = { version = "0.7", features = ["codec"] }
+tokio-util = { version = "0.7", features = ["codec", "rt"] }
 bytes = "1"
 dirs = "6"
 tokio-tungstenite = "0.26"

--- a/crates/infinity-daemon/src/session/agent_loop.rs
+++ b/crates/infinity-daemon/src/session/agent_loop.rs
@@ -14,6 +14,7 @@ use crate::session::ActiveThreads;
 struct WorkerChannels {
     input_tx: mpsc::UnboundedSender<(infinity_agent_core::message::InputMessage, String)>,
     subscribe_tx: mpsc::UnboundedSender<SubscribeRequest>,
+    handle: tokio::task::JoinHandle<()>,
 }
 
 #[expect(
@@ -34,10 +35,20 @@ pub async fn agent_loop(
     subscriber_map: SubscriberMap,
     active_threads: ActiveThreads,
     idle_tx: mpsc::UnboundedSender<()>,
+    shutdown: tokio_util::sync::CancellationToken,
 ) {
     let mut workers: HashMap<String, WorkerChannels> = HashMap::new();
 
-    while let Some(msg) = rx.recv().await {
+    loop {
+        let msg = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => {
+                tracing::info!("Agent loop for session {} received shutdown signal", session_id);
+                None
+            }
+            msg = rx.recv() => msg,
+        };
+        let Some(msg) = msg else { break };
         let thread_id = match &msg {
             AgentMessage::Input(input, _) => input.group_id.clone(),
             AgentMessage::Subscribe { thread_id, .. } => thread_id.clone(),
@@ -80,7 +91,7 @@ pub async fn agent_loop(
             .or_insert_with(|| Arc::new(std::sync::Mutex::new(parent_subs)))
             .clone();
 
-        tokio::task::spawn_local(rap_protocol::log_panic(
+        let handle = tokio::task::spawn_local(rap_protocol::log_panic(
             "thread_worker",
             thread_worker(
                 thread_id.clone(),
@@ -114,8 +125,27 @@ pub async fn agent_loop(
             WorkerChannels {
                 input_tx,
                 subscribe_tx,
+                handle,
             },
         );
+    }
+
+    // Wind down: dropping each worker's channels signals it to interrupt any
+    // in-flight completion (which flushes pending history items — e.g. tool
+    // results — to the store) and exit. Wait for every worker to finish so
+    // the session is not torn down underneath them.
+    let handles: Vec<(String, tokio::task::JoinHandle<()>)> = workers
+        .drain()
+        .map(|(thread_id, w)| (thread_id, w.handle))
+        .collect();
+    for (thread_id, handle) in handles {
+        if let Err(e) = handle.await {
+            if e.is_panic() {
+                tracing::error!("thread worker {thread_id} panicked during shutdown: {e}");
+            } else {
+                tracing::warn!("thread worker {thread_id} cancelled during shutdown: {e}");
+            }
+        }
     }
 }
 
@@ -193,6 +223,7 @@ mod tests {
         mpsc::UnboundedSender<AgentMessage>,
         mpsc::UnboundedReceiver<()>,
         ActiveThreads,
+        tokio_util::sync::CancellationToken,
     ) {
         let (agent_tx, agent_rx) = mpsc::unbounded_channel();
         let (idle_tx, idle_rx) = mpsc::unbounded_channel();
@@ -211,6 +242,7 @@ mod tests {
         let sender = InMemoryMessageSender::new(input_tx);
         let subscriber_map: SubscriberMap = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let active_threads = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let shutdown = tokio_util::sync::CancellationToken::new();
 
         tokio::task::spawn_local(agent_loop(
             session_id.into(),
@@ -226,9 +258,10 @@ mod tests {
             subscriber_map,
             active_threads.clone(),
             idle_tx,
+            shutdown.clone(),
         ));
 
-        (agent_tx, idle_rx, active_threads)
+        (agent_tx, idle_rx, active_threads, shutdown)
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -246,7 +279,8 @@ mod tests {
                     .await
                     .expect("spawn child thread");
 
-                let (tx, mut idle_rx, _) = spawn_test_agent_loop("root", conv, state, model).await;
+                let (tx, mut idle_rx, _, _shutdown) =
+                    spawn_test_agent_loop("root", conv, state, model).await;
 
                 tx.send(user_text_input("root", "hello root"))
                     .expect("send root user input");
@@ -298,7 +332,8 @@ mod tests {
                     .await
                     .expect("ensure root thread");
 
-                let (tx, mut idle_rx, _) = spawn_test_agent_loop("t1", conv, state, model).await;
+                let (tx, mut idle_rx, _, _shutdown) =
+                    spawn_test_agent_loop("t1", conv, state, model).await;
 
                 tx.send(user_text_input("t1", "first"))
                     .expect("send first user input");
@@ -328,6 +363,131 @@ mod tests {
             .await;
     }
 
+    /// Regression test: a tool result that arrived and is being processed by
+    /// the model (completion in flight) must be persisted to the conversation
+    /// store when the session is shut down. Shutdown interrupts the in-flight
+    /// completion (stripping trailing reasoning) and waits for every thread
+    /// worker to flush pending history items before the agent loop returns.
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_persists_in_flight_tool_result() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (conv, state, _dir) = tmp_stores();
+                let (model, mut ctrl) = mock_model();
+                conv.ensure_root_thread("t1")
+                    .await
+                    .expect("ensure root thread");
+
+                use async_trait::async_trait;
+                struct AsyncTool;
+                #[async_trait]
+                impl Tool<InMemoryMessageSender> for AsyncTool {
+                    fn name(&self) -> &str {
+                        "async_tool"
+                    }
+                    fn description(&self) -> &str {
+                        "a"
+                    }
+                    fn parameters(&self) -> serde_json::Value {
+                        serde_json::json!({"type":"object","properties":{}})
+                    }
+                    async fn execute(
+                        &self,
+                        _: serde_json::Value,
+                        _: String,
+                        _: Option<String>,
+                        _: &infinity_agent_core::tools::ToolContext<InMemoryMessageSender>,
+                    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+                        Ok(())
+                    }
+                }
+
+                let (tx, mut idle_rx, active_threads, shutdown) = spawn_test_agent_loop_with_tools(
+                    "t1",
+                    conv.clone(),
+                    state,
+                    model,
+                    vec![Box::new(AsyncTool)],
+                    0,
+                )
+                .await;
+
+                // 1. User input → model issues an async tool call.
+                tx.send(user_text_input("t1", "do something"))
+                    .expect("send user input");
+                let _req = ctrl.next_request().await;
+                ctrl.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
+                ctrl.finish();
+
+                // 2. The tool result arrives → the worker starts a new
+                //    completion. Waiting for the model request guarantees the
+                //    completion is in flight and the tool result is sitting in
+                //    the history manager's pending (unsynced) items.
+                tx.send(AgentMessage::Input(
+                    Box::new(InputMessage {
+                        content: InputMessageContent::User(UserContent::ToolResult(
+                            rig::message::ToolResult {
+                                id: "tc-1".into(),
+                                call_id: None,
+                                content: rig::OneOrMany::one(
+                                    rig::message::ToolResultContent::Text(rig::agent::Text {
+                                        text: "tool execution result".into(),
+                                    }),
+                                ),
+                            },
+                        )),
+                        group_id: "t1".into(),
+                        metadata: None,
+                        synthetic: None,
+                        display_as: None,
+                        subscription: false,
+                    }),
+                    uuid::Uuid::new_v4().to_string(),
+                ))
+                .expect("send tool result");
+                let _req2 = ctrl.next_request().await;
+
+                // 3. Shut down the session while the model is mid-response.
+                shutdown.cancel();
+
+                // 4. The worker interrupts the completion and exits; the
+                //    WorkerGuard pings idle when the last worker is done.
+                tokio::time::timeout(std::time::Duration::from_secs(5), idle_rx.recv())
+                    .await
+                    .expect("workers should wind down after shutdown");
+                assert!(
+                    active_threads
+                        .lock()
+                        .expect("bug: active_threads mutex poisoned")
+                        .is_empty(),
+                    "no thread workers should remain after shutdown"
+                );
+
+                // 5. The tool result must have been synced to the store.
+                let history = conv
+                    .load_history_up_to("t1", None, None)
+                    .await
+                    .expect("load history");
+                let has_tool_result = history.iter().any(|m| {
+                    if let infinity_agent_core::message::InfinityMessage::ToolResult {
+                        result, ..
+                    } = m
+                        && let rig::message::ToolResultContent::Text(t) = result.content.first()
+                    {
+                        result.id == "tc-1" && t.text.contains("tool execution result")
+                    } else {
+                        false
+                    }
+                });
+                assert!(
+                    has_tool_result,
+                    "in-flight tool result should be persisted on shutdown; history: {history:#?}"
+                );
+            })
+            .await;
+    }
+
     async fn spawn_test_agent_loop_with_tools(
         session_id: &str,
         conv: InMemoryConversationStore,
@@ -339,6 +499,7 @@ mod tests {
         mpsc::UnboundedSender<AgentMessage>,
         mpsc::UnboundedReceiver<()>,
         ActiveThreads,
+        tokio_util::sync::CancellationToken,
     ) {
         let (agent_tx, agent_rx) = mpsc::unbounded_channel();
         let (idle_tx, idle_rx) = mpsc::unbounded_channel();
@@ -357,6 +518,7 @@ mod tests {
         let sender = InMemoryMessageSender::new(input_tx);
         let subscriber_map: SubscriberMap = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let active_threads = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let shutdown = tokio_util::sync::CancellationToken::new();
 
         tokio::task::spawn_local(agent_loop(
             session_id.into(),
@@ -372,9 +534,10 @@ mod tests {
             subscriber_map,
             active_threads.clone(),
             idle_tx,
+            shutdown.clone(),
         ));
 
-        (agent_tx, idle_rx, active_threads)
+        (agent_tx, idle_rx, active_threads, shutdown)
     }
 
     /// Reproduces corruption when compaction triggers mid-tool-call:
@@ -430,7 +593,7 @@ mod tests {
                     ];
 
                 // context_window = 100, so 76 input tokens triggers compaction
-                let (tx, _idle_rx, _) =
+                let (tx, _idle_rx, _, _shutdown) =
                     spawn_test_agent_loop_with_tools("t1", conv.clone(), state, model, tools, 100)
                         .await;
 
@@ -633,7 +796,7 @@ mod tests {
                 ];
 
                 // context_window = 100
-                let (tx, _idle_rx, _) =
+                let (tx, _idle_rx, _, _shutdown) =
                     spawn_test_agent_loop_with_tools("t1", conv.clone(), state, model, tools, 100)
                         .await;
 

--- a/crates/infinity-daemon/src/session/mod.rs
+++ b/crates/infinity-daemon/src/session/mod.rs
@@ -704,6 +704,11 @@ fn spawn_agent_loop(
 
     let subscriber_map = Arc::new(std::sync::Mutex::new(HashMap::new()));
 
+    // Internal token used by session_wrapper to tell the agent loop to wind
+    // down its thread workers (interrupting in-flight completions so they
+    // flush pending history) before the session is torn down.
+    let worker_shutdown = tokio_util::sync::CancellationToken::new();
+
     let agent_fut = agent_loop(
         session_id.clone(),
         agent_rx,
@@ -718,6 +723,7 @@ fn spawn_agent_loop(
         subscriber_map.clone(),
         active_threads.clone(),
         idle_tx.clone(),
+        worker_shutdown.clone(),
     );
 
     let handle = tokio::task::spawn_local(session_wrapper(
@@ -729,6 +735,7 @@ fn spawn_agent_loop(
         active_threads,
         idle_rx,
         shutdown_rx,
+        worker_shutdown,
         spawned_servers,
     ));
     (idle_tx, handle, subscriber_map)
@@ -751,6 +758,7 @@ async fn session_wrapper(
     active_threads: ActiveThreads,
     mut idle_rx: mpsc::UnboundedReceiver<()>,
     mut shutdown_rx: oneshot::Receiver<()>,
+    worker_shutdown: tokio_util::sync::CancellationToken,
     mut spawned_servers: Vec<tokio::process::Child>,
 ) {
     // Determine why we exited: idle (no client) vs explicit shutdown.
@@ -758,9 +766,13 @@ async fn session_wrapper(
     tokio::pin!(agent_fut);
     loop {
         tokio::select! {
+            // Biased so that a completed agent_fut is always consumed by its
+            // own arm; the other arms may then safely `.await` it knowing it
+            // has not already returned Ready.
+            biased;
             _ = &mut agent_fut => {
-                // agent_loop returned (rx closed). Wait for workers to drain.
-                while idle_rx.try_recv().is_ok() {}
+                // agent_loop returned (rx closed). It joins all thread
+                // workers before returning, so nothing is left running.
                 idle_exited = {
                     let smap = subscriber_map.lock().expect("bug: mutex poisoned");
                     smap.values().all(|subs| subs.lock().expect("bug: mutex poisoned").iter().all(|tx| tx.is_closed()))
@@ -770,6 +782,11 @@ async fn session_wrapper(
             _ = &mut shutdown_rx => {
                 tracing::info!("Received `shutdown_rx`.");
                 conversation_store.clear_pending_choices(&session_id);
+                // Interrupt live thread workers and wait for them to flush
+                // pending history items (e.g. in-flight tool results) to the
+                // store before tearing the session down.
+                worker_shutdown.cancel();
+                (&mut agent_fut).await;
                 idle_exited = false;
                 break;
             }
@@ -793,6 +810,11 @@ async fn session_wrapper(
                 };
                 if !has_clients {
                     tracing::info!("Exiting agent {} due to idle", session_id);
+                    // Wind down the agent loop too. All workers are already
+                    // idle, so this returns promptly after joining their
+                    // finished tasks.
+                    worker_shutdown.cancel();
+                    (&mut agent_fut).await;
                     idle_exited = true;
                     break;
                 } else {

--- a/crates/infinity-daemon/src/session/thread_worker.rs
+++ b/crates/infinity-daemon/src/session/thread_worker.rs
@@ -255,7 +255,17 @@ pub async fn thread_worker(
                     continue;
                 },
                 first = rx.recv() => {
-                    let Some(first) = first else { return };
+                    let Some(first) = first else {
+                        // Input channel closed — the session is shutting down.
+                        // Interrupt the in-flight completion and wait for it to
+                        // wind down so pending history items (e.g. a tool result
+                        // that was being processed) are synced to the store. The
+                        // cancellation path strips trailing reasoning before the
+                        // sync, so no partial thinking is persisted.
+                        let _ = completion_cancel_tx.take().expect("bug: cancel_tx missing during shutdown").send(());
+                        completion_fut.take().expect("bug: completion_fut missing during shutdown").await;
+                        return;
+                    };
                     let mut batch = vec![first];
                     while let Ok(item) = rx.try_recv() {
                         batch.push(item);


### PR DESCRIPTION
Previously, stopping an agent (quit → "stop agent" → `ShutdownSession`) while
the model was processing a freshly-arrived tool result lost that result:
`session_wrapper` broke out of its select on `shutdown_rx` and **dropped** the
`agent_loop` future. That closed each thread worker's input channel, and the
worker's `rx.recv()` arm responded to the closed channel with a bare `return`,
dropping the in-flight completion future. Since pending history items (the
tool result, plus any partial assistant output) are only synced to the
conversation store at the end of a completion, the store was left ending at
the tool call — on reload the conversation showed the call but no result.

* `thread_worker`: when the input channel closes mid-completion, reuse the
  existing interrupt mechanism — send `completion_cancel_tx` and await the
  completion future. The cancellation path strips trailing reasoning and then
  syncs all pending history items to the store, so nothing is dropped except
  incomplete thinking.
* `agent_loop`: accept a shutdown signal and keep each worker's `JoinHandle`.
  On shutdown (or rx close), drop all worker channels — triggering each
  worker's graceful interrupt path — and join every worker before returning,
  so the session is never torn down underneath them.
* `session_wrapper`: on `shutdown_rx`, signal the agent loop and await
  `agent_fut` to completion (instead of dropping it) before killing RAP
  servers and marking the session shut down. The idle-exit path now winds the
  agent loop down the same way. The select is `biased` toward `agent_fut` so
  a self-completed loop is always consumed by its own arm, making the
  `.await` in the other arms safe. The old "drain idle pings" hack is gone
  since agent_loop now joins workers itself.
* Added regression test `shutdown_persists_in_flight_tool_result` covering
  the exact race: tool result arrives, model request is in flight, shutdown
  fires — the tool result must be in the conversation store afterwards.
  (Verified the test fails against the old code.)

Co-authored-by: Infinity 🤖 <infinity@hydro.run>