### PR TITLE
fix(sandbox): detect repository root when the requested path is nested inside a repo (#65)

### DIFF
--- a/crates/sandbox-core/src/lib.rs
+++ b/crates/sandbox-core/src/lib.rs
@@ -9,3 +9,18 @@ pub mod types;
 
 pub const DEFAULT_SANDBOX_NAME: &str = "Infinity 🤖";
 pub const DEFAULT_SANDBOX_EMAIL: &str = "infinity@hydro.run";
+
+/// Walk up from `start` to find the repository root: the closest ancestor
+/// (including `start` itself) containing a `.jj` directory or a `.git`
+/// entry (directory, or file for worktrees/submodules).
+///
+/// This allows repositories to be detected even when the provided path is
+/// nested inside the repo — important for jj repos, where subdirectories
+/// carry no marker of their own (unlike git, where commands walk up
+/// themselves).
+pub fn find_repo_root(start: &std::path::Path) -> Option<std::path::PathBuf> {
+    start
+        .ancestors()
+        .find(|dir| dir.join(".jj").is_dir() || dir.join(".git").exists())
+        .map(std::path::Path::to_path_buf)
+}

--- a/crates/sandbox-core/src/server.rs
+++ b/crates/sandbox-core/src/server.rs
@@ -469,8 +469,12 @@ async fn handle_clone_repo<B: SandboxBackend, M: MetadataStore, C: CallbackClien
     let bookmark = format!("sandbox-{}", invocation.group_id);
     let path = PathBuf::from(&remote_uri);
 
+    // If the requested path was nested inside the repository (rather than
+    // being the repo root itself), note the detected root in the response.
+    let root_note = repo_root_note(&args.repo, &path);
+
     // Resolve the base revision to an absolute jj change_id.
-    let (repo_state, msg) = if path.join(".jj").is_dir() {
+    let (repo_state, mut msg) = if path.join(".jj").is_dir() {
         // Jujutsu repo — resolve base revision via jj.
         let _ = run_jj(&path, &["workspace", "update-stale"]).await;
         let rev_to_resolve = args
@@ -558,7 +562,28 @@ async fn handle_clone_repo<B: SandboxBackend, M: MetadataStore, C: CallbackClien
     state.metadata.put(&repo_state).await?;
 
     tracing::info!(group_id = %invocation.group_id, remote = %remote_uri, "repo cloned");
+    if let Some(note) = root_note {
+        msg.push_str(&note);
+    }
     Ok(msg)
+}
+
+/// If `requested` is a local path nested inside the resolved repository
+/// `root`, return a note for the tool response pointing at the root.
+/// Returns `None` when the requested path is the root itself, or when it
+/// is not a resolvable local path (e.g. a git remote URI).
+fn repo_root_note(requested: &str, root: &Path) -> Option<String> {
+    let requested_abs = Path::new(requested).canonicalize().ok()?;
+    if requested_abs != root && requested_abs.starts_with(root) {
+        Some(format!(
+            " Note: the requested path `{requested}` is inside a repository rooted at `{}`; \
+             the sandbox operates on the whole repository, and file paths are relative to \
+             that root.",
+            root.display()
+        ))
+    } else {
+        None
+    }
 }
 
 async fn handle_open_sandbox_direct<B: SandboxBackend, M: MetadataStore, C: CallbackClient>(
@@ -593,7 +618,16 @@ async fn handle_open_sandbox_direct<B: SandboxBackend, M: MetadataStore, C: Call
     state.metadata.put(&repo_state).await?;
 
     tracing::info!(group_id = %invocation.group_id, remote = %remote_uri, "opened direct sandbox");
-    Ok("Repository initialized (Direct mode — file edits require approval, commands run without file write access unless write-orig is granted).".to_owned())
+    let mut msg = "Repository initialized (Direct mode — file edits require approval, commands run without file write access unless write-orig is granted).".to_owned();
+    // `args.repo` is the path as requested by the caller, while `remote_uri`
+    // is the backend-resolved repository root (canonicalized, walked up to
+    // the nearest `.jj`/`.git`). For a directory with no VCS at all, the
+    // backend falls back to the requested path itself, so Direct mode still
+    // works on non-VCS directories and no note is emitted.
+    if let Some(note) = repo_root_note(&args.repo, Path::new(&remote_uri)) {
+        msg.push_str(&note);
+    }
+    Ok(msg)
 }
 
 use crate::{DEFAULT_SANDBOX_EMAIL, DEFAULT_SANDBOX_NAME};
@@ -2131,12 +2165,12 @@ async fn migrate_import_inner<B: SandboxBackend, M: MetadataStore, C: CallbackCl
         .canonicalize()
         .map_err(|e| SandboxError::Other(format!("failed to canonicalize cwd: {e}")))?;
 
+    // Walk up to the repository root so a cwd nested inside the repo
+    // (including subdirectories of jj repos) is detected correctly.
+    let local_repo = crate::find_repo_root(&local_repo)
+        .ok_or_else(|| SandboxError::Other("cwd is not inside a git or jj repository".into()))?;
+
     let is_jj = local_repo.join(".jj").is_dir();
-    if !is_jj && !local_repo.join(".git").exists() {
-        return Err(SandboxError::Other(
-            "cwd is not a git or jj repository".into(),
-        ));
-    }
 
     // Write bundle to temp file
     let tmp = tempfile::NamedTempFile::new().map_err(SandboxError::Io)?;

--- a/crates/sandbox-local/src/backend.rs
+++ b/crates/sandbox-local/src/backend.rs
@@ -217,8 +217,9 @@ impl Drop for LocalBackend {
 #[async_trait]
 impl SandboxBackend for LocalBackend {
     /// For local mode, the repo arg is a path to an existing git dir.
-    /// We don't need to do anything special — just validate it exists
-    /// and return the path as the remote URI.
+    /// We don't need to do anything special — just validate it exists,
+    /// resolve the repository root (walking up from nested paths), and
+    /// return the root path as the remote URI.
     async fn init_repo(&self, repo: &str, _group_id: &str) -> Result<String, SandboxError> {
         let path = PathBuf::from(repo);
         if !path.is_absolute() {
@@ -232,7 +233,13 @@ impl SandboxBackend for LocalBackend {
             )));
         }
         let abs = path.canonicalize().map_err(SandboxError::Io)?;
-        Ok(abs.to_string_lossy().to_string())
+        // Walk up to the repository root so paths nested inside a repo
+        // (e.g. a cwd in a subdirectory of a jj repo, which has no
+        // `.jj`/`.git` marker of its own) resolve to the repo itself.
+        // If no root is found, fall back to the path as given so callers
+        // produce their usual "not a repository" errors.
+        let root = sandbox_core::find_repo_root(&abs).unwrap_or(abs);
+        Ok(root.to_string_lossy().to_string())
     }
 
     /// Create a sandbox for the given group. If a cached directory already

--- a/crates/sandbox-local/tests/nested_repo_root.rs
+++ b/crates/sandbox-local/tests/nested_repo_root.rs
@@ -1,0 +1,170 @@
+//! Tests that `clone_repo` detects the repository root when the provided
+//! path is nested inside a repo (important for jj repos, where
+//! subdirectories carry no `.jj`/`.git` marker), and reports the detected
+//! root in the tool response.
+
+mod common;
+
+use common::{invoke, jj_init_with_file, start_test_server};
+use rap_client::callback_server::start_callback_channel;
+
+use std::process::Command;
+
+/// Create a plain git repo (no jj) with an initial commit.
+fn git_init_with_file(filename: &str, content: &str) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let path = tmp.path();
+    let git = |args: &[&str]| {
+        assert!(
+            Command::new("git")
+                .args(["-c", "init.defaultBranch=main"])
+                .args(["-c", "user.name=test"])
+                .args(["-c", "user.email=test@test"])
+                .args(args)
+                .current_dir(path)
+                .status()
+                .expect("run git command")
+                .success()
+        );
+    };
+    git(&["init"]);
+    std::fs::write(path.join(filename), content).expect("write file");
+    git(&["add", "-A"]);
+    git(&["commit", "-m", "initial"]);
+    tmp
+}
+
+/// clone_repo with a path nested inside a jj repo should resolve to the
+/// repo root, use Jujutsu workspaces, and note the detected root.
+#[tokio::test]
+async fn jj_clone_from_nested_dir() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let tmp = jj_init_with_file("README.md", "hello\n");
+    let repo = tmp.path();
+    let nested = repo.join("src").join("deep");
+    std::fs::create_dir_all(&nested).expect("create nested dir");
+
+    let server_url = start_test_server(&repo.join(".test-metadata")).await;
+    let (callback_url, mut rx) = start_callback_channel()
+        .await
+        .expect("start callback channel");
+
+    let group_id = "jj-nested-clone";
+    let text = invoke(
+        &server_url,
+        &callback_url,
+        group_id,
+        "clone_repo",
+        serde_json::json!({ "repo": nested.to_str().expect("nested path to str") }),
+        &mut rx,
+        None,
+    )
+    .await;
+    assert!(
+        text.contains("Jujutsu workspaces"),
+        "expected jj mode for nested path inside jj repo, got: {text}"
+    );
+    let canonical_root = repo.canonicalize().expect("canonicalize repo root");
+    assert!(
+        text.contains(&format!("rooted at `{}`", canonical_root.display())),
+        "expected note about detected repo root, got: {text}"
+    );
+
+    // Files should be read relative to the repo root, not the nested dir.
+    let text = invoke(
+        &server_url,
+        &callback_url,
+        group_id,
+        "read_file",
+        serde_json::json!({ "path": "README.md" }),
+        &mut rx,
+        None,
+    )
+    .await;
+    assert!(text.contains("hello"), "got: {text}");
+}
+
+/// clone_repo with a path nested inside a plain git repo should resolve to
+/// the repo root, use Git worktrees, and note the detected root.
+#[tokio::test]
+async fn git_clone_from_nested_dir() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let tmp = git_init_with_file("README.md", "hello\n");
+    let repo = tmp.path();
+    let nested = repo.join("src").join("deep");
+    std::fs::create_dir_all(&nested).expect("create nested dir");
+
+    let server_url = start_test_server(&repo.join(".test-metadata")).await;
+    let (callback_url, mut rx) = start_callback_channel()
+        .await
+        .expect("start callback channel");
+
+    let group_id = "git-nested-clone";
+    let text = invoke(
+        &server_url,
+        &callback_url,
+        group_id,
+        "clone_repo",
+        serde_json::json!({ "repo": nested.to_str().expect("nested path to str") }),
+        &mut rx,
+        None,
+    )
+    .await;
+    assert!(
+        text.contains("Git worktrees"),
+        "expected git mode for nested path inside git repo, got: {text}"
+    );
+    let canonical_root = repo.canonicalize().expect("canonicalize repo root");
+    assert!(
+        text.contains(&format!("rooted at `{}`", canonical_root.display())),
+        "expected note about detected repo root, got: {text}"
+    );
+
+    // Files should be read relative to the repo root, not the nested dir.
+    let text = invoke(
+        &server_url,
+        &callback_url,
+        group_id,
+        "read_file",
+        serde_json::json!({ "path": "README.md" }),
+        &mut rx,
+        None,
+    )
+    .await;
+    assert!(text.contains("hello"), "got: {text}");
+}
+
+/// clone_repo with the repo root itself should not include a root note.
+#[tokio::test]
+async fn no_note_when_path_is_root() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let tmp = jj_init_with_file("README.md", "hello\n");
+    let repo = tmp.path();
+
+    let server_url = start_test_server(&repo.join(".test-metadata")).await;
+    let (callback_url, mut rx) = start_callback_channel()
+        .await
+        .expect("start callback channel");
+
+    let text = invoke(
+        &server_url,
+        &callback_url,
+        "jj-root-clone",
+        "clone_repo",
+        serde_json::json!({ "repo": repo.to_str().expect("repo path to str") }),
+        &mut rx,
+        None,
+    )
+    .await;
+    assert!(
+        text.contains("Repository initialized (using Jujutsu workspaces)."),
+        "got: {text}"
+    );
+    assert!(
+        !text.contains("rooted at"),
+        "unexpected root note for root path, got: {text}"
+    );
+}


### PR DESCRIPTION
* Add `sandbox_core::find_repo_root`, which walks up from a path to the
  closest ancestor containing a `.jj` directory or a `.git` entry
  (directory, or file for worktrees/submodules). This makes jj repos
  detectable when the cwd is inside a nested folder — jj subdirectories
  carry no marker of their own, so the previous `path.join(".jj")` check
  silently fell through to git mode (or failed entirely for
  non-colocated jj repos).
* `LocalBackend::init_repo` now resolves the requested path to the
  repository root before storing it as the remote URI, so sandboxes are
  always created from the repo root. Falls back to the path as given
  when no root is found, preserving existing error paths.
* `clone_repo` and `open_sandbox_direct` responses now include a note
  when the detected repository root differs from the requested path,
  telling the agent that the sandbox operates on the whole repository
  and that file paths are relative to the root.
* The migration-import cwd check also walks up to the repo root instead
  of requiring cwd to be the root itself.
* Add integration tests (`nested_repo_root.rs`) covering jj and git
  clones from nested directories (mode detection + root note + reads
  relative to the root) and the no-note case when cloning from the root.
  
Fixes #65