### PR TITLE
refactor(infinity-agent-core)!: extract provider protocol into `infinity-provider-protocol` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,6 +2237,7 @@ dependencies = [
  "infinity-agent-core",
  "infinity-daemon",
  "infinity-protocol",
+ "infinity-provider-protocol",
  "insta",
  "nix",
  "rap-client",
@@ -2266,17 +2267,16 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "futures-util",
+ "infinity-provider-protocol",
  "insta",
  "rap-client",
  "rap-protocol",
  "rhai",
  "rig-core",
  "rig-mock",
- "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
- "tokio-util",
  "tracing",
  "url",
  "uuid",
@@ -2331,6 +2331,7 @@ dependencies = [
  "include_dir",
  "infinity-agent-core",
  "infinity-protocol",
+ "infinity-provider-protocol",
  "insta",
  "nix",
  "playwright-rs",
@@ -2367,12 +2368,30 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "aws-config",
- "infinity-agent-core",
+ "infinity-provider-protocol",
  "rig-bedrock",
  "rig-core",
  "serde_json",
  "tokio",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "infinity-provider-protocol"
+version = "0.1.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "futures-util",
+ "rig-core",
+ "rig-mock",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/rap-steering-server",
     "crates/rap-github-event-poller",
     "crates/infinity-protocol",
+    "crates/infinity-provider-protocol",
     "crates/infinity-daemon",
     "crates/infinity-provider-bedrock",
     "crates/rig-mock",

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -7910,6 +7910,7 @@ Used by:
   infinity-daemon 0.1.0
   infinity-protocol 0.1.0
   infinity-provider-bedrock 0.1.0
+  infinity-provider-protocol 0.1.0
   rap-client 0.1.0
   rap-github-event-poller 0.1.0
   rap-protocol 0.1.0

--- a/crates/infinity-agent-cli/Cargo.toml
+++ b/crates/infinity-agent-cli/Cargo.toml
@@ -50,6 +50,7 @@ vt100 = { workspace = true }
 alacritty_terminal = { workspace = true }
 rig-mock = { path = "../rig-mock" }
 rap-client = { path = "../rap-client" }
+infinity-provider-protocol = { path = "../infinity-provider-protocol" }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "test-util"] }
 

--- a/crates/infinity-agent-cli/tests/e2e_daemon_tui.rs
+++ b/crates/infinity-agent-cli/tests/e2e_daemon_tui.rs
@@ -21,11 +21,11 @@ use std::time::Duration;
 
 use common::{ScriptedEvents, SharedEmulator, VirtualTerm, Vt100Emulator, render_screen};
 use infinity_agent_cli::daemon_client;
-use infinity_agent_core::model_provider::{ModelEntry, ModelProvider, SingleModelProvider};
 use infinity_daemon::client_handler::handle_client_channels;
 use infinity_daemon::ids::SequentialIdSource;
 use infinity_daemon::session::{SessionManager, SessionManagerConfig};
 use infinity_protocol::{ClientMessage, DaemonMessage};
+use infinity_provider_protocol::{ModelEntry, ModelProvider, SingleModelProvider};
 use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use rig::message::UserContent;
 use rig_mock::{MockModelController, mock_model};

--- a/crates/infinity-agent-core/Cargo.toml
+++ b/crates/infinity-agent-core/Cargo.toml
@@ -7,12 +7,11 @@ license = "Apache-2.0"
 [dependencies]
 rap-client = { path = "../rap-client" }
 rap-protocol = { path = "../rap-protocol" }
+infinity-provider-protocol = { path = "../infinity-provider-protocol" }
 rig-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-schemars = { workspace = true }
-tokio = { workspace = true, features = ["net", "rt", "time"] }
-tokio-util = { version = "0.7", features = ["codec"] }
+tokio = { workspace = true, features = ["rt", "time"] }
 futures-util = { workspace = true }
 async-trait = { workspace = true }
 async-stream = "0.3"

