### PR TITLE
feat(infinity-agent-cli): show provider ID in CLI model picker

### DIFF
--- a/crates/infinity-agent-cli/src/model_picker.rs
+++ b/crates/infinity-agent-cli/src/model_picker.rs
@@ -117,7 +117,10 @@ impl ModelPicker {
                 format!("{}k ctx", model.context_window / 1_000)
             };
 
-            let line = format!(" {:<24} {:>10}", model.display_name, ctx_str);
+            let line = format!(
+                " {:<10} {:<24} {:>10}",
+                model.provider_id, model.display_name, ctx_str
+            );
 
             // Fill the row background
             for x in area.x..area.right() {

--- a/crates/infinity-agent-cli/tests/snapshots/tui_reflow_snapshots__picker_before_resize.snap
+++ b/crates/infinity-agent-cli/tests/snapshots/tui_reflow_snapshots__picker_before_resize.snap
@@ -27,8 +27,8 @@ expression: h.screen_with_scrollback()
 │scroll line 05                                                                  │
 │                                                                                │
 │────────────────────────────────────────────────────────────────────────────────│
-│ Mock Model                 100k ctx                                            │
-│ Mock Mini                   32k ctx                                            │
+│ mock       Mock Model                 100k ctx                                 │
+│ mock       Mock Mini                   32k ctx                                 │
 │                                                                                │
 │↑↓ navigate  enter select  esc cancel              mock: mock-model · 0% context│
 └────────────────────────────────────────────────────────────────────────────────┘

--- a/crates/infinity-agent-cli/tests/snapshots/tui_reflow_snapshots__picker_resized_narrow.snap
+++ b/crates/infinity-agent-cli/tests/snapshots/tui_reflow_snapshots__picker_resized_narrow.snap
@@ -31,8 +31,8 @@ expression: h.screen_with_scrollback()
 │                                                  │
 │                                                  │
 │──────────────────────────────────────────────────│
-│ Mock Model                 100k ctx              │
-│ Mock Mini                   32k ctx              │
+│ mock       Mock Model                 100k ctx   │
+│ mock       Mock Mini                   32k ctx   │
 │                                                  │
 │↑↓ navigate  enter…  mock: mock-model · 0% context│
 └──────────────────────────────────────────────────┘

--- a/crates/infinity-agent-cli/tests/snapshots/tui_viewport_snapshots__model_picker_open.snap
+++ b/crates/infinity-agent-cli/tests/snapshots/tui_viewport_snapshots__model_picker_open.snap
@@ -28,8 +28,8 @@ expression: h.screen_with_scrollback()
 │scroll line 08                                                                  │
 │                                                                                │
 │────────────────────────────────────────────────────────────────────────────────│
-│ Mock Model                 100k ctx                                            │
-│ Mock Mini                   32k ctx                                            │
+│ mock       Mock Model                 100k ctx                                 │
+│ mock       Mock Mini                   32k ctx                                 │
 │                                                                                │
 │↑↓ navigate  enter select  esc cancel              mock: mock-model · 0% context│
 └────────────────────────────────────────────────────────────────────────────────┘

--- a/crates/infinity-agent-cli/tests/snapshots/tui_viewport_snapshots__picker_open_with_prints.snap
+++ b/crates/infinity-agent-cli/tests/snapshots/tui_viewport_snapshots__picker_open_with_prints.snap
@@ -28,8 +28,8 @@ expression: h.screen_with_scrollback()
 │info arriving while picker open 2                                               │
 │                                                                                │
 │────────────────────────────────────────────────────────────────────────────────│
-│ Mock Model                 100k ctx                                            │
-│ Mock Mini                   32k ctx                                            │
+│ mock       Mock Model                 100k ctx                                 │
+│ mock       Mock Mini                   32k ctx                                 │
 │                                                                                │
 │↑↓ navigate  enter select  esc cancel              mock: mock-model · 0% context│
 └────────────────────────────────────────────────────────────────────────────────┘


### PR DESCRIPTION
Added provider_id as a left column (10 chars wide) in the model picker.
Updated snapshots to match.

Row format: ` {provider_id:<10} {display_name:<24} {ctx:>10}`

Co-authored-by: Infinity 🤖 <infinity@hydro.run>