### PR TITLE
fix(infinity-daemon): add `keeps_session_alive` flag

### DIFF
--- a/crates/infinity-agent-cli/src/acp_server.rs
+++ b/crates/infinity-agent-cli/src/acp_server.rs
@@ -464,6 +464,7 @@ async fn run_session_connection(
             let msg = ClientMessage::Connect {
                 session_id: daemon_id.clone(),
                 thread_id: None,
+                keeps_session_alive: true,
             };
             send(&mut framed, &msg).await?;
             conn.daemon_id = Some(daemon_id);
@@ -509,6 +510,7 @@ async fn run_session_connection(
                 cwd,
                 location: None,
                 model: None,
+                keeps_session_alive: true,
             };
             send(&mut framed, &msg).await?;
             // Wait for Connected to get daemon ID, then send input.
@@ -559,6 +561,7 @@ async fn run_session_connection(
             let msg = ClientMessage::Connect {
                 session_id: daemon_id.clone(),
                 thread_id: None,
+                keeps_session_alive: true,
             };
             send(&mut framed, &msg).await?;
             conn.daemon_id = Some(daemon_id.clone());

--- a/crates/infinity-agent-cli/src/daemon_client.rs
+++ b/crates/infinity-agent-cli/src/daemon_client.rs
@@ -373,6 +373,7 @@ pub async fn run_headless(message: String) -> Result<(), BoxError> {
         cwd,
         location: None,
         model: None,
+        keeps_session_alive: true,
     };
     framed.send(Bytes::from(serde_json::to_vec(&msg)?)).await?;
 
@@ -589,6 +590,7 @@ where
         to_daemon.send(ClientMessage::Connect {
             session_id: resolved,
             thread_id: None,
+            keeps_session_alive: true,
         })?;
     }
 
@@ -728,7 +730,7 @@ where
                     }
 
                     if let Some(target) = maybe_target {
-                        let _ = to_daemon.send(ClientMessage::Connect { session_id: target, thread_id: None });
+                        let _ = to_daemon.send(ClientMessage::Connect { session_id: target, thread_id: None, keeps_session_alive: true });
                     } // if none, will be created on next user input
                 }
 
@@ -772,7 +774,7 @@ where
                         }
                     } else {
                         pending_input.push(text);
-                        let _ = to_daemon.send(ClientMessage::CreateSession { cwd: cwd.clone(), location: None, model: selected_model.clone() });
+                        let _ = to_daemon.send(ClientMessage::CreateSession { cwd: cwd.clone(), location: None, model: selected_model.clone(), keeps_session_alive: true });
                     }
                 }
             }

--- a/crates/infinity-daemon/src/client_handler.rs
+++ b/crates/infinity-daemon/src/client_handler.rs
@@ -11,7 +11,7 @@ use tokio::net::UnixStream;
 use tokio::sync::{Mutex, mpsc};
 use tokio_util::codec::Framed;
 
-use crate::session::SessionManager;
+use crate::session::{SessionManager, Subscriber};
 
 /// List directory entries matching a partial path for tab-completion.
 /// Given "/home/user/fo", lists entries in "/home/user/" that start with "fo".