--- a/crates/infinity-agent-core/src/batch_processor.rs
+++ b/crates/infinity-agent-core/src/batch_processor.rs
@@ -17,9 +17,9 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::event_processor::{self, CompletionAction, HistoryManager};
 use crate::message::{InputMessage, InputMessageContent, SyntheticKind, TaggedSyntheticKind};
-use crate::model_provider::{ModelProvider, ProviderStreamingResponse};
 use crate::tools::{Tool, ToolContext};
 use crate::traits::{ConversationStore, InputSender, StateStore};
+use infinity_provider_protocol::{ModelProvider, ProviderStreamingResponse};
 use rap_client::http::HttpClient;
 use rap_client::notifier::RapNotifier;
 
@@ -388,11 +388,11 @@ mod tests {
     use super::DisplayEvent;
     use crate::event_processor::HistoryManager;
     use crate::message::{InputMessage, InputMessageContent, OAuthRequired, UserChoiceRequired};
-    use crate::model_provider::ProviderStreamingResponse;
     use crate::test_helpers::mock_provider;
     use crate::tools::{Tool, ToolContext};
     use crate::traits::{ConversationStore, InputSender, StateStore};
     use async_trait::async_trait;
+    use infinity_provider_protocol::ProviderStreamingResponse;
     use rap_client::http::HttpClient;
     use rig::OneOrMany;
     use rig::completion::ToolDefinition;

--- a/crates/infinity-agent-core/src/event_processor.rs
+++ b/crates/infinity-agent-core/src/event_processor.rs
@@ -17,9 +17,9 @@ use tracing;
 use crate::message::{
     InfinityMessage, InputMessage, InputMessageContent, SyntheticKind, TaggedSyntheticKind,
 };
-use crate::model_provider::{ModelProvider, ProviderStreamingResponse};
 use crate::tools::{Tool, ToolContext};
 use crate::traits::{ConversationStore, InputSender, StateStore};
+use infinity_provider_protocol::{ModelProvider, ProviderStreamingResponse};
 
 // ── Public types ──
 

--- a/crates/infinity-agent-core/src/lib.rs
+++ b/crates/infinity-agent-core/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod batch_processor;
 pub mod event_processor;
 pub mod message;
-pub mod model_provider;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 pub mod tools;

--- a/crates/infinity-agent-core/src/test_helpers.rs
+++ b/crates/infinity-agent-core/src/test_helpers.rs
@@ -2,7 +2,7 @@
 
 use rig_mock::{MockCompletionModel, MockModelController, mock_model};
 
-use crate::model_provider::{ModelEntry, SingleModelProvider};
+use infinity_provider_protocol::{ModelEntry, SingleModelProvider};
 
 /// Wrap a mock model as a single-model provider. The model is registered as
 /// `"mock"` with a zero context window and no output token limit.

--- a/crates/infinity-daemon/Cargo.toml
+++ b/crates/infinity-daemon/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 infinity-agent-core = { path = "../infinity-agent-core" }
 infinity-protocol = { path = "../infinity-protocol" }
+infinity-provider-protocol = { path = "../infinity-provider-protocol" }
 rap-client = { path = "../rap-client" }
 rap-protocol = { path = "../rap-protocol" }
 

--- a/crates/infinity-daemon/src/models.rs
+++ b/crates/infinity-daemon/src/models.rs
@@ -9,16 +9,16 @@
 //! provider id to the command that serves that provider over a Unix socket.
 //! The daemon spawns each command, reads the socket path the process prints
 //! on stdout, and talks to it through a
-//! [`RemoteModelProvider`](infinity_agent_core::model_provider::remote::RemoteModelProvider).
+//! [`RemoteModelProvider`](infinity_provider_protocol::remote::RemoteModelProvider).
 
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use infinity_agent_core::model_provider::remote::RemoteModelProvider;
-use infinity_agent_core::model_provider::{ModelEntry, ModelProvider};
 use infinity_protocol::ModelRef;
+use infinity_provider_protocol::remote::RemoteModelProvider;
+use infinity_provider_protocol::{ModelEntry, ModelProvider};
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncBufReadExt;
 

--- a/crates/infinity-daemon/src/session/agent_loop.rs
+++ b/crates/infinity-daemon/src/session/agent_loop.rs
@@ -175,8 +175,8 @@ mod tests {
 
     use super::*;
     use infinity_agent_core::message::{InputMessage, InputMessageContent};
-    use infinity_agent_core::model_provider::{ModelEntry, SingleModelProvider};
     use infinity_agent_core::traits::ConversationStore;
+    use infinity_provider_protocol::{ModelEntry, SingleModelProvider};
     use rig::message::UserContent;
     use rig_mock::mock_model;
 

--- a/crates/infinity-daemon/src/session/mod.rs
+++ b/crates/infinity-daemon/src/session/mod.rs
@@ -154,10 +154,7 @@ impl SessionManager {
     /// and killed on drop.
     pub async fn with_providers(
         config: SessionManagerConfig,
-        providers: Vec<(
-            String,
-            Arc<dyn infinity_agent_core::model_provider::ModelProvider>,
-        )>,
+        providers: Vec<(String, Arc<dyn infinity_provider_protocol::ModelProvider>)>,
         provider_processes: Vec<tokio::process::Child>,
     ) -> Result<Self, BoxError> {
         let SessionManagerConfig {

--- a/crates/infinity-daemon/src/session/thread_worker.rs
+++ b/crates/infinity-daemon/src/session/thread_worker.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use infinity_agent_core::batch_processor::DisplayEvent;
 use infinity_agent_core::event_processor;
 use infinity_agent_core::message::{InputMessage, InputMessageContent};
-use infinity_agent_core::model_provider::ProviderStreamingResponse;
 use infinity_agent_core::tools::{Tool, ToolContext};
 use infinity_protocol::DaemonMessage;
+use infinity_provider_protocol::ProviderStreamingResponse;
 use rig::message::UserContent;
 use tokio::sync::{mpsc, oneshot};
 
@@ -60,7 +60,7 @@ fn apply_model_switch(
     display_tx: &mpsc::UnboundedSender<DisplayEvent<ProviderStreamingResponse>>,
     model_slot: &mut Option<(
         infinity_protocol::ModelRef,
-        Arc<dyn infinity_agent_core::model_provider::ModelProvider>,
+        Arc<dyn infinity_provider_protocol::ModelProvider>,
     )>,
     context_window: &mut usize,
 ) {
@@ -290,7 +290,7 @@ pub async fn thread_worker(
     let mut context_window = model_entry.context_window;
     let mut model_slot: Option<(
         infinity_protocol::ModelRef,
-        Arc<dyn infinity_agent_core::model_provider::ModelProvider>,
+        Arc<dyn infinity_provider_protocol::ModelProvider>,
     )> = Some((model_ref, provider));
     // Set when `model_switch_rx` is closed, so selects stop polling it (a
     // closed channel is always ready and would otherwise spin).
@@ -716,8 +716,8 @@ impl Drop for WorkerGuard {
 #[expect(clippy::collapsible_if, reason = "test readability")]
 mod tests {
     use super::*;
-    use infinity_agent_core::model_provider::{ModelEntry, SingleModelProvider};
     use infinity_agent_core::traits::{ConversationStore, InputSender};
+    use infinity_provider_protocol::{ModelEntry, SingleModelProvider};
     use rig_mock::mock_model;
 
     fn test_model_ref() -> infinity_protocol::ModelRef {

--- a/crates/infinity-daemon/tests/web_e2e.rs
+++ b/crates/infinity-daemon/tests/web_e2e.rs
@@ -33,11 +33,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use infinity_agent_core::model_provider::{ModelEntry, ModelProvider, SingleModelProvider};
 use infinity_daemon::ids::SequentialIdSource;
 use infinity_daemon::rap_callback;
 use infinity_daemon::session::{SessionManager, SessionManagerConfig};
 use infinity_daemon::ws_handler;
+use infinity_provider_protocol::{ModelEntry, ModelProvider, SingleModelProvider};
 use playwright_rs::{
     Animations, Browser, BrowserContext, Page, Playwright, ScreenshotAssertionOptions, expect,
     expect_page,

--- a/crates/infinity-provider-bedrock/Cargo.toml
+++ b/crates/infinity-provider-bedrock/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]
-infinity-agent-core = { path = "../infinity-agent-core" }
+infinity-provider-protocol = { path = "../infinity-provider-protocol" }
 aws-config = { version = "*", default-features = false, features = ["credentials-process"] }
 rig-core = { workspace = true }
 rig-bedrock = { workspace = true }

--- a/crates/infinity-provider-bedrock/src/lib.rs
+++ b/crates/infinity-provider-bedrock/src/lib.rs
@@ -6,7 +6,7 @@
 //! token limits. Callers only deal in plain rig [`CompletionRequest`]s.
 
 use async_trait::async_trait;
-use infinity_agent_core::model_provider::{
+use infinity_provider_protocol::{
     ModelEntry, ModelProvider, ProviderCompletionResponse, erase_streaming_response,
 };
 use rig::client::CompletionClient;

--- a/crates/infinity-provider-bedrock/src/main.rs
+++ b/crates/infinity-provider-bedrock/src/main.rs
@@ -1,5 +1,5 @@
 //! Standalone binary serving the Bedrock [`ModelProvider`] over a Unix
-//! socket (see `infinity_agent_core::model_provider::remote`).
+//! socket (see `infinity_provider_protocol::remote`).
 //!
 //! Prints the generated socket path as the first (and only) stdout line so a
 //! supervisor (e.g. `infinity-daemon`) can discover it; logs go to stderr.
@@ -7,8 +7,8 @@
 use std::io::Write;
 use std::sync::Arc;
 
-use infinity_agent_core::model_provider::remote::serve_provider;
 use infinity_provider_bedrock::BedrockProvider;
+use infinity_provider_protocol::remote::serve_provider;
 use tracing_subscriber::EnvFilter;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/crates/infinity-provider-protocol/Cargo.toml
+++ b/crates/infinity-provider-protocol/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "infinity-provider-protocol"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+
+[dependencies]
+rig-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = { workspace = true }
+async-trait = { workspace = true }
+async-stream = "0.3"
+futures-util = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+tokio = { workspace = true, features = ["net", "rt", "time"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+uuid = { workspace = true }
+
+[dev-dependencies]
+rig-mock = { path = "../rig-mock" }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/infinity-provider-protocol/src/lib.rs
+++ b/crates/infinity-provider-protocol/src/lib.rs
@@ -1,4 +1,8 @@
-//! Extensible model provider abstraction.
+//! Extensible model provider abstraction and its remote wire protocol.
+//!
+//! This crate is intentionally lightweight so that out-of-process provider
+//! implementations (e.g. `infinity-provider-bedrock`) can depend on it
+//! without pulling in the rest of the agent stack.
 //!
 //! A [`ModelProvider`] exposes async APIs for listing the models it offers and
 //! for invoking one of them. Implementations internally wrap a rig

--- a/crates/infinity-provider-protocol/src/remote.rs
+++ b/crates/infinity-provider-protocol/src/remote.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 use tokio::net::{UnixListener, UnixStream};
 use tokio_util::codec::{Framed, LinesCodec};
 
-use super::{ModelEntry, ModelProvider, ProviderCompletionResponse, ProviderStreamingResponse};
+use crate::{ModelEntry, ModelProvider, ProviderCompletionResponse, ProviderStreamingResponse};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
@@ -166,7 +166,7 @@ pub enum WireStreamItem {
 
 /// Convert one streamed item from the server-side provider into wire items.
 /// `Reasoning` fans out into one item per content block, mirroring
-/// [`super::erase_streaming_response`].
+/// [`crate::erase_streaming_response`].
 fn content_to_wire(
     item: Result<StreamedAssistantContent<ProviderStreamingResponse>, CompletionError>,
 ) -> Vec<WireStreamItem> {
@@ -487,7 +487,7 @@ impl ModelProvider for RemoteModelProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model_provider::SingleModelProvider;
+    use crate::SingleModelProvider;
     use rig::completion::Usage;
     use rig::message::UserContent;
     use rig_mock::mock_model;

--- a/docs/docs/infinity-runtime/model-providers.md
+++ b/docs/docs/infinity-runtime/model-providers.md
@@ -16,7 +16,7 @@ Providers own all backend-specific behavior. Callers hand them a plain [rig](htt
 
 ## The `ModelProvider` trait
 
-Defined in `infinity_agent_core::model_provider`:
+Defined in the `infinity-provider-protocol` crate — a deliberately lightweight crate so provider implementations can depend on it without pulling in the rest of the runtime:
 
 ```rust
 #[async_trait]
@@ -79,13 +79,13 @@ The trait is dyn-compatible, which requires erasing the backend-specific streami
 
 ## The provider process transport
 
-The local daemon (Infinity Code) runs each provider as a separate process configured in `~/.infinity/providers.json` (see [Model Providers in the Infinity Code docs](/docs/infinity-code/model-providers) for installing and configuring them) and aggregates their models into one catalog, with the first model of the first configured provider as the default. These provider processes are served over a **Unix domain socket**. You rarely need the details — `infinity_agent_core::model_provider::remote` provides both sides — but they matter when packaging a provider as an installable crate.
+The local daemon (Infinity Code) runs each provider as a separate process configured in `~/.infinity/providers.json` (see [Model Providers in the Infinity Code docs](/docs/infinity-code/model-providers) for installing and configuring them) and aggregates their models into one catalog, with the first model of the first configured provider as the default. These provider processes are served over a **Unix domain socket**. You rarely need the details — `infinity_provider_protocol::remote` provides both sides — but they matter when packaging a provider as an installable crate.
 
 A provider binary does three things:
 
 ```rust
 use std::sync::Arc;
-use infinity_agent_core::model_provider::remote::serve_provider;
+use infinity_provider_protocol::remote::serve_provider;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {


### PR DESCRIPTION
* Move `infinity_agent_core::model_provider` (the `ModelProvider` trait, `ModelEntry`,
  `erase_streaming_response`, `SingleModelProvider`, and the `remote` Unix-socket wire
  protocol) into a new lightweight `infinity-provider-protocol` crate whose dependency
  surface is just rig-core + serde/schemars + async plumbing — no rap-client,
  rap-protocol, rhai, chrono, etc.
* `infinity-provider-bedrock` now depends only on `infinity-provider-protocol`, dropping
  the entire `infinity-agent-core`/rap dependency tree from provider builds.
* No legacy path: all consumers (`infinity-agent-core` internals, `infinity-daemon`,
  `infinity-agent-cli` tests) import `infinity_provider_protocol::…` directly instead
  of going through a re-export.
* Trim now-unused deps from `infinity-agent-core` (`schemars`, `tokio-util`, tokio `net`
  feature).
* Update `docs/docs/infinity-runtime/model-providers.md` to reference the new crate.
* Regenerate the Rust section of `THIRD-PARTY` (adds `infinity-provider-protocol` to the
  Apache-2.0 "used by" list); the npm sections are unchanged since no npm deps changed.

BREAKING CHANGE: `infinity_agent_core::model_provider` no longer exists; use the
`infinity-provider-protocol` crate directly.

Verified with `./check.bash`: fmt, clippy (-D warnings), check, and all tests pass. The
web-e2e step fails only due to the pre-existing `playwright-rs` driver-download 404
documented in check.bash, unrelated to this change.