### PR TITLE
fix(infinity-agent-cli): count deferred soft wraps in the inline viewport's output tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,6 +2366,7 @@ name = "infinity-provider-bedrock"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-config",
  "infinity-agent-core",
  "rig-bedrock",
  "rig-core",

--- a/crates/infinity-agent-cli/src/inline_viewport.rs
+++ b/crates/infinity-agent-cli/src/inline_viewport.rs
@@ -232,8 +232,18 @@ impl OutputTracker {
                 .expect("bug: print_above wrote invalid UTF-8");
             for ch in text.chars() {
                 let w = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0) as u32;
-                let col = this.line_len % this.width as u32;
-                if col + w > this.width as u32 {
+                if w == 0 {
+                    continue;
+                }
+                let width = this.width as u32;
+                let col = this.line_len % width;
+                // The char starts on the next row when it doesn't fit on
+                // the current one (wide char at the last column), or when
+                // the previous char exactly filled the row — the terminal
+                // defers that wrap until the next printable char, so a
+                // full row (`col == 0` with a non-empty line) advances on
+                // the char after it.
+                if (col == 0 && this.line_len > 0) || col + w > width {
                     // Auto-wrap: the char starts on the next row.
                     this.line_advances += 1;
                 }

--- a/crates/infinity-agent-cli/tests/common/mod.rs
+++ b/crates/infinity-agent-cli/tests/common/mod.rs
@@ -67,6 +67,10 @@ pub trait Emulator: Send {
     fn resize(&mut self, cols: u16, rows: u16);
     /// Text of a visible screen row, exactly `cols` display columns wide.
     fn row_text(&self, row: u16) -> String;
+    /// Background markers of a visible screen row, exactly `cols` display
+    /// columns wide: `' '` for the default background, `'#'` for any
+    /// explicitly set background color.
+    fn row_bg(&self, row: u16) -> String;
     /// Number of rows currently in scrollback history.
     fn history_len(&self) -> usize;
     /// Text of a scrollback row; index 0 is the oldest row.
@@ -132,6 +136,34 @@ impl Emulator for Vt100Emulator {
                     col += if cell.is_wide() { 2 } else { 1 };
                 }
                 _ => {
+                    out.push(' ');
+                    col += 1;
+                }
+            }
+        }
+        out
+    }
+
+    fn row_bg(&self, row: u16) -> String {
+        let screen = self.parser.screen();
+        let (_, cols) = screen.size();
+        let mut out = String::new();
+        let mut col = 0;
+        while col < cols {
+            match screen.cell(row, col) {
+                Some(cell) => {
+                    let marker = if cell.bgcolor() == vt100::Color::Default {
+                        ' '
+                    } else {
+                        '#'
+                    };
+                    let width = if cell.is_wide() { 2 } else { 1 };
+                    for _ in 0..width {
+                        out.push(marker);
+                    }
+                    col += width;
+                }
+                None => {
                     out.push(' ');
                     col += 1;
                 }
@@ -238,6 +270,22 @@ impl Emulator for AlacrittyEmulator {
 
     fn row_text(&self, row: u16) -> String {
         self.line_text(Line(row as i32))
+    }
+
+    fn row_bg(&self, row: u16) -> String {
+        use alacritty_terminal::vte::ansi::{Color as AnsiColor, NamedColor};
+        let grid = self.term.grid();
+        let cols = grid.columns();
+        let line = &grid[Line(row as i32)];
+        (0..cols)
+            .map(|col| {
+                if line[Column(col)].bg == AnsiColor::Named(NamedColor::Background) {
+                    ' '
+                } else {
+                    '#'
+                }
+            })
+            .collect()
     }
 
     fn history_len(&self) -> usize {
@@ -560,6 +608,18 @@ impl TuiHarness {
         let emu = lock_emu(&self.emu);
         render_screen(&**emu, true)
     }
+
+    /// Like [`TuiHarness::screen`], but followed by a second frame showing
+    /// per-cell background markers (`#` where a cell has an explicitly set
+    /// background color). Catches styling corruption that is invisible in
+    /// the character grid, like a widget background leaking into blank rows.
+    pub fn screen_with_bg(&self) -> String {
+        let emu = lock_emu(&self.emu);
+        let mut out = render_screen(&**emu, false);
+        out.push_str("bg:\n");
+        out.push_str(&render_bg_frame(&**emu));
+        out
+    }
 }
 
 pub fn render_screen(emu: &dyn Emulator, with_scrollback: bool) -> String {
@@ -596,6 +656,25 @@ pub fn render_screen(emu: &dyn Emulator, with_scrollback: bool) -> String {
     if !title.is_empty() {
         out.push_str(&format!("title: {title}\n"));
     }
+    out
+}
+
+/// Render a frame of per-cell background markers for the visible screen:
+/// `#` where a cell has a non-default background color, ` ` otherwise.
+pub fn render_bg_frame(emu: &dyn Emulator) -> String {
+    let (cols, rows) = emu.size();
+    let mut out = String::new();
+    out.push('┌');
+    out.push_str(&"─".repeat(cols as usize));
+    out.push_str("┐\n");
+    for row in 0..rows {
+        out.push('│');
+        out.push_str(&emu.row_bg(row));
+        out.push_str("│\n");
+    }
+    out.push('└');
+    out.push_str(&"─".repeat(cols as usize));
+    out.push_str("┘\n");
     out
 }
 

--- a/crates/infinity-agent-cli/tests/snapshots/tui_submit_wrap_snapshots__after_child_row.snap
+++ b/crates/infinity-agent-cli/tests/snapshots/tui_submit_wrap_snapshots__after_child_row.snap
@@ -1,0 +1,50 @@
+---
+source: crates/infinity-agent-cli/tests/tui_submit_wrap_snapshots.rs
+expression: h.screen_with_bg()
+---
+┌────────────────────────────────────────────────────────────────────────────────┐
+│history line 13                                                                 │
+│history line 14                                                                 │
+│history line 15                                                                 │
+│history line 16                                                                 │
+│history line 17                                                                 │
+│history line 18                                                                 │
+│history line 19                                                                 │
+│history line 20                                                                 │
+│> warm up the session                                                           │
+│> please refactor the parser module to support incremental reparsing and then ad│
+│d regression tests covering the new behavior end to end, including the error rec│
+│overy paths and the checkpoint serialization logic                              │
+│                                                                                │
+│▄▄▄▄▄▄▄▄▄▄                                                                      │
+│child-a1 child working                                                          │
+│────────────────────────────────────────────────────────────────────────────────│
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│/help for commands                                 mock: mock-model · 0% context│
+└────────────────────────────────────────────────────────────────────────────────┘
+cursor: row=17 col=1
+bg:
+┌────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│################################################################################│
+│################################################################################│
+│################################################################################│
+│                                                                                │
+└────────────────────────────────────────────────────────────────────────────────┘

--- a/crates/infinity-agent-cli/tests/tui_submit_wrap_snapshots.rs
+++ b/crates/infinity-agent-cli/tests/tui_submit_wrap_snapshots.rs
@@ -1,0 +1,102 @@
+//! Regression test for viewport corruption when a long (wrapping) input
+//! was submitted while the agent was actively thinking: the input box was
+//! drawn one row too low, its background leaked into the row below, and
+//! the status bar landed on the terminal's bottom row on top of the box
+//! background.
+//!
+//! Mechanism of the (fixed) bug:
+//!
+//! 1. Submitting a 3+-row input shrinks the viewport, opening a gap
+//!    between the anchor and the bottom-pinned viewport.
+//! 2. The `> `-prefixed echo wraps in scrollback. `OutputTracker` counted
+//!    a wrap only when `col + w > width` with `col = line_len % width`,
+//!    which is never true for single-width chars — soft wraps went
+//!    uncounted (the terminal defers the wrap of an exactly-full row to
+//!    the next printable char, which then starts at `col == 0`), so the
+//!    *real* anchor ended up below the *tracked* one.
+//! 3. The divergence stayed latent while `ideal_viewport_y > viewport_y`:
+//!    `draw()` takes the pin branch, which positions with an absolute
+//!    `MoveTo`. (This is also why spinner-row toggles never triggered the
+//!    bug — the pin branch doesn't update `viewport_y`.)
+//! 4. The first draw whose viewport *growth* made
+//!    `ideal_viewport_y <= viewport_y` positioned relatively from the
+//!    real (lower) anchor — painting the whole frame one row too low. Any
+//!    growth qualified: input wrapping, autocomplete rows, or (as used
+//!    here, requiring no typing at all) a child-thread row.
+//!
+//! Snapshots include a background-marker frame (see
+//! `TuiHarness::screen_with_bg`) since the corruption was partly
+//! invisible in the character grid alone.
+
+mod common;
+
+use common::TuiHarness;
+use infinity_agent_core::batch_processor::DisplayEvent;
+use ratatui::crossterm::event::KeyCode;
+use rig_mock::MockStreamingResponse;
+
+type Evt = DisplayEvent<MockStreamingResponse>;
+
+/// Long enough to wrap to three rows in the input box (78 inner columns at
+/// width 80) and to three rows in the `> `-prefixed scrollback echo.
+const LONG_INPUT: &str = "please refactor the parser module to support incremental \
+     reparsing and then add regression tests covering the new behavior end to end, \
+     including the error recovery paths and the checkpoint serialization logic";
+
+/// Agent mid-thinking on a full screen; type a wrapping input, submit it
+/// (interrupting the thinking), receive the wrapped echo, then a
+/// child-thread event adds a thread row — a one-row viewport growth with
+/// no typing. Before the fix, the final frame was corrupted: box one row
+/// too low, background under the status row, cursor desynced.
+///
+/// (The bug reproduced identically on the reflowing/alacritty backend;
+/// the vt100 one suffices since no resizes are involved.)
+#[tokio::test(start_paused = true)]
+async fn submit_wrapping_input_during_thinking() {
+    let mut h = TuiHarness::spawn(80, 20).await;
+    let h = &mut h;
+    // Fill the screen with prior conversation so the viewport sits at the
+    // bottom with no slack, like a real session in progress.
+    for i in 1..=20 {
+        h.display(Evt::Info(format!("history line {i:02}")));
+    }
+    h.display(Evt::UserInput("warm up the session".to_owned()));
+    h.display(Evt::StartOutput);
+    h.display(Evt::ThinkingStart);
+    h.display(Evt::ThinkingChunk {
+        chunk: "pondering the request".to_owned(),
+    });
+    h.settle().await;
+
+    // Type the long message (wraps to 3 rows in the box) and submit it,
+    // interrupting the active thinking.
+    h.type_str(LONG_INPUT);
+    h.settle().await;
+    h.key(KeyCode::Enter);
+    h.settle().await;
+    let sent = h
+        .input_rx
+        .try_recv()
+        .expect("input should be submitted on Enter");
+    assert_eq!(sent, LONG_INPUT);
+
+    // The daemon echoes the submitted input (the `> ` line wraps in
+    // scrollback) and a new turn starts.
+    h.display(Evt::UserInput(LONG_INPUT.to_owned()));
+    h.display(Evt::StartOutput);
+    h.settle().await;
+
+    // A child thread reports activity: one more viewport row — the growth
+    // that used to turn the latent anchor mistracking into visible
+    // corruption. The box must sit directly under the border with a clean
+    // status row below it.
+    h.display_for_thread("child-a1", Evt::StartOutput);
+    h.display_for_thread(
+        "child-a1",
+        Evt::ThinkingChunk {
+            chunk: "child working".to_owned(),
+        },
+    );
+    h.settle().await;
+    insta::assert_snapshot!("after_child_row", h.screen_with_bg());
+}


### PR DESCRIPTION
Fixes TUI corruption where, after submitting a long (wrapping) input while
the agent was actively thinking, the input box was drawn one row too low —
its background leaked into the row below and the status bar was painted on
the terminal's bottom row on top of the box background.

## Root cause

`OutputTracker::track` counted an auto-wrap only when `col + w > width`
with `col = line_len % width` — never true for single-width chars, so soft
wraps of ordinary text went uncounted and the tracked anchor fell behind
the real one after any wrapped `print_above` (e.g. the `> ` echo of a
submitted input). Terminals defer the wrap of an exactly-full row until
the next printable char; that char starts at `col == 0` of a non-empty
logical line, which the tracker now counts as a row advance. The per-char
loop guarantees one advance per crossed multiple of `width` (a char is at
most 2 columns wide, so it can never skip a boundary).

The divergence stayed latent while `ideal_viewport_y > viewport_y` (the
pin branch positions with an absolute `MoveTo`) and corrupted the frame on
the first draw whose viewport growth made `ideal <= viewport_y` (relative
positioning from the real, lower anchor): input wrapping, autocomplete
rows, or a child-thread row (no typing needed).

## Tests

* `tests/tui_submit_wrap_snapshots.rs` — regression test driving the full
  scenario (full screen, mid-thinking, 3-row wrapped input, Enter, wrapped
  echo, child-thread row growth) and snapshotting the now-correct frame
  including a background-marker grid
* Harness: `Emulator::row_bg` (vt100 + alacritty backends) and
  `TuiHarness::screen_with_bg()` render per-cell background markers so
  background-styling corruption is visible in snapshots