### PR TITLE
fix(infinity-agent-cli): strip ANSI escapes from external text instead of panicking

### DIFF
--- a/crates/infinity-agent-cli/src/inline_viewport.rs
+++ b/crates/infinity-agent-cli/src/inline_viewport.rs
@@ -193,9 +193,12 @@ fn write_spans<'a>(
 ///
 /// Understands CR/LF/tab stops, skips SGR styling sequences, measures
 /// printable text by display width, and accounts for auto-wrap at the
-/// terminal width. Anything else printed through
-/// [`InlineViewport::print_above`] would silently desynchronize the anchor
+/// terminal width. Only the exact sequences the TUI itself emits through
+/// [`InlineViewport::print_above`] (SGR styling, i.e. `CSI <digits/;> m`)
+/// are recognized; anything else would silently desynchronize the anchor
 /// tracking, so unrecognized control bytes and escape sequences panic.
+/// External text (tool results, model output, ...) must be sanitized with
+/// [`crate::sanitize::strip_ansi`] before it is printed.
 struct OutputTracker {
     width: u16,
     /// Display width of the logical line printed so far (since last CR/LF).
@@ -279,18 +282,18 @@ impl OutputTracker {
                     );
                     self.state = TrackerState::Csi;
                 }
-                TrackerState::Csi => {
-                    if (0x40..=0x7e).contains(&b) {
-                        // Only SGR (styling) is cursor-neutral; anything
-                        // else would desynchronize the anchor tracking.
-                        assert!(
-                            b == b'm',
-                            "bug: print_above wrote untracked CSI sequence ending in {:?}",
-                            b as char
-                        );
-                        self.state = TrackerState::Ground;
-                    }
-                }
+                TrackerState::Csi => match b {
+                    // Parameter bytes of the SGR sequences the TUI emits
+                    // (crossterm's SetColors/SetAttribute): digits and `;`.
+                    b'0'..=b'9' | b';' => {}
+                    // Only SGR (styling) is cursor-neutral; anything else
+                    // would desynchronize the anchor tracking.
+                    b'm' => self.state = TrackerState::Ground,
+                    _ => panic!(
+                        "bug: print_above wrote untracked CSI byte {:?} (only SGR is tracked)",
+                        b as char
+                    ),
+                },
             }
         }
         flush_run(self, run_start.take(), bytes.len());

