### PR TITLE
fix(infinity-daemon): use total_tokens for context usage and compaction trigger

### DIFF
--- a/crates/infinity-agent-cli/src/daemon_client.rs
+++ b/crates/infinity-agent-cli/src/daemon_client.rs
@@ -22,11 +22,15 @@ pub struct DaemonTokenUsage(pub Option<TokenUsage>);
 
 impl GetTokenUsage for DaemonTokenUsage {
     fn token_usage(&self) -> Option<rig::completion::Usage> {
-        self.0.as_ref().map(|u| rig::completion::Usage {
-            input_tokens: u.input_tokens.unwrap_or(0),
-            output_tokens: u.output_tokens.unwrap_or(0),
-            total_tokens: u.input_tokens.unwrap_or(0) + u.output_tokens.unwrap_or(0),
-            cached_input_tokens: 0,
+        self.0.as_ref().map(|u| {
+            let input = u.input_tokens.unwrap_or(0);
+            let output = u.output_tokens.unwrap_or(0);
+            rig::completion::Usage {
+                input_tokens: input,
+                output_tokens: output,
+                total_tokens: u.total_tokens.unwrap_or(input + output),
+                cached_input_tokens: 0,
+            }
         })
     }
 }

--- a/crates/infinity-agent-core/src/batch_processor.rs
+++ b/crates/infinity-agent-core/src/batch_processor.rs
@@ -206,7 +206,7 @@ pub async fn process_batch<'a: 'b, 'b, P, C, S, M, H>(
     tool_context: ToolContext<M>,
     extra_system_prompt: &'a Option<String>,
     rap_notifier: Option<&'a RapNotifier<H>>,
-    input_tokens_out: Option<&'a Cell<u64>>,
+    total_tokens_out: Option<&'a Cell<u64>>,
 ) -> Option<(Pin<Box<dyn Future<Output = ()> + 'b>>, oneshot::Sender<()>)>
 where
     P: ModelProvider + ?Sized,
@@ -317,10 +317,12 @@ where
                     }
                     Ok(event_processor::CompletionEvent::Action(CompletionAction::Done(r))) => {
                         // there may be multiple `Done` if the agent synchronously loops back
-                        if let Some(input_tokens_out) = input_tokens_out
+                        if let Some(total_tokens_out) = total_tokens_out
                             && let Some(usage) = r.token_usage()
                         {
-                            input_tokens_out.set(usage.input_tokens);
+                            // Use total_tokens which includes cached input. When prompt
+                            // caching is active, `input_tokens` alone undercounts usage.
+                            total_tokens_out.set(usage.total_tokens);
                         }
                         resp = Some(r);
                     }

--- a/crates/infinity-daemon/src/session/display.rs
+++ b/crates/infinity-daemon/src/session/display.rs
@@ -37,6 +37,7 @@ pub(crate) fn display_event_to_daemon<R: GetTokenUsage>(
             let token_usage = r.and_then(|r| r.token_usage()).map(|u| TokenUsage {
                 input_tokens: Some(u.input_tokens),
                 output_tokens: Some(u.output_tokens),
+                total_tokens: Some(u.total_tokens),
             });
             DaemonMessage::ResponseDone {
                 thread_id: tid,

--- a/crates/infinity-daemon/src/session/thread_worker.rs
+++ b/crates/infinity-daemon/src/session/thread_worker.rs
@@ -200,7 +200,7 @@ pub async fn thread_worker(
             .map(|t| (t.name().to_owned(), t.as_ref()))
             .collect();
 
-    let input_tokens_cell = std::cell::Cell::new(0u64);
+    let total_tokens_cell = std::cell::Cell::new(0u64);
     let mut compaction_triggered = false;
     let mut pending_non_interrupt_items = vec![];
     let mut completion_fut = None;
@@ -234,13 +234,13 @@ pub async fn thread_worker(
                     #[expect(clippy::let_underscore_future, reason = "dropping completed future")]
                     let _ = completion_fut.take().expect("bug: completion_fut missing after poll");
 
-                    // Background compaction: trigger if input tokens > 75% of context window
-                    let input_tokens = input_tokens_cell.get() as usize;
-                    if !compaction_triggered && context_window > 0 && input_tokens > context_window * 3 / 4 {
+                    // Background compaction: trigger if total tokens > 75% of context window
+                    let total_tokens = total_tokens_cell.get() as usize;
+                    if !compaction_triggered && context_window > 0 && total_tokens > context_window * 3 / 4 {
                         compaction_triggered = true;
                         tracing::info!(
-                            "Auto-compaction for thread {}: {} input tokens > 75% of {} context window",
-                            &active_group_id, input_tokens, context_window
+                            "Auto-compaction for thread {}: {} total tokens > 75% of {} context window",
+                            &active_group_id, total_tokens, context_window
                         );
                         let _ = display_tx.send(DisplayEvent::Info(
                             "✦ Auto-compaction triggered (context > 75%)".to_owned(),
@@ -442,7 +442,7 @@ pub async fn thread_worker(
             tool_context.clone(),
             &extra_system_prompt,
             rap_notifier.as_ref(),
-            Some(&input_tokens_cell),
+            Some(&total_tokens_cell),
         )
         .await;
 

--- a/crates/infinity-protocol/src/lib.rs
+++ b/crates/infinity-protocol/src/lib.rs
@@ -316,6 +316,12 @@ pub struct SubthreadInfo {
 pub struct TokenUsage {
     pub input_tokens: Option<u64>,
     pub output_tokens: Option<u64>,
+    /// Total tokens including cached input. When prompt caching is active,
+    /// `input_tokens` only reflects uncached input, so consumers should prefer
+    /// `total_tokens` (falling back to `input + output` if absent for
+    /// backwards compatibility).
+    #[serde(default)]
+    pub total_tokens: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/infinity-ui/src/types.ts
+++ b/infinity-ui/src/types.ts
@@ -38,6 +38,8 @@ export interface RemoteInfo {
 export interface TokenUsage {
   input_tokens: number | null;
   output_tokens: number | null;
+  /** Total tokens including cached input. Prefer this over input+output. */
+  total_tokens?: number | null;
 }
 
 /* ── Display segments for structured tool result rendering ── */

--- a/infinity-web/src/App.tsx
+++ b/infinity-web/src/App.tsx
@@ -352,8 +352,9 @@ export function App() {
             if (isForCurrentView(p.thread_id)) {
               if (p.token_usage) {
                 const total =
+                  p.token_usage.total_tokens ??
                   (p.token_usage.input_tokens ?? 0) +
-                  (p.token_usage.output_tokens ?? 0);
+                    (p.token_usage.output_tokens ?? 0);
                 setTotalTokens(total);
               }
               finishAssistant();
@@ -752,8 +753,10 @@ export function App() {
 
   const viewKeys = Object.keys(views);
   const hasViews = viewKeys.length > 0;
-  const chatVisible = (chatPinned || chatHover || pendingChoices.length > 0) && !chatAsTab;
-  const chatPanelOffset = hasViews && chatPinned && !chatAsTab ? chatPanelWidth + 16 : 24;
+  const chatVisible =
+    (chatPinned || chatHover || pendingChoices.length > 0) && !chatAsTab;
+  const chatPanelOffset =
+    hasViews && chatPinned && !chatAsTab ? chatPanelWidth + 16 : 24;
 
   // Auto-select first view tab when views first appear
   useEffect(() => {
@@ -823,7 +826,14 @@ export function App() {
     };
     window.addEventListener("mousemove", onMove);
     return () => window.removeEventListener("mousemove", onMove);
-  }, [sidebarPinned, chatPinned, chatAsTab, hasViews, sidebarWidth, chatPanelWidth]);
+  }, [
+    sidebarPinned,
+    chatPinned,
+    chatAsTab,
+    hasViews,
+    sidebarWidth,
+    chatPanelWidth,
+  ]);
 
   return (
     <div
@@ -860,7 +870,16 @@ export function App() {
             aria-label="Move chat back to side panel"
             title="Move chat back to side panel"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <polyline points="9 18 15 12 9 6" />
               <rect x="3" y="3" width="18" height="18" rx="2" fill="none" />
             </svg>
@@ -876,7 +895,8 @@ export function App() {
           </button>
         )}
         <span className={css.infoPill}>
-          {providerName && `${providerName}: `}{modelName}
+          {providerName && `${providerName}: `}
+          {modelName}
           {modelName && " \u00b7 "}
           {Math.round(contextPct)}% context
         </span>
@@ -920,7 +940,9 @@ export function App() {
           <nav className={css.viewNav}>
             {chatAsTab && (
               <button
-                className={activeTab === "__chat" ? css.viewTabActive : css.viewTab}
+                className={
+                  activeTab === "__chat" ? css.viewTabActive : css.viewTab
+                }
                 onClick={() => setActiveTab("__chat")}
               >
                 Chat
@@ -992,7 +1014,16 @@ export function App() {
                 title="Pop chat into tab"
                 data-pinned="true"
               >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
                   <polyline points="15 3 21 3 21 9" />
                   <line x1="10" y1="14" x2="21" y2="3" />
                   <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5" />


### PR DESCRIPTION
With Bedrock prompt caching, `input_tokens` only reflects uncached (new) input
tokens. This caused two bugs:

1. **Web UI context percentage showed ~1%** even at 800k tokens: the
   `TokenUsage` protocol struct lacked `total_tokens`, so the web UI computed
   `input_tokens + output_tokens` which only captured the small uncached
   portion.

2. **Auto-compaction never triggered**: the compaction check compared
   `input_tokens` (uncached only) against 75% of the context window, so it
   never fired when most input was cached.

Changes:
- Added `total_tokens` field to `infinity_protocol::TokenUsage` (with
  `#[serde(default)]` for backwards compat)
- Populate `total_tokens` in `display_event_to_daemon`
- Web UI uses `total_tokens` (falling back to `input + output`)
- Updated TypeScript `TokenUsage` interface
- Renamed `input_tokens_cell`/`input_tokens_out` → `total_tokens_cell`/
  `total_tokens_out` and store `usage.total_tokens` instead of
  `usage.input_tokens`
- Fixed `DaemonTokenUsage` in CLI to use `total_tokens` when available


Co-authored-by: Infinity 🤖 <infinity@hydro.run>