### PR TITLE
fix(infinity-agent-core): compaction inside child thread no longer panics on indexing

### DIFF
--- a/crates/infinity-agent-core/src/event_processor.rs
+++ b/crates/infinity-agent-core/src/event_processor.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     collections::{HashMap, HashSet},
     time::Duration,
 };
@@ -127,6 +127,11 @@ pub struct HistoryManager<C: ConversationStore, S: StateStore> {
     /// summary covers up to. Used to compute the correct relative split
     /// position when a second compaction is applied on top of an existing one.
     compacted_up_to: RefCell<Option<i64>>,
+    /// Number of ancestor messages prepended to the in-memory history.
+    /// These messages are NOT in this thread's own store, so they must be
+    /// subtracted when computing absolute store indices. Reset to 0 after
+    /// compaction replaces ancestors with a summary.
+    ancestor_prefix_len: Cell<usize>,
 }
 
 impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
@@ -147,7 +152,7 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
             .cloned()
             .unwrap_or_else(|| thread_id.clone());
 
-        let (history, compacted_up_to) = conversation_store
+        let (history, compacted_up_to, ancestor_prefix_len) = conversation_store
             .load_history_with_ancestors(&thread_id)
             .await
             .map_err(|e| Box::new(e) as BoxError)?;
@@ -176,6 +181,7 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
             pending_complete_tool_calls: RefCell::new(HashSet::new()),
             interrupted_tool_calls: RefCell::new(Vec::new()),
             compacted_up_to: RefCell::new(compacted_up_to),
+            ancestor_prefix_len: Cell::new(ancestor_prefix_len),
         })
     }
 
@@ -447,7 +453,11 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
                 .compacted_up_to
                 .borrow()
                 .map_or(0, |prev| prev as usize - 1);
-            let up_to = (up_to_order as usize).saturating_sub(offset);
+            // Add ancestor_prefix_len because those messages occupy the beginning
+            // of the in-memory history but are not counted by up_to_order (which
+            // is relative to this thread's own store).
+            let up_to =
+                (up_to_order as usize).saturating_sub(offset) + self.ancestor_prefix_len.get();
             let mut history = self.history.borrow_mut();
             if up_to <= history.len() {
                 let remaining = history.split_off(up_to);
@@ -459,6 +469,8 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
                 }];
                 history.extend(remaining);
                 *self.compacted_up_to.borrow_mut() = Some(up_to_order);
+                // After compaction, ancestors are consumed into the summary.
+                self.ancestor_prefix_len.set(0);
                 return Ok(true);
             }
         }
@@ -473,8 +485,8 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
     }
 
     /// Compute a safe spawn point that excludes trailing unanswered tool calls.
-    /// Returns an absolute store order (accounting for prior compaction offset)
-    /// suitable for use as `spawn_order_override`.
+    /// Returns an absolute store order (accounting for prior compaction offset
+    /// and ancestor prefix) suitable for use as `spawn_order_override`.
     pub fn safe_spawn_point(&self) -> usize {
         // TODO: when we support parallel tool calls, we may need to walk back across
         // tool results if there is an unresolved tool call remaining in the group.
@@ -499,7 +511,9 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
             .compacted_up_to
             .borrow()
             .map_or(0, |prev| prev as usize - 1);
-        safe + offset
+        // Subtract ancestor_prefix_len because those messages are not in this
+        // thread's own store (they come from parent/ancestor threads).
+        safe.saturating_sub(self.ancestor_prefix_len.get()) + offset
     }
 
     /// Record a subscription in the current thread's metadata. The