--- a/crates/infinity-agent-cli/src/install.rs
+++ b/crates/infinity-agent-cli/src/install.rs
@@ -104,7 +104,10 @@ async fn run_cargo_install(
                 match line {
                     Some(text) => {
                         viewport.print_line_above(
-                            Line::from(Span::styled(&text, Style::default().fg(Color::DarkGray))),
+                            Line::from(Span::styled(
+                                crate::sanitize::strip_ansi(&text),
+                                Style::default().fg(Color::DarkGray),
+                            )),
                         )?;
                         draw_spinner(viewport, &spinner_start, &status)?;
                     }

--- a/crates/infinity-agent-cli/src/lib.rs
+++ b/crates/infinity-agent-cli/src/lib.rs
@@ -6,6 +6,7 @@ pub mod install;
 pub mod model_picker;
 pub mod modifier_diff;
 pub mod quit_picker;
+pub mod sanitize;
 pub mod session_picker;
 pub mod term_io;
 pub mod terminal;

--- a/crates/infinity-agent-cli/src/sanitize.rs
+++ b/crates/infinity-agent-cli/src/sanitize.rs
@@ -1,0 +1,167 @@
+//! Sanitizing of externally sourced text before it reaches the terminal.
+
+use std::borrow::Cow;
+
+/// Parser state for [`strip_ansi`], mirroring the escape-sequence states of
+/// a VT parser (<https://vt100.net/emu/dec_ansi_parser>) closely enough to
+/// find the end of each sequence.
+enum State {
+    /// Plain text.
+    Ground,
+    /// Seen ESC, deciding the sequence type from the next byte.
+    Esc,
+    /// Inside `ESC` + intermediate bytes (an nF sequence), waiting for the
+    /// final byte.
+    EscIntermediate,
+    /// Inside a CSI sequence (`ESC [`), waiting for the final byte.
+    Csi,
+    /// Inside an OSC/DCS/SOS/PM/APC string, waiting for BEL or ST (`ESC \`).
+    EscString,
+    /// Seen ESC inside an [`State::EscString`]: either the start of the ST
+    /// terminator or an aborting new escape sequence.
+    EscStringEsc,
+}
+
+/// Strip ANSI escape sequences and non-whitespace control characters from
+/// text that originates outside the TUI (tool results, model output,
+/// subscription events, subprocess output, ...).
+///
+/// The inline viewport tracks the cursor position by parsing everything it
+/// prints (see `OutputTracker` in `inline_viewport`), and deliberately
+/// understands only the small set of sequences the TUI itself emits —
+/// anything else panics as a bug in our code. External text can contain
+/// arbitrary escape sequences (e.g. `cat`ing a file with captured TUI
+/// output), so it must be sanitized before printing.
+///
+/// Removes:
+/// * CSI sequences (`ESC [ … final`), including SGR styling;
+/// * OSC/DCS/SOS/PM/APC string sequences (terminated by BEL or `ESC \`);
+/// * all other escape sequences (`ESC` + intermediates + final byte);
+/// * C0 control characters and DEL, except `\t`, `\n`, and `\r`.
+pub fn strip_ansi(text: &str) -> Cow<'_, str> {
+    let needs_stripping = text
+        .bytes()
+        .any(|b| (b < 0x20 && b != b'\t' && b != b'\n' && b != b'\r') || b == 0x7f);
+    if !needs_stripping {
+        return Cow::Borrowed(text);
+    }
+
+    // Dispatch for a byte following ESC (from ground or aborting a string).
+    let after_esc = |ch: char| match ch {
+        '[' => State::Csi,
+        // OSC / DCS / SOS / PM / APC: consume until BEL or ST.
+        ']' | 'P' | 'X' | '^' | '_' => State::EscString,
+        '\x20'..='\x2f' => State::EscIntermediate,
+        // Any other byte completes a two-byte sequence (e.g. `ESC 7`).
+        _ => State::Ground,
+    };
+
+    let mut out = String::with_capacity(text.len());
+    let mut state = State::Ground;
+    for ch in text.chars() {
+        state = match state {
+            State::Ground => match ch {
+                '\x1b' => State::Esc,
+                '\t' | '\n' | '\r' => {
+                    out.push(ch);
+                    State::Ground
+                }
+                '\x00'..='\x1f' | '\x7f' => State::Ground,
+                _ => {
+                    out.push(ch);
+                    State::Ground
+                }
+            },
+            State::Esc => after_esc(ch),
+            State::EscIntermediate => match ch {
+                '\x20'..='\x2f' => State::EscIntermediate,
+                _ => State::Ground, // final byte
+            },
+            State::Csi => match ch {
+                '\x40'..='\x7e' => State::Ground, // final byte
+                _ => State::Csi,                  // parameter/intermediate bytes
+            },
+            State::EscString => match ch {
+                '\x07' => State::Ground, // BEL terminator
+                '\x1b' => State::EscStringEsc,
+                _ => State::EscString,
+            },
+            State::EscStringEsc => match ch {
+                '\\' => State::Ground, // ST terminator
+                // ESC not starting ST aborts the string and begins a new
+                // escape sequence (matching VT parser behavior).
+                _ => after_esc(ch),
+            },
+        };
+    }
+    Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text_is_borrowed() {
+        assert!(matches!(
+            strip_ansi("hello world\nwith\ttabs\r\n"),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn strips_sgr() {
+        assert_eq!(strip_ansi("a \x1b[31mred\x1b[0m word"), "a red word");
+    }
+
+    #[test]
+    fn strips_cursor_movement() {
+        assert_eq!(strip_ansi("\x1b[2J\x1b[10;20Htext\x1b[1A"), "text");
+    }
+
+    #[test]
+    fn strips_osc_with_bel_terminator() {
+        assert_eq!(strip_ansi("\x1b]0;window title\x07after"), "after");
+    }
+
+    #[test]
+    fn strips_osc_with_st_terminator() {
+        assert_eq!(
+            strip_ansi("\x1b]8;;http://x\x1b\\link\x1b]8;;\x1b\\"),
+            "link"
+        );
+    }
+
+    #[test]
+    fn strips_dcs_string() {
+        assert_eq!(strip_ansi("\x1bPq#0;2;0;0;0\x1b\\after"), "after");
+    }
+
+    #[test]
+    fn esc_aborts_unterminated_osc() {
+        // An ESC that doesn't start ST aborts the string and starts a new
+        // sequence; the text after that sequence is kept.
+        assert_eq!(strip_ansi("\x1b]0;title\x1b[31mred"), "red");
+    }
+
+    #[test]
+    fn strips_two_byte_escapes() {
+        assert_eq!(strip_ansi("\x1b7saved\x1b8restored\x1bc"), "savedrestored");
+    }
+
+    #[test]
+    fn strips_nf_sequences() {
+        // Designate character set: ESC + intermediate + final.
+        assert_eq!(strip_ansi("\x1b(Btext"), "text");
+    }
+
+    #[test]
+    fn strips_control_chars_keeps_whitespace() {
+        assert_eq!(strip_ansi("a\x00b\x08c\td\ne\rf\x7fg"), "abc\td\ne\rfg");
+    }
+
+    #[test]
+    fn keeps_unicode() {
+        assert_eq!(strip_ansi("\x1b[1m✓ naïve 日本語\x1b[m"), "✓ naïve 日本語");
+    }
+}

--- a/crates/infinity-agent-cli/src/terminal.rs
+++ b/crates/infinity-agent-cli/src/terminal.rs
@@ -4,6 +4,7 @@ use crate::{
     inline_viewport::{InlineViewport, ResetScrollRegion},
     model_picker::{ModelPicker, ModelPickerResult, ModelPickerWidget},
     quit_picker::{QuitPicker, QuitPickerResult, QuitPickerWidget},
+    sanitize::strip_ansi,
     session_picker::{SessionPicker, SessionPickerResult, SessionPickerWidget},
     term_io::{EventSource, TermOut},
     text_input::{TextInput, TextInputWidget},
@@ -368,9 +369,9 @@ where
                     }
                     DisplayEvent::ThinkingChunk { chunk } => {
                         if is_root {
-                            thinking_text_buffer.push_str(&chunk);
+                            thinking_text_buffer.push_str(&strip_ansi(&chunk));
                         } else {
-                            thread_buffers.entry(child_tid).or_default().push_str(&chunk);
+                            thread_buffers.entry(child_tid).or_default().push_str(&strip_ansi(&chunk));
                         }
                     }
                     DisplayEvent::StartOutput => {
@@ -403,11 +404,12 @@ where
 
                             spinner_state = Some(SpinnerState::Thinking);
 
+                            let chunk = strip_ansi(&chunk);
                             let chunk = if stream_start {
                                 stream_start = false;
-                                chunk.trim_start().to_owned()
+                                chunk.trim_start()
                             } else {
-                                chunk
+                                &chunk
                             };
 
                             if !chunk.is_empty() {
@@ -422,7 +424,7 @@ where
                                 })?;
                             }
                         } else {
-                            thread_buffers.entry(child_tid).or_default().push_str(&chunk);
+                            thread_buffers.entry(child_tid).or_default().push_str(&strip_ansi(&chunk));
                         }
                     }
                     DisplayEvent::ResponseDone(r) => {
@@ -448,6 +450,7 @@ where
 
                         let display_text = display_as
                             .unwrap_or_else(|| format!("{}({})", name, args));
+                        let display_text = strip_ansi(&display_text);
 
                         if is_root {
                             spinner_state = Some(SpinnerState::WaitingToolCall);
@@ -491,7 +494,8 @@ where
                                     viewport.print_spans_above(Line::from(vec![
                                         Span::styled(" ✓", Style::default().fg(Color::Green)),
                                     ]))?;
-                                    let lines: Vec<&str> = diff.patch.lines().collect();
+                                    let patch = strip_ansi(&diff.patch);
+                                    let lines: Vec<&str> = patch.lines().collect();
                                     print_continuation_lines(
                                         &mut viewport,
                                         &lines,
@@ -501,6 +505,7 @@ where
                                     viewport.print_line_above(Line::from(vec![]))?;
                                 }
                                 Some(rap_protocol::DisplaySegment::Text(t)) => {
+                                    let t = strip_ansi(t);
                                     let lines: Vec<&str> = t.lines().collect();
                                     if lines.len() <= 1 {
                                         let first = lines.first().copied().unwrap_or("");
@@ -540,6 +545,7 @@ where
                         // Print each line separately: ratatui `Line` drops
                         // embedded newlines, and raw LF would not return the
                         // cursor to column 0 in raw mode anyway.
+                        let text = strip_ansi(&text);
                         for line in text.lines() {
                             viewport.print_line_above(Line::from(line.to_owned()))?;
                         }
@@ -553,7 +559,7 @@ where
                         }
                     }
                     DisplayEvent::UserInput(text) => {
-                        let sanitized = text.replace('\n', "\r\n");
+                        let sanitized = strip_ansi(&text).replace('\n', "\r\n");
                         end_stream(&mut viewport, &mut mid_stream)?;
                         viewport.print_line_above(Line::from(vec![
                             Span::styled(format!("> {}", sanitized), Style::default().add_modifier(Modifier::BOLD)),
@@ -566,6 +572,8 @@ where
                     DisplayEvent::SubscriptionEvent { name, text } => {
                         end_stream(&mut viewport, &mut mid_stream)?;
                         let pfx = if !is_root { format!("[{}] ", &child_tid[..child_tid.len().min(8)]) } else { String::new() };
+                        let name = strip_ansi(&name);
+                        let text = strip_ansi(&text);
                         let lines: Vec<&str> = text.lines().collect();
                         if lines.len() <= 1 {
                             // Single line: print inline

--- a/crates/infinity-agent-cli/tests/snapshots/tui_flow_snapshots__ansi_tool_result_stripped.snap
+++ b/crates/infinity-agent-cli/tests/snapshots/tui_flow_snapshots__ansi_tool_result_stripped.snap
@@ -1,0 +1,41 @@
+---
+source: crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
+expression: h.screen_with_scrollback()
+---
+~ 
+~ 
+~ 
+~ 
+~ 
+~ 
+~ 
+~ 
+~ 
+~ 
+~ 
+~ 
+~ 
+~ 
+~ 
+~ 
+┌────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                │
+│                                                                                │
+│Infinity Agent CLI                                                              │
+│Type your messages below. /help for commands. Ctrl+C to exit.                   │
+│                                                                                │
+│> cat the snapshot                                                              │
+│◆ $ cat snap.txt                                                                │
+│✓ first line red                                                                │
+│  second line                                                                   │
+│  third line                                                                    │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│────────────────────────────────────────────────────────────────────────────────│
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│/help for commands                                 mock: mock-model · 0% context│
+└────────────────────────────────────────────────────────────────────────────────┘
+cursor: row=15 col=1

--- a/crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
+++ b/crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
@@ -170,6 +170,36 @@ async fn diff_and_empty_tool_results() {
     insta::assert_snapshot!("empty_tool_result", h.screen_with_scrollback());
 }
 
+/// Tool output containing ANSI escape sequences and stray control bytes
+/// (e.g. `cat`ing a file with captured TUI output) must be stripped before
+/// printing instead of panicking the anchor tracker
+/// (<https://github.com/hydro-project/infinity/issues/69>).
+#[tokio::test(start_paused = true)]
+async fn ansi_in_tool_result_is_stripped() {
+    let h = TuiHarness::spawn_reflowing(80, 18).await;
+
+    h.display(Evt::UserInput("cat the snapshot".to_owned()));
+    h.display(Evt::StartOutput);
+    h.display(Evt::ToolCall {
+        name: "execute_command".to_owned(),
+        args: serde_json::json!({"command": "cat snap.txt"}),
+        display_as: Some("$ cat \x1b[1msnap.txt\x1b[0m".to_owned()),
+    });
+    // OSC (the sequence from the issue), SGR colors, cursor movement, a DCS
+    // string, and a stray control byte — all across multiple lines.
+    h.display(Evt::ToolResult {
+        segments: vec![rap_protocol::DisplaySegment::Text(
+            "\x1b]0;window title\x07first line \x1b[31mred\x1b[0m\n\
+             second\x08 line \x1b[2J\x1b[10;20H\n\
+             \x1bPq#0;2;0;0;0\x1b\\third line"
+                .to_owned(),
+        )],
+    });
+    h.display(Evt::ResponseDone(None));
+    h.settle().await;
+    insta::assert_snapshot!("ansi_tool_result_stripped", h.screen_with_scrollback());
+}
+
 /// Child-thread lifecycle specifics: a `close_thread` tool call removes the
 /// row immediately (it never gets a result), and child subscription events
 /// print with a `[thread-id] ` prefix.


### PR DESCRIPTION
The inline viewport's `OutputTracker` panics on any escape sequence it
doesn't understand, so tool results containing ANSI codes (e.g. `cat`ing a
file with captured TUI output) crashed the CLI with
`bug: print_above wrote untracked escape sequence ESC ']'`.

* Add `sanitize::strip_ansi`, a small VT-parser-shaped state machine that
  removes CSI sequences, OSC/DCS/SOS/PM/APC strings (BEL- or ST-terminated),
  all other escape sequences, and non-whitespace control characters (keeps
  `\t`, `\n`, `\r`), returning `Cow::Borrowed` for the common clean case.
* Proactively sanitize all externally sourced text in `terminal.rs` before
  it reaches the viewport: tool results (text and diff segments), tool call
  display text, model text/thinking chunks, info lines, subscription events,
  and user input; also sanitize cargo output lines in `install.rs` (which
  carry colors when `CARGO_TERM_COLOR=always` is inherited).
* Tighten `OutputTracker` to exactly what the TUI itself emits through
  `print_above`: CSI parameter bytes are now restricted to digits and `;`
  with `m` (SGR) as the only accepted final byte — anything else still
  panics as a bug, per the "internal output only" contract.
* Add unit tests for `strip_ansi` and a `tui_flow_snapshots` regression test
  feeding OSC/SGR/cursor-movement/DCS sequences and stray control bytes
  through a tool result.
  
  Fixes #69 