### PR TITLE
test(infinity-agent-cli): add snapshot test for model update on session load

### DIFF
--- a/crates/infinity-agent-cli/tests/snapshots/tui_snapshots__session_loaded_updates_model_name.snap
+++ b/crates/infinity-agent-cli/tests/snapshots/tui_snapshots__session_loaded_updates_model_name.snap
@@ -1,0 +1,25 @@
+---
+source: crates/infinity-agent-cli/tests/tui_snapshots.rs
+assertion_line: 211
+expression: h.screen()
+---
+┌────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│Infinity Agent CLI                                                              │
+│Type your messages below. /help for commands. Ctrl+C to exit.                   │
+│                                                                                │
+│                                                                                │
+│✦ Loading session — thread aaa-bbb                                              │
+│                                                                                │
+│────────────────────────────────────────────────────────────────────────────────│
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│Mock Mini (/help for commands)                        aaa-bbb | 31% context used│
+└────────────────────────────────────────────────────────────────────────────────┘
+cursor: row=13 col=1
+title: Other model session

--- a/crates/infinity-agent-cli/tests/tui_snapshots.rs
+++ b/crates/infinity-agent-cli/tests/tui_snapshots.rs
@@ -194,6 +194,24 @@ async fn session_loaded_updates_title_and_status() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn session_loaded_updates_model_name() {
+    let h = TuiHarness::spawn(80, 16).await;
+
+    // Load a session whose thread uses a different model than the default.
+    h.session_tx
+        .send(infinity_agent_cli::terminal::SessionChanged {
+            session_id: "aaa-bbb".to_owned(),
+            title: Some("Other model session".to_owned()),
+            total_tokens_used: 10_000,
+            model_name: "Mock Mini".to_owned(),
+            context_window: 32_000,
+        })
+        .expect("UI task dropped session channel");
+    h.settle().await;
+    insta::assert_snapshot!(h.screen());
+}
+
+#[tokio::test(start_paused = true)]
 async fn spinner_states_animate_over_time() {
     let h = TuiHarness::spawn(80, 16).await;
 


### PR DESCRIPTION
Added `session_loaded_updates_model_name` snapshot test verifying the status
bar shows the loaded session's model ("Mock Mini") and correct context usage
(31%) instead of the startup default.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>
PR: #23