### PR TITLE
fix(infinity-ui): preserve FileTree selection state and scroll position across diff updates

### DIFF
--- a/infinity-ui/src/components/DiffView.tsx
+++ b/infinity-ui/src/components/DiffView.tsx
@@ -77,6 +77,7 @@ export const DiffView = memo(function DiffView({
   }, [filePaths]);
   const [expandedItems, setExpandedItems] = useState<string[]>();
   const [selectedItems, setSelectedItems] = useState<string[]>([]);
+  const treeOptions = useMemo(() => ({ flattenEmptyDirectories: true }), []);
 
   const diffCacheRef = useRef<
     Map<
@@ -164,7 +165,7 @@ export const DiffView = memo(function DiffView({
         <FileTree
           files={filePaths}
           gitStatus={gitStatus}
-          options={{ flattenEmptyDirectories: true }}
+          options={treeOptions}
           selectedItems={selectedItems}
           expandedItems={expandedItems ?? allDirs}
           onExpandedItemsChange={setExpandedItems}


### PR DESCRIPTION
Memoize the `options` object passed to `<FileTree>` so it maintains a stable
reference. Previously, a new inline object `{ flattenEmptyDirectories: true }`
was created on every render, causing the `@pierre/trees` `useFileTreeInstance`
hook (which has `options` in its `ref` callback dependency array) to destroy
and recreate the entire FileTree instance on each update — resetting both
selection state and scroll position.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>