--- a/crates/infinity-agent-core/src/traits.rs
+++ b/crates/infinity-agent-core/src/traits.rs
@@ -22,12 +22,14 @@ pub trait ConversationStore: Send + Sync + Clone {
     /// Load full history for a thread including ancestor context and compaction.
     /// Walks backwards through ancestors to find the most recent compaction
     /// summary, skipping all earlier ancestors (their content is in the summary).
-    /// Returns `(history, leaf_compacted_up_to)` where the second element is
-    /// the absolute store index the leaf thread's compaction covers, if any.
+    /// Returns `(history, leaf_compacted_up_to, ancestor_prefix_len)` where the
+    /// second element is the absolute store index the leaf thread's compaction
+    /// covers (if any), and the third is how many messages at the front of the
+    /// history come from ancestors (not this thread's own store).
     async fn load_history_with_ancestors(
         &self,
         thread_id: &str,
-    ) -> Result<(Vec<InfinityMessage>, Option<i64>), Self::Error> {
+    ) -> Result<(Vec<InfinityMessage>, Option<i64>, usize), Self::Error> {
         // Check the thread itself first
         if let Ok(Some((summary, compacted_up_to))) = self
             .load_latest_compaction_summary_up_to(thread_id, None)
@@ -43,7 +45,7 @@ pub trait ConversationStore: Send + Sync + Clone {
                 self.load_history_up_to(thread_id, Some(compacted_up_to), None)
                     .await?,
             );
-            return Ok((combined, Some(compacted_up_to)));
+            return Ok((combined, Some(compacted_up_to), 0));
         }
 
         let ancestors = self.get_ancestor_chain(thread_id).await?;
@@ -91,8 +93,9 @@ pub trait ConversationStore: Send + Sync + Clone {
             }
         }
 
+        let ancestor_prefix_len = combined.len();
         combined.extend(self.load_history_up_to(thread_id, None, None).await?);
