### PR TITLE
fix(web): stop replays from duplicating the transcript on reconnect

### DIFF
--- a/crates/infinity-daemon/src/session/thread_worker.rs
+++ b/crates/infinity-daemon/src/session/thread_worker.rs
@@ -413,13 +413,17 @@ pub async fn thread_worker(
                 });
             }
         }
-        subscribers
-            .lock()
-            .expect("bug: mutex poisoned")
-            .push(Subscriber {
-                tx,
-                keeps_session_alive,
-            });
+        let mut subs = subscribers.lock().expect("bug: mutex poisoned");
+        // A client can legitimately re-send Connect on the same connection
+        // (e.g. its connect-retry timer fires while a slow resume is still in
+        // flight). Replace any existing subscription on the same channel
+        // instead of stacking a duplicate, which would deliver every display
+        // event to that client N times from then on.
+        subs.retain(|sub| !sub.tx.same_channel(&tx));
+        subs.push(Subscriber {
+            tx,
+            keeps_session_alive,
+        });
     };
 
     loop {

--- a/infinity-web/src/App.tsx
+++ b/infinity-web/src/App.tsx
@@ -495,6 +495,18 @@ export function App() {
               views: Record<string, any>;
               in_progress?: boolean;
             }>(m);
+            // A Replay always carries the complete transcript for the
+            // connected thread, so rebuild the view from scratch instead of
+            // appending. On a WS reconnect (Welcome → re-Connect) the old
+            // transcript is still loaded; appending the replayed history
+            // duplicated the entire message list (and DOM) on every
+            // reconnect, degrading performance permanently. Bumping the
+            // generation invalidates MessageList's prefix cache so the
+            // fresh list re-renders once. (Unlike resetMessages, keep the
+            // input draft — the user may be mid-typing during a blip.)
+            setMsgState((prev) => ({ messages: [], gen: prev.gen + 1 }));
+            setPendingChoices([]);
+            streamingRef.current = false;
             for (const h of p.history) processOne(h);
             // After replay, mark any open assistant as done
             finishAssistant();


### PR DESCRIPTION
* `infinity-web/src/App.tsx`: a `Replay` always carries the complete
  transcript for the connected thread, so the handler now clears the
  message state (bumping the generation to invalidate MessageList's
  prefix cache), pending choices, and streaming flag before processing
  the replayed history. Previously the WS-reconnect path (`Welcome` →
  re-`Connect`) never reset the transcript — unlike `navigateTo` /
  `MigrateComplete` — so each reconnect appended a full extra copy of
  the history to the messages array and DOM, making the page
  progressively laggier with every disconnect/reconnect cycle. The
  input draft is deliberately preserved (unlike `resetMessages`).

* `crates/infinity-daemon/src/session/thread_worker.rs`:
  `handle_subscribe` now replaces an existing subscription on the same
  channel (`same_channel`) instead of pushing a duplicate. The web
  client re-sends `Connect` every 5s until `Connected` arrives; when a
  resume was slow, each retry stacked another subscriber for the same
  client, causing every display event (and another full `Replay`) to be
  delivered N times from then on.