### PR TITLE
fix: increase LengthDelimitedCodec max frame size to 256 MiB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,6 +2304,7 @@ dependencies = [
  "rap-protocol",
  "serde",
  "serde_json",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/infinity-agent-cli/src/acp_server.rs
+++ b/crates/infinity-agent-cli/src/acp_server.rs
@@ -22,7 +22,7 @@ use agent_client_protocol::{
 };
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
-use infinity_protocol::{ClientMessage, DaemonMessage, SessionInfo};
+use infinity_protocol::{ClientMessage, DaemonMessage, SessionInfo, length_delimited_codec};
 use std::sync::Mutex;
 use tokio::net::UnixStream;
 use tokio::sync::mpsc;
@@ -85,7 +85,7 @@ struct SessionCmd {
 pub async fn run() -> Result<(), BoxError> {
     // Control connection — gets Welcome and SessionsUpdated.
     let control_stream = crate::daemon_client::ensure_daemon_running().await?;
-    let mut control_framed = Framed::new(control_stream, LengthDelimitedCodec::new());
+    let mut control_framed = Framed::new(control_stream, length_delimited_codec());
 
     let welcome = recv(&mut control_framed).await?;
     let sessions = match welcome {
@@ -440,7 +440,7 @@ async fn run_session_connection(
     mut cmd_rx: mpsc::UnboundedReceiver<SessionCmd>,
 ) -> Result<(), BoxError> {
     let stream = crate::daemon_client::ensure_daemon_running().await?;
-    let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+    let mut framed = Framed::new(stream, length_delimited_codec());
 
     // Skip Welcome on this connection.
     let _ = recv(&mut framed).await?;

--- a/crates/infinity-agent-cli/src/daemon_client.rs
+++ b/crates/infinity-agent-cli/src/daemon_client.rs
@@ -6,7 +6,9 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
 use infinity_agent_core::batch_processor::DisplayEvent;
-use infinity_protocol::{ClientMessage, DaemonMessage, ModelRef, SessionInfo, TokenUsage};
+use infinity_protocol::{
+    ClientMessage, DaemonMessage, ModelRef, SessionInfo, TokenUsage, length_delimited_codec,
+};
 use rig::completion::GetTokenUsage;
 use tokio::io::AsyncBufReadExt;
 use tokio::net::UnixStream;
@@ -252,7 +254,7 @@ async fn launch_daemon() -> Result<(), BoxError> {
 /// Send a task to the daemon and exit without opening the TUI.
 pub async fn run_headless(message: String) -> Result<(), BoxError> {
     let stream = ensure_daemon_running().await?;
-    let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+    let mut framed = Framed::new(stream, length_delimited_codec());
 
     /// Receive the next DaemonMessage from the framed socket.
     async fn recv(
@@ -325,7 +327,7 @@ pub async fn run_with_daemon(
     session: Option<String>,
 ) -> Result<(), BoxError> {
     let stream = ensure_daemon_running().await?;
-    let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+    let mut framed = Framed::new(stream, length_delimited_codec());
 
     let (to_daemon_tx, mut to_daemon_rx) = mpsc::unbounded_channel::<ClientMessage>();
     let (from_daemon_tx, from_daemon_rx) = mpsc::unbounded_channel::<DaemonMessage>();

--- a/crates/infinity-daemon/src/client_handler.rs
+++ b/crates/infinity-daemon/src/client_handler.rs
@@ -5,11 +5,11 @@ use futures_util::{SinkExt, StreamExt};
 use infinity_agent_core::message::{
     InputMessage, InputMessageContent, SyntheticKind, TaggedSyntheticKind,
 };
-use infinity_protocol::{ClientMessage, DaemonMessage};
+use infinity_protocol::{ClientMessage, DaemonMessage, length_delimited_codec};
 use rig::message::UserContent;
 use tokio::net::UnixStream;
 use tokio::sync::{Mutex, mpsc};
-use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use tokio_util::codec::Framed;
 
 use crate::session::SessionManager;
 
@@ -231,7 +231,7 @@ fn strip_client_message(msg: ClientMessage, remote_name: &str) -> ClientMessage 
 
 /// Handle a client over a unix socket (serialized framing).
 pub async fn handle_client(stream: UnixStream, session_manager: Arc<Mutex<SessionManager>>) {
-    let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+    let mut framed = Framed::new(stream, length_delimited_codec());
     let (client_msg_tx, client_msg_rx) = mpsc::unbounded_channel();
     let (daemon_msg_tx, mut daemon_msg_rx) = mpsc::unbounded_channel();
 

--- a/crates/infinity-daemon/src/remote.rs
+++ b/crates/infinity-daemon/src/remote.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
-use infinity_protocol::{ClientMessage, DaemonMessage, SessionInfo};
+use infinity_protocol::{ClientMessage, DaemonMessage, SessionInfo, length_delimited_codec};
 use serde::Deserialize;
 use tokio::net::UnixStream;
 use tokio::process::Child;
@@ -146,7 +146,7 @@ impl RemoteDaemons {
         let stream = UnixStream::connect(&local_sock)
             .await
             .map_err(|e| format!("connect to tunnel failed: {e}"))?;
-        let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+        let mut framed = Framed::new(stream, length_delimited_codec());
 
         // Read and discard Welcome
         let first = framed
@@ -430,7 +430,7 @@ async fn open_remote_connection(
         local_sock,
     };
 
-    Ok((Framed::new(stream, LengthDelimitedCodec::new()), tunnel))
+    Ok((Framed::new(stream, length_delimited_codec()), tunnel))
 }
 
 /// Long-running control worker for a single remote daemon.

--- a/crates/infinity-protocol/Cargo.toml
+++ b/crates/infinity-protocol/Cargo.toml
@@ -9,6 +9,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 dirs = "6"
 rap-protocol = { path = "../rap-protocol" }
+tokio-util = { version = "0.7", features = ["codec"] }
 
 [lints]
 workspace = true

--- a/crates/infinity-protocol/src/lib.rs
+++ b/crates/infinity-protocol/src/lib.rs
@@ -1,6 +1,24 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tokio_util::codec::LengthDelimitedCodec;
+
+/// Maximum frame size for daemon ↔ client communication (256 MiB).
+///
+/// The default `LengthDelimitedCodec` limit is 8 MiB, which is too small for
+/// messages that carry large tool outputs, file contents, or replayed
+/// conversation history. We use a generous 256 MiB limit to avoid "frame size
+/// too big" errors in practice.
+const MAX_FRAME_LENGTH: usize = 256 * 1024 * 1024;
+
+/// Create a [`LengthDelimitedCodec`] configured with the project-wide maximum
+/// frame size. Use this instead of `LengthDelimitedCodec::new()` to ensure
+/// both client and daemon agree on the limit.
+pub fn length_delimited_codec() -> LengthDelimitedCodec {
+    LengthDelimitedCodec::builder()
+        .max_frame_length(MAX_FRAME_LENGTH)
+        .new_codec()
+}
 
 /// Returns the path to the daemon unix socket: `~/.infinity/daemon.sock`.
 pub fn socket_path() -> PathBuf {


### PR DESCRIPTION
The "Failed to send daemon message to client: frame size too big" error
occurs because `LengthDelimitedCodec::new()` defaults to an 8 MiB max
frame length. When a DaemonMessage exceeds this (e.g. replaying a long
conversation, large tool outputs, or file contents), the codec rejects
it.

Changes:
* Added `tokio-util` dependency to `infinity-protocol` crate
* Added `length_delimited_codec()` helper in `infinity-protocol` that
  builds a codec with a 256 MiB limit
* Replaced all `LengthDelimitedCodec::new()` calls in `infinity-daemon`
  and `infinity-agent-cli` with the shared helper, ensuring both sides
  agree on the limit

Co-authored-by: Infinity 🤖 <infinity@hydro.run>