### PR TITLE
fix(sandbox-local): pass `--ignore-working-copy` to jj cleanup commands

### DIFF
--- a/crates/sandbox-core/src/jj.rs
+++ b/crates/sandbox-core/src/jj.rs
@@ -156,10 +156,21 @@ pub async fn jj_detect_external_bookmark_move(dir: &Path, bookmark_name: &str) -
 
 /// Check if a bookmark's commit is empty (no file changes).
 pub async fn jj_bookmark_is_empty(dir: &Path, bookmark: &str) -> bool {
-    run_jj(dir, &["log", "--no-graph", "-r", bookmark, "-T", "empty"])
-        .await
-        .map(|s| s == "true")
-        .unwrap_or(false)
+    run_jj(
+        dir,
+        &[
+            "--ignore-working-copy",
+            "log",
+            "--no-graph",
+            "-r",
+            bookmark,
+            "-T",
+            "empty",
+        ],
+    )
+    .await
+    .map(|s| s == "true")
+    .unwrap_or(false)
 }
 
 /// Read the configured jj user from a repo directory.

--- a/crates/sandbox-local/src/backend.rs
+++ b/crates/sandbox-local/src/backend.rs
@@ -144,7 +144,15 @@ impl LocalBackend {
 /// Check if a jj bookmark's commit is empty (no changes) using a synchronous command.
 fn jj_bookmark_is_empty(dir: &Path, bookmark: &str) -> bool {
     Command::new("jj")
-        .args(["log", "--no-graph", "-r", bookmark, "-T", "empty"])
+        .args([
+            "--ignore-working-copy",
+            "log",
+            "--no-graph",
+            "-r",
+            bookmark,
+            "-T",
+            "empty",
+        ])
         .current_dir(dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -176,12 +184,12 @@ impl Drop for LocalBackend {
                 SandboxMode::Jj { .. } => {
                     if jj_bookmark_is_empty(dir, &branch) {
                         let _ = Command::new("jj")
-                            .args(["abandon", &branch])
+                            .args(["--ignore-working-copy", "abandon", &branch])
                             .current_dir(dir)
                             .status();
                     }
                     let _ = Command::new("jj")
-                        .args(["workspace", "forget"])
+                        .args(["--ignore-working-copy", "workspace", "forget"])
                         .current_dir(dir)
                         .status();
                     let _ = std::fs::remove_dir_all(dir);
@@ -497,7 +505,7 @@ impl SandboxBackend for LocalBackend {
                         .remote_uri,
                 );
                 if orig.join(".git").exists()
-                    && let Err(e) = run_jj(&orig, &["git", "export"]).await
+                    && let Err(e) = run_jj(&orig, &["--ignore-working-copy", "git", "export"]).await
                 {
                     tracing::warn!(error = %e, "jj git export failed");
                 }
@@ -536,9 +544,9 @@ impl SandboxBackend for LocalBackend {
         match &entry.state.mode {
             SandboxMode::Jj { .. } => {
                 if jj::jj_bookmark_is_empty(dir, &branch).await {
-                    let _ = run_jj(dir, &["abandon", &branch]).await;
+                    let _ = run_jj(dir, &["--ignore-working-copy", "abandon", &branch]).await;
                 }
-                let _ = run_jj(dir, &["workspace", "forget"]).await;
+                let _ = run_jj(dir, &["--ignore-working-copy", "workspace", "forget"]).await;
                 if dir.exists() {
                     std::fs::remove_dir_all(dir).map_err(SandboxError::Io)?;
                 }

--- a/crates/sandbox-local/tests/stale_workspace_cleanup.rs
+++ b/crates/sandbox-local/tests/stale_workspace_cleanup.rs
@@ -1,0 +1,126 @@
+//! Reproducer: closing a child sandbox fails to forget its workspace when the
+//! parent has operated since the child's last operation, making the child stale.
+//! Without `--ignore-working-copy`, `workspace forget` errors out and the
+//! workspace lingers in jj.
+
+mod common;
+
+use common::{invoke, jj_init_with_file, start_test_server};
+use rap_client::callback_server::start_callback_channel;
+
+use std::path::Path;
+use std::process::Command;
+
+fn jj_cmd(repo: &Path) -> Command {
+    let mut cmd = Command::new("jj");
+    cmd.arg("-R").arg(repo).current_dir(repo);
+    cmd
+}
+
+#[tokio::test]
+async fn workspace_forget_succeeds_when_child_is_stale() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let tmp = jj_init_with_file("README.md", "hello\n");
+    let repo = tmp.path();
+    let metadata_dir = tempfile::tempdir().expect("create metadata tempdir");
+
+    let server_url = start_test_server(metadata_dir.path()).await;
+    let (callback_url, mut rx) = start_callback_channel()
+        .await
+        .expect("start callback channel");
+
+    let parent_id = "parent-thread";
+    let child_id = "child-thread";
+    let repo_str = repo.to_str().expect("repo path to str");
+
+    // 1. Clone repo for parent
+    let text = invoke(
+        &server_url,
+        &callback_url,
+        parent_id,
+        "clone_repo",
+        serde_json::json!({ "repo": repo_str }),
+        &mut rx,
+        None,
+    )
+    .await;
+    assert!(text.contains("Repository initialized"), "got: {text}");
+
+    // 2. Edit in parent
+    let text = invoke(
+        &server_url,
+        &callback_url,
+        parent_id,
+        "edit_file",
+        serde_json::json!({ "path": "README.md", "old_str": "hello\n", "new_str": "hello world\n" }),
+        &mut rx,
+        None,
+    )
+    .await;
+    assert!(text.contains("Replaced"), "got: {text}");
+
+    // 3. Clone repo for child based on parent
+    let text = invoke(
+        &server_url,
+        &callback_url,
+        child_id,
+        "clone_repo",
+        serde_json::json!({ "repo": repo_str, "base_thread_id": parent_id }),
+        &mut rx,
+        Some(vec![parent_id.to_owned()]),
+    )
+    .await;
+    assert!(text.contains("Repository initialized"), "got: {text}");
+
+    // 4. Edit in child
+    let text = invoke(
+        &server_url,
+        &callback_url,
+        child_id,
+        "create_file",
+        serde_json::json!({ "path": "child.txt", "content": "from child\n" }),
+        &mut rx,
+        Some(vec![parent_id.to_owned()]),
+    )
+    .await;
+    assert!(text.contains("Created file"), "got: {text}");
+
+    // 5. Parent does more work — this makes the child sandbox stale.
+    let text = invoke(
+        &server_url,
+        &callback_url,
+        parent_id,
+        "create_file",
+        serde_json::json!({ "path": "after.txt", "content": "more\n" }),
+        &mut rx,
+        None,
+    )
+    .await;
+    assert!(text.contains("Created file"), "got: {text}");
+
+    // 6. Close the child thread — workspace forget must succeed despite stale.
+    let resp = reqwest::Client::new()
+        .post(format!("{server_url}/close_thread"))
+        .json(&serde_json::json!({ "thread_id": child_id }))
+        .send()
+        .await
+        .expect("send close_thread");
+    assert!(resp.status().is_success(), "close_thread failed");
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    // 7. Only default + parent workspaces should remain.
+    let output = jj_cmd(repo)
+        .args(["--ignore-working-copy", "workspace", "list"])
+        .output()
+        .expect("jj workspace list");
+    let list = String::from_utf8_lossy(&output.stdout).to_string();
+
+    let workspace_count = list.lines().count();
+    assert!(
+        workspace_count == 2,
+        "child workspace should have been forgotten, but {} workspaces remain:\n{list}",
+        workspace_count
+    );
+}


### PR DESCRIPTION
When a parent thread continues working after a child is done, the child's
jj workspace becomes stale. On `close_thread`, `jj workspace forget` and
`jj abandon` fail with "working copy is stale", leaving the child's
workspace and commit dangling in jj.

* Add `--ignore-working-copy` to `workspace forget` and `abandon` in
  `cleanup_sandbox_permanently` (async close_thread path)
* Add `--ignore-working-copy` to the same commands in `Drop for LocalBackend`
  (server shutdown sync path)
* Add `--ignore-working-copy` to `jj_bookmark_is_empty` (both async and sync)
* Add `--ignore-working-copy` to `jj git export` from the orig dir in
  `push_sandbox`
* Add regression test reproducing the production scenario

Co-authored-by: Infinity 🤖 <infinity@hydro.run>