-        Ok((combined, None))
+        Ok((combined, None, ancestor_prefix_len))
     }
 
     async fn append_messages(

--- a/crates/infinity-daemon/src/memory_store.rs
+++ b/crates/infinity-daemon/src/memory_store.rs
@@ -1334,7 +1334,7 @@ mod tests {
             .await
             .expect("append child messages");
 
-        let (history, _) = store
+        let (history, _, _) = store
             .load_history_with_ancestors(&child)
             .await
             .expect("load history with ancestors");
@@ -1388,7 +1388,7 @@ mod tests {
             .await
             .expect("append grandchild messages");
 
-        let (history, _) = store
+        let (history, _, _) = store
             .load_history_with_ancestors(&grandchild)
             .await
             .expect("load history with ancestors");
@@ -1422,7 +1422,7 @@ mod tests {
             .await
             .expect("save compaction summary");
 
-        let (history, compacted_up_to) = store
+        let (history, compacted_up_to, _) = store
             .load_history_with_ancestors("root")
             .await
             .expect("load history with ancestors");
@@ -1471,7 +1471,7 @@ mod tests {
             .await
             .expect("append child messages");
 
-        let (history, _) = store
+        let (history, _, _) = store
             .load_history_with_ancestors(&child)
             .await
             .expect("load history with ancestors");
@@ -1525,7 +1525,7 @@ mod tests {
             .await
             .expect("append child messages");
 
-        let (history, _) = store
+        let (history, _, _) = store
             .load_history_with_ancestors(&child)
             .await
             .expect("load history with ancestors");
@@ -1581,7 +1581,7 @@ mod tests {
             .await
             .expect("save child compaction summary");
 
-        let (history, compacted_up_to) = store
+        let (history, compacted_up_to, _) = store
             .load_history_with_ancestors(&child)
             .await
             .expect("load history with ancestors");

--- a/crates/infinity-daemon/src/session/agent_loop.rs
+++ b/crates/infinity-daemon/src/session/agent_loop.rs
@@ -1130,4 +1130,276 @@ mod tests {
             })
             .await;
     }
+
+    /// Regression test for issue #31: compaction spawned inside a child thread
+    /// uses safe_spawn_point() which includes ancestor messages in the index,
+    /// causing a panic ("range end index X out of range for slice of length Y")
+    /// when the grandchild tries to load history.
+    #[tokio::test(flavor = "current_thread")]
+    async fn compaction_inside_child_thread_does_not_panic() {
+        use infinity_agent_core::tools::thread::{CloseThreadTool, SpawnThreadTool};
+        use rig::completion::Usage;
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (conv, state, _dir) = tmp_stores();
+                let (model, mut ctrl) = mock_model();
+                conv.ensure_root_thread("root")
+                    .await
+                    .expect("ensure root thread");
+
+                use async_trait::async_trait;
+                struct AsyncTool;
+                #[async_trait]
+                impl Tool<InMemoryMessageSender> for AsyncTool {
+                    fn name(&self) -> &str {
+                        "async_tool"
+                    }
+                    fn description(&self) -> &str {
+                        "a"
+                    }
+                    fn parameters(&self) -> serde_json::Value {
+                        serde_json::json!({"type":"object","properties":{}})
+                    }
+                    async fn execute(
+                        &self,
+                        _: serde_json::Value,
+                        _: String,
+                        _: Option<String>,
+                        _: &infinity_agent_core::tools::ToolContext<InMemoryMessageSender>,
+                    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+                        Ok(())
+                    }
+                }
+
+                let tools: Vec<Box<dyn Tool<InMemoryMessageSender>>> = vec![
+                    Box::new(AsyncTool),
+                    Box::new(SpawnThreadTool {
+                        conversation_store: conv.clone(),
+                    }),
+                    Box::new(CloseThreadTool::<_, rap_client::http::SimpleHttpClient> {
+                        conversation_store: conv.clone(),
+                        rap_notifier: None,
+                    }),
+                ];
+
+                // context_window = 100, so 76 input tokens triggers compaction
+                let (tx, _idle_rx, _, _shutdown) = spawn_test_agent_loop_with_tools(
+                    "root",
+                    conv.clone(),
+                    state,
+                    model,
+                    tools,
+                    100,
+                )
+                .await;
+
+                // ── Build root history ──
+                tx.send(user_text_input("root", "root message one"))
+                    .expect("send");
+                let _req = ctrl.next_request().await;
+                ctrl.send_text("root response one");
+                ctrl.finish();
+
+                tx.send(user_text_input("root", "root message two"))
+                    .expect("send");
+                let _req = ctrl.next_request().await;
+                ctrl.send_text("root response two");
+                ctrl.finish();
+
+                // ── Spawn a child thread from root ──
+                tx.send(user_text_input("root", "spawn a child"))
+                    .expect("send");
+                let _req = ctrl.next_request().await;
+                ctrl.send_tool_call(
+                    "tc-spawn",
+                    "spawn_thread",
+                    serde_json::json!({
+                        "instructions": "do child work",
+                        "child_of": ["root"]
+                    }),
+                );
+                ctrl.finish();
+
+                // Parent gets tool result after spawn — extract child thread ID
+                let parent_followup = ctrl.next_request().await;
+                let child_thread_id = parent_followup
+                    .chat_history
+                    .iter()
+                    .find_map(|m| {
+                        if let rig::message::Message::User { content } = m
+                            && let UserContent::ToolResult(r) = content.first()
+                            && let rig::message::ToolResultContent::Text(t) = r.content.first()
+                            && t.text.contains("successfully spawned")
+                        {
+                            let after = t.text.strip_prefix(
+                                "Child thread is successfully spawned and has ID: ",
+                            )?;
+                            Some(after.split('.').next()?.to_owned())
+                        } else {
+                            None
+                        }
+                    })
+                    .expect("should find child thread ID in spawn result");
+                ctrl.send_text("ok, child spawned");
+                ctrl.finish();
+
+                // ── Child thread gets its first model call ──
+                let _child_req = ctrl.next_request().await;
+                ctrl.send_text("child first response");
+                ctrl.finish();
+
+                // ── Send another round to child ──
+                tx.send(user_text_input(&child_thread_id, "child follow-up"))
+                    .expect("send");
+                let _req = ctrl.next_request().await;
+                // Child responds with a TOOL CALL + high usage → triggers compaction.
+                // The tool call is after safe_spawn_point, so it survives compaction.
+                let high_usage = Some(Usage {
+                    input_tokens: 76,
+                    output_tokens: 10,
+                    total_tokens: 86,
+                    cached_input_tokens: 0,
+                });
+                ctrl.send_tool_call("tc-child", "async_tool", serde_json::json!({}));
+                ctrl.finish_with_usage(high_usage);
+
+                // Send tool result before compaction completes
+                tx.send(AgentMessage::Input(
+                    Box::new(InputMessage {
+                        content: InputMessageContent::User(UserContent::ToolResult(
+                            rig::message::ToolResult {
+                                id: "tc-child".into(),
+                                call_id: None,
+                                content: rig::OneOrMany::one(
+                                    rig::message::ToolResultContent::Text(rig::agent::Text {
+                                        text: "async tool result".into(),
+                                    }),
+                                ),
+                            },
+                        )),
+                        group_id: child_thread_id.clone(),
+                        metadata: None,
+                        synthetic: None,
+                        display_as: None,
+                        subscription: false,
+                    }),
+                    uuid::Uuid::new_v4().to_string(),
+                ))
+                .expect("send tool result");
+
+                // Two model requests arrive: compaction grandchild + child processing
+                // the tool result. Handle in whichever order they come.
+                let req_a = ctrl.next_request().await;
+                let is_compaction_req = |req: &rig::completion::CompletionRequest| -> bool {
+                    req.chat_history.iter().any(|m| {
+                        if let rig::message::Message::User { content } = m
+                            && let UserContent::ToolResult(r) = content.first()
+                            && let rig::message::ToolResultContent::Text(t) = r.content.first()
+                        {
+                            t.text.contains("compaction thread")
+                        } else {
+                            false
+                        }
+                    })
+                };
+
+                let find_grandchild_id =
+                    |req: &rig::completion::CompletionRequest| -> String {
+                        req.chat_history
+                            .iter()
+                            .find_map(|m| {
+                                if let rig::message::Message::User { content } = m
+                                    && let UserContent::ToolResult(r) = content.first()
+                                    && let rig::message::ToolResultContent::Text(t) =
+                                        r.content.first()
+                                    && t.text.contains("close_thread with your thread ID")
+                                {
+                                    let start = t.text.find('(')? + 1;
+                                    let end = t.text.find(')')?;
+                                    Some(t.text[start..end].to_owned())
+                                } else {
+                                    None
+                                }
+                            })
+                            .expect("should find grandchild thread ID")
+                    };
+
+                let handle_compaction =
+                    |ctrl: &mut rig_mock::MockModelController,
+                     req: &rig::completion::CompletionRequest| {
+                        let id = find_grandchild_id(req);
+                        ctrl.send_tool_call(
+                            "tc-close",
+                            "close_thread",
+                            serde_json::json!({
+                                "thread_id": id,
+                                "report_to_parent": "Summary of child work"
+                            }),
+                        );
+                        ctrl.finish();
+                    };
+
+                let compaction_req;
+                if is_compaction_req(&req_a) {
+                    compaction_req = req_a;
+                    handle_compaction(&mut ctrl, &compaction_req);
+                    // Now handle the child's tool result processing
+                    let _req_b = ctrl.next_request().await;
+                    ctrl.send_text("processed tool result");
+                    ctrl.finish();
+                } else {
+                    // Child's tool result came first
+                    ctrl.send_text("processed tool result");
+                    ctrl.finish();
+                    compaction_req = ctrl.next_request().await;
+                    handle_compaction(&mut ctrl, &compaction_req);
+                }
+
+                // Snapshot the history sent to the compaction thread's model call.
+                insta::assert_json_snapshot!(
+                    "issue31_compaction_child_history",
+                    compaction_req.chat_history,
+                    {
+                        "[].content[].id" => "[id]",
+                        "[].content[].content[].text" => insta::dynamic_redaction(|value, _| {
+                            let s = value.as_str().unwrap_or("");
+                            if s.contains("compaction thread") {
+                                insta::internals::Content::String("[compaction_instructions]".into())
+                            } else if s.contains("INSIDE the thread") {
+                                insta::internals::Content::String("[spawn_instructions]".into())
+                            } else {
+                                value
+                            }
+                        })
+                    }
+                );
+
+                // ── After compaction applies, send a message to inspect the history ──
+                tx.send(user_text_input(
+                    &child_thread_id,
+                    "message after compaction",
+                ))
+                .expect("send post-compaction message");
+
+                let post_compaction_req = tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    ctrl.next_request(),
+                )
+                .await
+                .expect("child should respond after compaction");
+
+                // Post-compaction history should have: [summary, tool_call (survived
+                // because it was after safe_spawn_point), tool_result, model response,
+                // new user message]
+                insta::assert_json_snapshot!(
+                    "issue31_post_compaction_history",
+                    post_compaction_req.chat_history,
+                    {
+                        "[].content[].id" => "[id]",
+                    }
+                );
+            })
+            .await;
+    }
 }

--- a/crates/infinity-daemon/src/session/snapshots/infinity_daemon__session__agent_loop__tests__issue31_compaction_child_history.snap
+++ b/crates/infinity-daemon/src/session/snapshots/infinity_daemon__session__agent_loop__tests__issue31_compaction_child_history.snap
@@ -1,0 +1,136 @@
+---
+source: crates/infinity-daemon/src/session/agent_loop.rs
+expression: compaction_req.chat_history
+---
+[
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "root message one"
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "id": null,
+    "content": [
+      {
+        "text": "root response one"
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "root message two"
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "id": null,
+    "content": [
+      {
+        "text": "root response two"
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "spawn a child"
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "id": null,
+    "content": [
+      {
+        "id": "[id]",
+        "call_id": null,
+        "function": {
+          "name": "spawn_thread",
+          "arguments": {
+            "child_of": [
+              "root"
+            ],
+            "instructions": "do child work"
+          }
+        },
+        "signature": null,
+        "additional_params": null
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "toolresult",
+        "id": "[id]",
+        "content": [
+          {
+            "type": "text",
+            "text": "[spawn_instructions]"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "id": null,
+    "content": [
+      {
+        "text": "child first response"
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "child follow-up"
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "id": null,
+    "content": [
+      {
+        "id": "[id]",
+        "call_id": null,
+        "function": {
+          "name": "__harness_begin_compaction__",
+          "arguments": {}
+        },
+        "signature": null,
+        "additional_params": null
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "toolresult",
+        "id": "[id]",
+        "content": [
+          {
+            "type": "text",
+            "text": "[compaction_instructions]"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/crates/infinity-daemon/src/session/snapshots/infinity_daemon__session__agent_loop__tests__issue31_post_compaction_history.snap
+++ b/crates/infinity-daemon/src/session/snapshots/infinity_daemon__session__agent_loop__tests__issue31_post_compaction_history.snap
@@ -1,0 +1,64 @@
+---
+source: crates/infinity-daemon/src/session/agent_loop.rs
+expression: post_compaction_req.chat_history
+---
+[
+  {
+    "role": "assistant",
+    "id": null,
+    "content": [
+      {
+        "text": "[Compacted conversation summary]\nSummary of child work"
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "id": null,
+    "content": [
+      {
+        "id": "[id]",
+        "call_id": null,
+        "function": {
+          "name": "async_tool",
+          "arguments": {}
+        },
+        "signature": null,
+        "additional_params": null
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "toolresult",
+        "id": "[id]",
+        "content": [
+          {
+            "type": "text",
+            "text": "async tool result"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "id": null,
+    "content": [
+      {
+        "text": "processed tool result"
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "message after compaction"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
When compaction triggered inside a child thread, `safe_spawn_point()` returned
an in-memory index that included ancestor messages prepended to the history.
This index was used as `spawn_order_override` for the compaction grandchild,
but the child's actual store only contained its own messages — causing a panic:
"range end index X out of range for slice of length Y".

The fix:
- `load_history_with_ancestors` now returns `ancestor_prefix_len` as a third
  tuple element (how many messages at the front come from ancestor threads).
- `HistoryManager` stores this in a `Cell<usize>` field.
- `safe_spawn_point()` subtracts `ancestor_prefix_len` so the returned index
  is relative to the thread's own store.
- `apply_compaction()` adds `ancestor_prefix_len` to the split position (since
  ancestors occupy the beginning of in-memory history) and resets it to 0 after
  compaction (ancestors are consumed into the summary).

A regression test (`compaction_inside_child_thread_does_not_panic`) reproduces
the exact panic from issue #31 and uses insta snapshots to verify both the
compaction child's inherited history and the post-compaction history.

Fixes #31 

Co-authored-by: Infinity 🤖 <infinity@hydro.run>