### PR TITLE
feat(infinity-agent-cli): add `infinity daemon restart` and post-update daemon check

### DIFF
--- a/crates/infinity-agent-cli/src/daemon_client.rs
+++ b/crates/infinity-agent-cli/src/daemon_client.rs
@@ -150,16 +150,101 @@ pub async fn ensure_daemon_running() -> Result<UnixStream, BoxError> {
         })
 }
 
+/// Returns the pid of the running daemon, or `None` if it is not running.
+/// Probes the pid recorded in the pid file with signal 0: only `ESRCH` (no
+/// such process) is treated as not running, so a stale pid file (e.g. left
+/// behind by a crash) is detected while an unsignalable-but-alive process
+/// (`EPERM`) is not misreported as stopped. Pid reuse is an accepted risk:
+/// the daemon removes its pid file on clean shutdown, and both the file and
+/// the daemon are per-user.
+pub fn running_daemon_pid() -> Option<i32> {
+    let pid_str = std::fs::read_to_string(infinity_protocol::pid_path()).ok()?;
+    let pid: i32 = pid_str.trim().parse().ok()?;
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None) {
+        Err(nix::errno::Errno::ESRCH) => None,
+        _ => Some(pid),
+    }
+}
+
+/// Stop the running daemon: send SIGTERM and wait for the process to fully
+/// exit (so its shutdown cleanup of the socket and pid files completes).
+/// Returns `Ok(Some(pid))` if a daemon was stopped, `Ok(None)` if no daemon
+/// is running.
+pub async fn stop_daemon() -> Result<Option<i32>, BoxError> {
+    let Some(pid) = running_daemon_pid() else {
+        return Ok(None);
+    };
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(pid),
+        nix::sys::signal::Signal::SIGTERM,
+    )
+    .map_err(|e| format!("failed to send SIGTERM to daemon (pid {pid}): {e}"))?;
+    println!("stopping daemon (pid {pid})...");
+    wait_for_daemon_exit(pid).await?;
+    Ok(Some(pid))
+}
+
+/// How long to wait for the daemon to exit after SIGTERM. Generous because
+/// shutdown cleans up all active sessions.
+const DAEMON_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Restart the daemon: stop the running instance (if any), then launch a
+/// fresh one.
+pub async fn restart_daemon() -> Result<(), BoxError> {
+    if stop_daemon().await?.is_none() {
+        println!("daemon is not running — starting a fresh one");
+    }
+    launch_daemon().await?;
+    println!("daemon started");
+    Ok(())
+}
+
+/// Wait until the given pid no longer exists, or error out after
+/// [`DAEMON_SHUTDOWN_TIMEOUT`].
+async fn wait_for_daemon_exit(pid: i32) -> Result<(), BoxError> {
+    let deadline = tokio::time::Instant::now() + DAEMON_SHUTDOWN_TIMEOUT;
+    // Signal 0 probes liveness without delivering a signal; only ESRCH means
+    // the process is gone (see `running_daemon_pid`).
+    while !matches!(
+        nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None),
+        Err(nix::errno::Errno::ESRCH)
+    ) {
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!(
+                "daemon (pid {pid}) did not exit within {}s after SIGTERM",
+                DAEMON_SHUTDOWN_TIMEOUT.as_secs()
+            )
+            .into());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    Ok(())
+}
+
 /// How long to wait for a launched daemon to either report readiness or
 /// exit. Generous because daemon startup spawns model provider processes.
 const DAEMON_STARTUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Path to the CLI binary to spawn as the daemon. Usually the current
+/// executable, but after a self-update `/proc/self/exe` on Linux points at
+/// the replaced (deleted) inode and its path ends with " (deleted)" — strip
+/// that marker so we spawn the freshly installed binary at the original path.
+fn daemon_exe_path() -> Result<PathBuf, BoxError> {
+    let exe = std::env::current_exe()?;
+    if let Some(s) = exe.to_str()
+        && let Some(stripped) = s.strip_suffix(" (deleted)")
+    {
+        return Ok(PathBuf::from(stripped));
+    }
+    Ok(exe)
+}
 
 /// Launch the daemon as a background process and wait until it prints its
 /// ready line on stdout. If the daemon exits first (e.g. a configuration
 /// error), the error includes everything it printed to stdout/stderr, which
 /// would otherwise be invisible for a detached process.