@@ -308,6 +308,9 @@ pub async fn handle_client_channels(
     let mut remote_proxy_rx: Option<mpsc::UnboundedReceiver<DaemonMessage>> = None;
     let mut active_remote_name: Option<String> = None;
     let mut _booted_rap_servers: Vec<tokio::process::Child> = Vec::new(); // prevents shutdown until close
+    // Whether this connection's subscription keeps the session alive.
+    // Set by CreateSession/Connect and used when re-attaching on UserInput restart.
+    let mut connection_keeps_alive: bool = true;
 
     // Send Welcome immediately
     {
@@ -413,7 +416,8 @@ pub async fn handle_client_channels(
                 }
 
                     match msg {
-                        ClientMessage::CreateSession { cwd, location, model } => {
+                        ClientMessage::CreateSession { cwd, location, model, keeps_session_alive } => {
+                            connection_keeps_alive = keeps_session_alive;
                             if let Some(rname) = location {
                                 let rd = {
                                     let mgr = session_manager.lock().await;
@@ -422,7 +426,7 @@ pub async fn handle_client_channels(
                                 if let Some(rd) = rd {
                                     match rd.open_raw_connection(&rname).await {
                                         Ok((tx, rx)) => {
-                                            let _ = tx.send(ClientMessage::CreateSession { cwd, location: None, model });
+                                            let _ = tx.send(ClientMessage::CreateSession { cwd, location: None, model, keeps_session_alive });
                                             remote_proxy_tx = Some(tx);
                                             remote_proxy_rx = Some(rx);
                                             active_remote_name = Some(rname);
@@ -449,14 +453,15 @@ pub async fn handle_client_channels(
                                 let model = model.unwrap_or_else(|| mgr.catalog.default_ref().clone());
                                 match mgr.create_session(&cwd, model, &mut emit).await {
                                     Ok(sid) => {
-                                        mgr.attach_client(&sid, client_tx.clone(), false).await;
+                                        mgr.attach_client(&sid, client_tx.clone(), false, keeps_session_alive).await;
                                         attached_session_id = Some(sid);
                                     }
                                     Err(e) => { let _ = daemon_tx.send(DaemonMessage::Error { thread_id: None, text: format!("failed to create session: {e}") }); }
                                 }
                             }
                         }
-                    ClientMessage::Connect { session_id, thread_id } => {
+                    ClientMessage::Connect { session_id, thread_id, keeps_session_alive } => {
+                        connection_keeps_alive = keeps_session_alive;
                         if let Some((rname, real_session_id)) = is_remote_session(&session_id) {
                             let real_thread_id = thread_id.as_deref().map(|t| strip_id(t, rname));
                             let rname = rname.to_owned();
@@ -493,7 +498,7 @@ pub async fn handle_client_channels(
                             let target = thread_id.as_deref().unwrap_or(&session_id);
                             match mgr.resume_session(&session_id, target, &mut emit).await {
                                 Ok(()) => {
-                                    mgr.attach_client(target, client_tx.clone(), true).await;
+                                    mgr.attach_client(target, client_tx.clone(), true, keeps_session_alive).await;
                                     attached_session_id = Some(session_id);
                                 }
                                 Err(e) => { let _ = daemon_tx.send(DaemonMessage::Error { thread_id: Some(session_id), text: format!("failed to resume session: {e}") }); }
@@ -516,7 +521,7 @@ pub async fn handle_client_channels(
                             synthetic: None,
                             display_as: None,
                             subscription: false,
-                        }, None), Some(client_tx.clone()), &mut emit).await {
+                        }, None), Some(Subscriber { tx: client_tx.clone(), keeps_session_alive: connection_keeps_alive }), &mut emit).await {
                             let _ = daemon_tx.send(DaemonMessage::Error { thread_id: Some(thread_id), text: "session not found".into() });
                         }
                     }
@@ -572,7 +577,7 @@ pub async fn handle_client_channels(
                             synthetic: Some(SyntheticKind::Tagged(TaggedSyntheticKind::Compaction)),
                             display_as: None,
                             subscription: false,
-                        }, None), Some(client_tx.clone()), &mut emit).await;
+                        }, None), Some(Subscriber { tx: client_tx.clone(), keeps_session_alive: connection_keeps_alive }), &mut emit).await;
                     }
                     ClientMessage::SwitchModel { session_id: thread_id, model } => {
                         let mgr = session_manager.lock().await;

--- a/crates/infinity-daemon/src/remote.rs
+++ b/crates/infinity-daemon/src/remote.rs
@@ -116,6 +116,7 @@ impl RemoteDaemons {
             .send(ClientMessage::Connect {
                 session_id: session_id.to_owned(),
                 thread_id: thread_id.map(|t| t.to_owned()),
+                keeps_session_alive: true,
             })
             .map_err(|e| format!("send Connect failed: {e}"))?;
 

--- a/crates/infinity-daemon/src/session/mod.rs
+++ b/crates/infinity-daemon/src/session/mod.rs
@@ -34,7 +34,7 @@ pub use thread_worker::thread_worker;
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 /// Re-export from thread_worker.
-pub use thread_worker::{SubscribeRequest, ThreadSubscribers};
+pub use thread_worker::{SubscribeRequest, Subscriber, ThreadSubscribers};
 
 /// Message sent to the agent loop — either user input, a subscribe request,
 /// or a model switch for a specific thread.
@@ -274,8 +274,8 @@ impl SessionManager {
             let smap = session.subscriber_map.lock().expect("bug: mutex poisoned");
             if let Some(subs) = smap.get(group_id) {
                 let subs = subs.lock().expect("bug: mutex poisoned");
-                for tx in subs.iter() {
-                    let _ = tx.send(msg.clone());
+                for sub in subs.iter() {
+                    let _ = sub.tx.send(msg.clone());
                 }
             }
         }
@@ -471,11 +471,15 @@ impl SessionManager {
     /// If the session is alive, sends a subscribe request through the agent loop.
     /// Otherwise, loads history directly from the conversation store and sends
     /// a Replay message to the client.
+    ///
+    /// `keeps_session_alive`: when `false`, this subscriber will not prevent the
+    /// session from going idle and being shut down by the daemon.
     pub async fn attach_client(
         &mut self,
         thread_id: &str,
         tx: mpsc::UnboundedSender<DaemonMessage>,
         wants_replay: bool,
+        keeps_session_alive: bool,
     ) {
         let session_id = self.conversation_store.get_root_thread_id(thread_id);
 
@@ -493,7 +497,11 @@ impl SessionManager {
                 .clone();
             let _ = agent_tx.send(AgentMessage::Subscribe {
                 thread_id: thread_id.to_owned(),
-                request: (tx.clone(), wants_replay),
+                request: SubscribeRequest {
+                    tx: tx.clone(),
+                    wants_replay,
+                    keeps_session_alive,
+                },
             });
         } else if wants_replay {
             // Session not alive — load history from the conversation store directly.
@@ -525,11 +533,14 @@ impl SessionManager {
     /// Send user input text to a session's agent loop.
     /// If the session was shut down and no agent loop is running, this
     /// clears the shut_down flag and starts a new agent loop first.
+    ///
+    /// `subscriber` is the client to re-attach after a session restart.
+    /// Pass `None` for RAP callbacks (which should not trigger a restart).
     pub async fn send_input(
         &mut self,
         thread_id: &str,
         msg: (InputMessage, Option<String>),
-        client_tx: Option<mpsc::UnboundedSender<DaemonMessage>>,
+        subscriber: Option<Subscriber>,
         emit: &mut impl AsyncFnMut(DaemonMessage),
     ) -> bool {
         // Resolve thread ID to root session ID in case a child thread ID was provided.
@@ -547,9 +558,9 @@ impl SessionManager {
             store.sessions.contains_key(session_id)
         };
 
-        // if client_tx is None, that means this is for a RAP callback, but if the agent was shut down,
+        // if subscriber is None, that means this is for a RAP callback, but if the agent was shut down,
         // we should ignore the callback (the agent will not idle if any tool calls or subscriptions are active)
-        if needs_restart && client_tx.is_some() {
+        if needs_restart && subscriber.is_some() {
             // Remove stale session if present.
             self.sessions.remove(session_id);
             {
@@ -564,8 +575,9 @@ impl SessionManager {
                 return false;
             }
             // Re-attach client to the new session.
-            if let Some(tx) = client_tx {
-                self.attach_client(session_id, tx, false).await;
+            if let Some(sub) = subscriber {
+                self.attach_client(session_id, sub.tx, false, sub.keeps_session_alive)
+                    .await;
             }
         }
 
@@ -904,7 +916,7 @@ async fn session_wrapper(
                 // workers before returning, so nothing is left running.
                 idle_exited = {
                     let smap = subscriber_map.lock().expect("bug: mutex poisoned");
-                    smap.values().all(|subs| subs.lock().expect("bug: mutex poisoned").iter().all(|tx| tx.is_closed()))
+                    smap.values().all(|subs| subs.lock().expect("bug: mutex poisoned").iter().all(|sub| sub.tx.is_closed() || !sub.keeps_session_alive))
                 };
                 break;
             }
@@ -932,10 +944,10 @@ async fn session_wrapper(
                     let _ = store.save();
                 }
 
-                // If no client attached, exit the loop entirely.
+                // If no keep-alive client is attached, exit the loop entirely.
                 let has_clients = {
                     let smap = subscriber_map.lock().expect("bug: mutex poisoned");
-                    smap.values().any(|subs| subs.lock().expect("bug: mutex poisoned").iter().any(|tx| !tx.is_closed()))
+                    smap.values().any(|subs| subs.lock().expect("bug: mutex poisoned").iter().any(|sub| !sub.tx.is_closed() && sub.keeps_session_alive))
                 };
                 if !has_clients {
                     tracing::info!("Exiting agent {} due to idle", session_id);

--- a/crates/infinity-daemon/src/session/thread_worker.rs
+++ b/crates/infinity-daemon/src/session/thread_worker.rs
@@ -17,11 +17,24 @@ use crate::session::ActiveThreads;
 use crate::session_store;
 use infinity_agent_core::traits::StateStore;
 
-/// Shared subscriber list for a thread worker.
-pub type ThreadSubscribers = Arc<std::sync::Mutex<Vec<mpsc::UnboundedSender<DaemonMessage>>>>;
+/// A subscriber attached to a thread worker's display events.
+#[derive(Clone)]
+pub struct Subscriber {
+    pub tx: mpsc::UnboundedSender<DaemonMessage>,
+    /// When `false`, this subscriber does not prevent the session from
+    /// idling out (e.g. the Slack bot's persistent connections).
+    pub keeps_session_alive: bool,
+}
 
-/// Subscribe request: (client_tx, want_replay).
-pub type SubscribeRequest = (mpsc::UnboundedSender<DaemonMessage>, bool);
+/// Shared subscriber list for a thread worker.
+pub type ThreadSubscribers = Arc<std::sync::Mutex<Vec<Subscriber>>>;
+
+/// A request to subscribe to a thread worker's display events.
+pub struct SubscribeRequest {
+    pub tx: mpsc::UnboundedSender<DaemonMessage>,
+    pub wants_replay: bool,
+    pub keeps_session_alive: bool,
+}
 
 pub fn is_user_text_input(msg: &InputMessage) -> bool {
     msg.synthetic.is_none()
@@ -86,7 +99,7 @@ fn apply_model_switch(
     subscribers
         .lock()
         .expect("bug: mutex poisoned")
-        .retain(|tx| tx.send(msg.clone()).is_ok());
+        .retain(|sub| sub.tx.send(msg.clone()).is_ok());
     let provider = catalog
         .provider(&selected.provider_id)
         .expect("bug: cataloged model's provider missing from catalog")
@@ -274,7 +287,7 @@ pub async fn thread_worker(
 
                 if let Some(dm) = display_event_to_daemon(&fwd_group_id, evt) {
                     let mut subs = fwd_subscribers.lock().expect("bug: mutex poisoned");
-                    subs.retain(|tx| tx.send(dm.clone()).is_ok());
+                    subs.retain(|sub| sub.tx.send(dm.clone()).is_ok());
                 }
             }
         },
@@ -361,6 +374,7 @@ pub async fn thread_worker(
     // `subscribers` — see the exactly-once invariant on `current_thinking`.
     let handle_subscribe = async |tx: mpsc::UnboundedSender<DaemonMessage>,
                                   want_replay: bool,
+                                  keeps_session_alive: bool,
                                   completion_in_flight: bool| {
         if want_replay {
             let mut history: Vec<DaemonMessage> = {
@@ -399,7 +413,13 @@ pub async fn thread_worker(
                 });
             }
         }
-        subscribers.lock().expect("bug: mutex poisoned").push(tx);
+        subscribers
+            .lock()
+            .expect("bug: mutex poisoned")
+            .push(Subscriber {
+                tx,
+                keeps_session_alive,
+            });
     };
 
     loop {
@@ -503,8 +523,8 @@ pub async fn thread_worker(
                     }
                 },
                 req = subscribe_rx.recv() => {
-                    if let Some((tx, want_replay)) = req {
-                        handle_subscribe(tx, want_replay, true).await;
+                    if let Some(SubscribeRequest { tx, wants_replay, keeps_session_alive }) = req {
+                        handle_subscribe(tx, wants_replay, keeps_session_alive, true).await;
                     }
                     continue;
                 }
@@ -547,9 +567,14 @@ pub async fn thread_worker(
                         .map(|s| !s.is_empty())
                         .unwrap_or(false);
 
-                    while let Ok((tx, want_replay)) = subscribe_rx.try_recv() {
+                    while let Ok(SubscribeRequest {
+                        tx,
+                        wants_replay,
+                        keeps_session_alive,
+                    }) = subscribe_rx.try_recv()
+                    {
                         // handle replays before idling
-                        handle_subscribe(tx, want_replay, false).await;
+                        handle_subscribe(tx, wants_replay, keeps_session_alive, false).await;
                     }
 
                     if !last_is_tool_call && !has_subs {
@@ -583,8 +608,8 @@ pub async fn thread_worker(
                                 break;
                             }
                             req = subscribe_rx.recv() => {
-                                if let Some((tx, want_replay)) = req {
-                                    handle_subscribe(tx, want_replay, false).await;
+                                if let Some(SubscribeRequest { tx, wants_replay, keeps_session_alive }) = req {
+                                    handle_subscribe(tx, wants_replay, keeps_session_alive, false).await;
                                 }
                             }
                         }
@@ -941,7 +966,10 @@ mod tests {
         let active_threads: ActiveThreads =
             Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
         let sender = InMemoryMessageSender::new(input_tx.clone());
-        let subscribers: ThreadSubscribers = Arc::new(std::sync::Mutex::new(vec![client_tx]));
+        let subscribers: ThreadSubscribers = Arc::new(std::sync::Mutex::new(vec![Subscriber {
+            tx: client_tx,
+            keeps_session_alive: true,
+        }]));
 
         // Thread metadata (including the selected model) must exist before a
         // worker starts.
@@ -1080,7 +1108,13 @@ mod tests {
                 // trailing unresolved ToolCall in the history is what tells
                 // the client to show its "waiting for tool result" state.
                 let (tx2, mut rx2) = mpsc::unbounded_channel();
-                subscribe_tx.send((tx2, true)).expect("send subscribe");
+                subscribe_tx
+                    .send(SubscribeRequest {
+                        tx: tx2,
+                        wants_replay: true,
+                        keeps_session_alive: true,
+                    })
+                    .expect("send subscribe");
                 match tokio::time::timeout(std::time::Duration::from_secs(2), rx2.recv()).await {
                     Ok(Some(DaemonMessage::Replay {
                         history,
@@ -1746,7 +1780,13 @@ mod tests {
                 // end with the in-progress thinking and be marked in-progress
                 // (so the client keeps a live spinner instead of showing idle).
                 let (tx2, mut rx2) = mpsc::unbounded_channel();
-                subscribe_tx.send((tx2, true)).expect("send subscribe");
+                subscribe_tx
+                    .send(SubscribeRequest {
+                        tx: tx2,
+                        wants_replay: true,
+                        keeps_session_alive: true,
+                    })
+                    .expect("send subscribe");
                 match tokio::time::timeout(std::time::Duration::from_secs(2), rx2.recv()).await {
                     Ok(Some(DaemonMessage::Replay {
                         history,
@@ -1789,7 +1829,13 @@ mod tests {
                 }
 
                 let (tx3, mut rx3) = mpsc::unbounded_channel();
-                subscribe_tx.send((tx3, true)).expect("send subscribe");
+                subscribe_tx
+                    .send(SubscribeRequest {
+                        tx: tx3,
+                        wants_replay: true,
+                        keeps_session_alive: true,
+                    })
+                    .expect("send subscribe");
                 match tokio::time::timeout(std::time::Duration::from_secs(2), rx3.recv()).await {
                     Ok(Some(DaemonMessage::Replay {
                         history,

--- a/crates/infinity-daemon/tests/keep_alive.rs
+++ b/crates/infinity-daemon/tests/keep_alive.rs
@@ -1,0 +1,202 @@
+//! Integration tests for the `keeps_session_alive` connection flag.
+//!
+//! A connection that declares `keeps_session_alive: false` (e.g. the Slack
+//! bot's persistent per-thread connections) must not be the reason a session
+//! is kept warm: once the agent finishes its work, the session should idle
+//! out and its agent task should exit even though the client is still
+//! connected. A normal (keep-alive) connection must keep the session warm.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use infinity_daemon::client_handler::handle_client_channels;
+use infinity_daemon::ids::SequentialIdSource;
+use infinity_daemon::session::{SessionManager, SessionManagerConfig};
+use infinity_protocol::{ClientMessage, DaemonMessage};
+use infinity_provider_protocol::{ModelEntry, ModelProvider, SingleModelProvider};
+use rig_mock::{MockModelController, mock_model};
+use tokio::sync::{Mutex, mpsc};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+struct TestHarness {
+    manager: Arc<Mutex<SessionManager>>,
+    ctrl: MockModelController,
+    client_tx: mpsc::UnboundedSender<ClientMessage>,
+    daemon_rx: mpsc::UnboundedReceiver<DaemonMessage>,
+    _state_dir: tempfile::TempDir,
+    cwd: tempfile::TempDir,
+}
+
+/// Boot an in-process session manager with a mock model and connect one
+/// client to it through `handle_client_channels`. Must run inside a LocalSet.
+async fn start_harness() -> Result<TestHarness, BoxError> {
+    let (model, ctrl) = mock_model();
+    let entry = ModelEntry {
+        model_id: "mock-model".to_owned(),
+        display_name: "Mock Model".to_owned(),
+        context_window: 100_000,
+        max_output_tokens: None,
+        supports_image_input: false,
+    };
+    let state_dir = tempfile::tempdir()?;
+    let cwd = tempfile::tempdir()?;
+    let manager = SessionManager::with_providers(
+        SessionManagerConfig {
+            state_dir: state_dir.path().to_path_buf(),
+            callback_url: "http://127.0.0.1:0".to_owned(),
+            user_rap_config: None,
+            id_source: Arc::new(SequentialIdSource::new()),
+        },
+        vec![(
+            "mock".to_owned(),
+            Arc::new(SingleModelProvider::new(entry, model)) as Arc<dyn ModelProvider>,
+        )],
+        vec![],
+    )
+    .await?;
+    let manager = Arc::new(Mutex::new(manager));
+
+    let (client_tx, client_rx) = mpsc::unbounded_channel::<ClientMessage>();
+    let (daemon_tx, daemon_rx) = mpsc::unbounded_channel::<DaemonMessage>();
+    tokio::task::spawn_local(handle_client_channels(
+        client_rx,
+        daemon_tx,
+        manager.clone(),
+    ));
+
+    Ok(TestHarness {
+        manager,
+        ctrl,
+        client_tx,
+        daemon_rx,
+        _state_dir: state_dir,
+        cwd,
+    })
+}
+
+/// Receive daemon messages until the predicate matches, with a timeout.
+async fn wait_for_message(
+    rx: &mut mpsc::UnboundedReceiver<DaemonMessage>,
+    mut pred: impl FnMut(&DaemonMessage) -> bool,
+) -> DaemonMessage {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let msg = rx
+                .recv()
+                .await
+                .expect("daemon channel closed while waiting");
+            if pred(&msg) {
+                return msg;
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for daemon message")
+}
+
+/// Run one full round: create a session with the given keep-alive flag, send
+/// input, complete a mock model response, and return the session id.
+async fn create_session_and_chat(h: &mut TestHarness, keeps_session_alive: bool) -> String {
+    h.client_tx
+        .send(ClientMessage::CreateSession {
+            cwd: h.cwd.path().to_path_buf(),
+            location: None,
+            model: None,
+            keeps_session_alive,
+        })
+        .expect("send CreateSession");
+
+    let connected = wait_for_message(&mut h.daemon_rx, |m| {
+        matches!(m, DaemonMessage::Connected { .. })
+    })
+    .await;
+    let DaemonMessage::Connected { session_id, .. } = connected else {
+        unreachable!()
+    };
+
+    h.client_tx
+        .send(ClientMessage::UserInput {
+            session_id: session_id.clone(),
+            text: "hello".to_owned(),
+        })
+        .expect("send UserInput");
+
+    let _req = h.ctrl.next_request().await;
+    h.ctrl.send_text("hi there");
+    h.ctrl.finish();
+
+    wait_for_message(&mut h.daemon_rx, |m| {
+        matches!(m, DaemonMessage::ResponseDone { .. })
+    })
+    .await;
+
+    session_id
+}
+
+/// Poll until the session's agent task finishes, or time out.
+async fn wait_for_agent_exit(manager: &Arc<Mutex<SessionManager>>, session_id: &str) -> bool {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        {
+            let mgr = manager.lock().await;
+            match mgr.sessions.get(session_id) {
+                Some(s) if s.agent_task.is_finished() => return true,
+                None => return true,
+                _ => {}
+            }
+        }
+        if tokio::time::Instant::now() > deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// A connection with `keeps_session_alive: false` (like the Slack bot) must
+/// not keep the session warm: after the response completes, the session
+/// idles out and its agent task exits even though the client stays connected.
+#[tokio::test(flavor = "current_thread")]
+async fn non_keep_alive_client_does_not_keep_session_warm() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mut h = start_harness().await.expect("start harness");
+            let session_id = create_session_and_chat(&mut h, false).await;
+
+            // The client is still connected (client_tx alive), but the
+            // session must still wind down because the only subscriber is
+            // non-keep-alive.
+            assert!(
+                wait_for_agent_exit(&h.manager, &session_id).await,
+                "session should idle out despite the connected non-keep-alive client"
+            );
+        })
+        .await;
+}
+
+/// A normal connection (`keeps_session_alive: true`) keeps the session warm
+/// while it stays connected.
+#[tokio::test(flavor = "current_thread")]
+async fn keep_alive_client_keeps_session_warm() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mut h = start_harness().await.expect("start harness");
+            let session_id = create_session_and_chat(&mut h, true).await;
+
+            // Give the idle machinery ample time to (incorrectly) tear the
+            // session down; it must still be running afterwards.
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let mgr = h.manager.lock().await;
+            let session = mgr
+                .sessions
+                .get(&session_id)
+                .expect("session should still be tracked");
+            assert!(
+                !session.agent_task.is_finished(),
+                "session should stay warm while a keep-alive client is connected"
+            );
+        })
+        .await;
+}

--- a/crates/infinity-protocol/src/lib.rs
+++ b/crates/infinity-protocol/src/lib.rs
@@ -53,6 +53,10 @@ pub fn remotes_config_path() -> PathBuf {
 
 // ── Client → Daemon ─────────────────────────────────────────────────────────
 
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ClientMessage {
     /// Create a new session with the given working directory.
@@ -66,11 +70,21 @@ pub enum ClientMessage {
         /// daemon's default model.
         #[serde(default)]
         model: Option<ModelRef>,
+        /// When `false`, this connection will not prevent the session from
+        /// going idle and being shut down by the daemon. Defaults to `true`
+        /// so that normal interactive clients keep sessions alive.
+        #[serde(default = "default_true")]
+        keeps_session_alive: bool,
     },
     /// Connect to an existing session (optionally a specific thread).
     Connect {
         session_id: String,
         thread_id: Option<String>,
+        /// When `false`, this connection will not prevent the session from
+        /// going idle and being shut down by the daemon. Defaults to `true`
+        /// so that normal interactive clients keep sessions alive.
+        #[serde(default = "default_true")]
+        keeps_session_alive: bool,
     },
     UserInput {
         session_id: String,


### PR DESCRIPTION
 to prevent non-interactive clients from blocking idle shutdown

Add a `keeps_session_alive` boolean field to `ClientMessage::CreateSession` and `ClientMessage::Connect` (defaulting to `true` via serde for backward compat). Connections that set this to `false` are tracked but do not prevent the session from idling out — enabling persistent but passive client connections (e.g. bots) that should not keep sessions warm indefinitely.

Key changes:

* `infinity-protocol`: new `keeps_session_alive` field on `CreateSession` and `Connect`, with `#[serde(default = "default_true")]`.

* `client_handler.rs`: tracks `connection_keeps_alive` per connection and threads it through `attach_client` and `send_input`.

* `session/thread_worker.rs`: replaces bare `UnboundedSender` subscriber lists with a `Subscriber` struct carrying `tx` + `keeps_session_alive`. Idle-exit and has-clients checks now only consider keep-alive subscribers.

* `session/mod.rs`: exposes a `worker_shutdown` `CancellationToken` on sessions. `send_input` uses a retry loop (up to 2 attempts) to handle the race where the agent loop begins winding down between the restart check and the actual send — inputs arriving mid-wind-down now transparently restart the session.

* `infinity-agent-cli`: all existing call sites pass `keeps_session_alive: true` (preserving current behavior for interactive CLI clients).

* `tests/keep_alive.rs`: three integration tests covering non-keep-alive idle exit, keep-alive warmth, and input-after-idle-exit restart.