### PR TITLE
ci: add extra final step to aggregate matrix results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,17 @@ jobs:
 
       - name: Run tests
         run: cargo test --all-targets
+
+  test-all:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Test Suite Result (Full Matrix)
+    needs: [test]
+    steps:
+      - run: |
+          result="${{ needs.test.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi


### PR DESCRIPTION
Otherwise, when intermediate steps are skipped due to no changes, the PR
hangs in a state where it is waiting for expected checks.