### PR TITLE
fix(infinity-agent-cli): render subscription event body in gray instead of orange

### DIFF
--- a/crates/infinity-agent-cli/src/terminal.rs
+++ b/crates/infinity-agent-cli/src/terminal.rs
@@ -574,7 +574,8 @@ where
                             let first = lines.first().copied().unwrap_or("");
                             viewport.print_line_above(Line::from(vec![
                                 Span::raw(pfx),
-                                Span::styled(format!("⚡{}: {}", name, first), Style::default().fg(Color::Indexed(208))),
+                                Span::styled(format!("⚡{}: ", name), Style::default().fg(Color::Indexed(208))),
+                                Span::styled(first.to_owned(), Style::default().fg(Color::DarkGray)),
                             ]))?;
                         } else {
                             // Multi line: print header, then all lines from next line
@@ -586,7 +587,7 @@ where
                                 &mut viewport,
                                 &lines,
                                 2,
-                                Style::default().fg(Color::Indexed(208)),
+                                Style::default().fg(Color::DarkGray),
                             )?;
                         }
 


### PR DESCRIPTION
* Keep the `⚡name:` label orange (`Color::Indexed(208)`) for visual distinction
* Single-line events: split into two spans (orange label + `DarkGray` body)
* Multi-line events: continuation lines use `DarkGray` instead of orange
* Matches the style used for tool call result bodies

Co-authored-by: Infinity 🤖 <infinity@hydro.run>