-async fn launch_daemon() -> Result<(), BoxError> {
-    let current_exe = std::env::current_exe()?;
+pub async fn launch_daemon() -> Result<(), BoxError> {
+    let current_exe = daemon_exe_path()?;
     let mut child = tokio::process::Command::new(&current_exe)
         .arg("daemon")
         .env(

--- a/crates/infinity-agent-cli/src/install.rs
+++ b/crates/infinity-agent-cli/src/install.rs
@@ -431,6 +431,48 @@ async fn update_providers(
     Ok(failed)
 }
 
+/// After an update, ensure the daemon runs the freshly installed binaries:
+/// boot one if none is running, or warn that the running instance is still
+/// executing pre-update code and needs `infinity daemon restart`. Returns
+/// `Ok(false)` if the daemon needed to be started but failed to boot (the
+/// error is printed to the viewport), so callers can reflect it in their
+/// exit code after cleaning up the terminal.
+async fn ensure_fresh_daemon(
+    viewport: &mut InlineViewport<CrosstermTerm>,
+) -> Result<bool, BoxError> {
+    if let Some(pid) = crate::daemon_client::running_daemon_pid() {
+        viewport.print_line_above(Line::from(Span::styled(
+            format!(
+                "⚠ The daemon (pid {pid}) is still running the previous version — run `infinity daemon restart` to pick up the update"
+            ),
+            Style::default().fg(Color::Yellow),
+        )))?;
+        return Ok(true);
+    }
+
+    viewport.print_line_above(Line::from(Span::styled(
+        "Daemon is not running — starting it...",
+        Style::default().fg(Color::Yellow),
+    )))?;
+    viewport.draw(2, |_| {})?;
+    match crate::daemon_client::launch_daemon().await {
+        Ok(()) => {
+            viewport.print_line_above(Line::from(Span::styled(
+                "✓ Daemon started",
+                Style::default().fg(Color::Green),
+            )))?;
+            Ok(true)
+        }
+        Err(e) => {
+            viewport.print_line_above(Line::from(Span::styled(
+                format!("✗ Failed to start daemon: {e}"),
+                Style::default().fg(Color::Red),
+            )))?;
+            Ok(false)
+        }
+    }
+}
+
 /// `infinity provider update` — re-install all providers with recorded sources.
 pub async fn run_provider_update() -> Result<(), BoxError> {
     let mut term = CrosstermTerm::new();
@@ -438,6 +480,7 @@ pub async fn run_provider_update() -> Result<(), BoxError> {
     let mut viewport = InlineViewport::new(term, 2)?;
 
     let failed = update_providers(&mut viewport).await?;
+    let daemon_ok = ensure_fresh_daemon(&mut viewport).await?;
 
     let summary = if failed.is_empty() {
         Span::styled("✓ All providers updated", Style::default().fg(Color::Green))
@@ -451,10 +494,12 @@ pub async fn run_provider_update() -> Result<(), BoxError> {
     viewport.draw(2, |_| {})?;
     terminal::cleanup(viewport.term_mut())?;
 
-    if failed.is_empty() {
-        Ok(())
-    } else {
+    if !failed.is_empty() {
         Err("some providers failed to update".into())
+    } else if !daemon_ok {
+        Err("failed to start daemon after update".into())
+    } else {
+        Ok(())
     }
 }
 
@@ -508,6 +553,7 @@ pub async fn run_update() -> Result<(), BoxError> {
     let mut viewport = InlineViewport::new(term, 2)?;
 
     let failed = update_rap_tools(&mut viewport).await?;
+    let daemon_ok = ensure_fresh_daemon(&mut viewport).await?;
 
     let summary = if failed.is_empty() {
         Span::styled("✓ All tools updated", Style::default().fg(Color::Green))
@@ -521,10 +567,12 @@ pub async fn run_update() -> Result<(), BoxError> {
     viewport.draw(2, |_| {})?;
     terminal::cleanup(viewport.term_mut())?;
 
-    if failed.is_empty() {
-        Ok(())
-    } else {
+    if !failed.is_empty() {
         Err("some tools failed to update".into())
+    } else if !daemon_ok {
+        Err("failed to start daemon after update".into())
+    } else {
+        Ok(())
     }
 }
 
@@ -590,6 +638,7 @@ pub async fn run_self_update(features_override: Option<&str>) -> Result<(), BoxE
 
     let rap_failed = update_rap_tools(&mut viewport).await?;
     let provider_failed = update_providers(&mut viewport).await?;
+    let daemon_ok = ensure_fresh_daemon(&mut viewport).await?;
 
     let failed_count = rap_failed.len() + provider_failed.len();
     let summary = if failed_count == 0 {
@@ -604,9 +653,11 @@ pub async fn run_self_update(features_override: Option<&str>) -> Result<(), BoxE
     viewport.draw(2, |_| {})?;
     terminal::cleanup(viewport.term_mut())?;
 
-    if failed_count == 0 {
-        Ok(())
-    } else {
+    if failed_count != 0 {
         Err("some components failed to update".into())
+    } else if !daemon_ok {
+        Err("failed to start daemon after update".into())
+    } else {
+        Ok(())
     }
 }

--- a/crates/infinity-agent-cli/src/main.rs
+++ b/crates/infinity-agent-cli/src/main.rs
@@ -69,6 +69,8 @@ enum Commands {
 enum DaemonCommands {
     /// Stop the running daemon
     Stop,
+    /// Restart the daemon (stop it if running, then start a fresh instance)
+    Restart,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -178,18 +180,13 @@ async fn async_main(cli: Cli) -> Result<(), BoxError> {
             Commands::Update { features } => install::run_self_update(features.as_deref()).await,
             Commands::Daemon { action } => match action {
                 Some(DaemonCommands::Stop) => {
-                    let pid_path = infinity_protocol::pid_path();
-                    let pid_str = std::fs::read_to_string(&pid_path)
-                        .map_err(|_| "daemon is not running (no pid file)")?;
-                    let pid: i32 = pid_str.trim().parse().map_err(|_| "invalid pid file")?;
-                    nix::sys::signal::kill(
-                        nix::unistd::Pid::from_raw(pid),
-                        nix::sys::signal::Signal::SIGTERM,
-                    )
-                    .map_err(|e| format!("failed to send SIGTERM: {e}"))?;
-                    println!("sent SIGTERM to daemon (pid {pid})");
+                    let pid = daemon_client::stop_daemon()
+                        .await?
+                        .ok_or("daemon is not running")?;
+                    println!("daemon stopped (pid {pid})");
                     Ok(())
                 }
+                Some(DaemonCommands::Restart) => daemon_client::restart_daemon().await,
                 None => infinity_daemon::run_daemon(true).await,
             },
             Commands::Rap { action } => match action {


### PR DESCRIPTION
## `infinity daemon restart`

* New `DaemonCommands::Restart` subcommand backed by `daemon_client::restart_daemon()`:
  * Sends SIGTERM to the running daemon (found via the pid file, liveness-probed with signal 0 so stale pid files are ignored)
  * Waits up to 30s for the old process to fully exit — so its shutdown cleanup (removing the socket/pid files) can't race the new instance
  * Launches a fresh daemon via the existing `launch_daemon()` readiness handshake
  * If no daemon is running, just starts one
* `daemon stop` now uses the shared `running_daemon_pid()` helper instead of hand-parsing the pid file

## Post-update daemon check

* New `install::ensure_fresh_daemon()` runs after `infinity update`, `infinity rap update`, and `infinity provider update` (all of these update binaries the daemon executes or spawns):
  * If the daemon is **not** running → boots it, so the freshly installed version is live
  * If the daemon **is** running → prints a yellow warning that it's still on the previous version and to run `infinity daemon restart`
* `launch_daemon()` now resolves the executable via `daemon_exe_path()`, which strips the Linux `/proc/self/exe` " (deleted)" suffix — after a self-update, the old (replaced) binary would otherwise try to re-exec its deleted inode path; this ensures the freshly installed binary is spawned instead. Made `launch_daemon` `pub` for reuse from `install.rs`.

Verified with `./check.bash` (all checks pass, including web e2e).