### PR TITLE
fix(infinity-agent-cli): add missing `provider_id` field in test

### DIFF
--- a/crates/infinity-agent-cli/tests/snapshots/tui_snapshots__session_loaded_updates_model_name.snap
+++ b/crates/infinity-agent-cli/tests/snapshots/tui_snapshots__session_loaded_updates_model_name.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/infinity-agent-cli/tests/tui_snapshots.rs
-assertion_line: 211
+assertion_line: 213
 expression: h.screen()
 ---
 ┌────────────────────────────────────────────────────────────────────────────────┐
@@ -19,7 +19,7 @@ expression: h.screen()
 │                                                                                │
 │                                                                                │
 │                                                                                │
-│Mock Mini (/help for commands)                        aaa-bbb | 31% context used│
+│aaa-bbb | /help for commands                       mock: Mock Mini · 31% context│
 └────────────────────────────────────────────────────────────────────────────────┘
 cursor: row=13 col=1
 title: Other model session

--- a/crates/infinity-agent-cli/tests/tui_snapshots.rs
+++ b/crates/infinity-agent-cli/tests/tui_snapshots.rs
@@ -206,6 +206,7 @@ async fn session_loaded_updates_model_name() {
             total_tokens_used: 10_000,
             model_name: "Mock Mini".to_owned(),
             context_window: 32_000,
+            provider_id: "mock".to_owned(),
         })
         .expect("UI task dropped session channel");
     h.settle().await;


### PR DESCRIPTION
The `session_loaded_updates_model_name` test in `tui_snapshots.rs` was missing
the `provider_id` field on the `SessionChanged` struct initializer, which was
added in a recent merge. Added the field with value `"mock"` to match the
other test helpers.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>