### PR TITLE
fix(sandbox-core): resolve clippy 1.97 question_mark lints in server.rs

### DIFF
--- a/crates/sandbox-core/src/server.rs
+++ b/crates/sandbox-core/src/server.rs
@@ -705,15 +705,11 @@ fn detect_cd_to_original_repo(command: &str, remote_uri: &str) -> Option<String>
 
     // Strip optional quotes around the path.
     let (path_str, _rest) = if let Some(stripped) = after_cd.strip_prefix('"') {
-        match stripped.find('"') {
-            Some(end) => (&stripped[..end], &after_cd[2 + end..]),
-            None => return None,
-        }
+        let end = stripped.find('"')?;
+        (&stripped[..end], &after_cd[2 + end..])
     } else if let Some(stripped) = after_cd.strip_prefix('\'') {
-        match stripped.find('\'') {
-            Some(end) => (&stripped[..end], &after_cd[2 + end..]),
-            None => return None,
-        }
+        let end = stripped.find('\'')?;
+        (&stripped[..end], &after_cd[2 + end..])
     } else {
         // Unquoted: take until whitespace, `&&`, or `;`.
         let end = after_cd
@@ -1726,10 +1722,9 @@ fn parse_changed_files(output: &str) -> Vec<(FileChangeStatus, &str)> {
                     (FileChangeStatus::Modified, rest)
                 } else if let Some(rest) = line.strip_prefix("A\t").or(line.strip_prefix("A ")) {
                     (FileChangeStatus::Added, rest)
-                } else if let Some(rest) = line.strip_prefix("D\t").or(line.strip_prefix("D ")) {
-                    (FileChangeStatus::Deleted, rest)
                 } else {
-                    return None;
+                    let rest = line.strip_prefix("D\t").or(line.strip_prefix("D "))?;
+                    (FileChangeStatus::Deleted, rest)
                 };
             Some((status, path.trim()))
         })


### PR DESCRIPTION
CI's Lint job (clippy 1.97) fails on three new `clippy::question_mark`
warnings that local stable clippy 1.96 does not yet flag:

* `detect_cd_to_original_repo`: replace the two
  `match stripped.find(...) { Some(end) => ..., None => return None }`
  blocks (double- and single-quoted `cd` path parsing) with
  `let end = stripped.find(...)?;`
* `parse_changed_files`: rewrite the trailing
  `else if let Some(rest) = ... else { return None }` branch for the
  `D` (deleted) status using the `?` operator inside the `else` block

No behavior change. Verified with cargo fmt, stable and nightly
`cargo clippy --all-targets -- -D warnings` (both clean workspace-wide),
and `cargo test -p sandbox-core` (14/14 pass).