### PR TITLE
feat: Show a placeholder in the session picker when there are no sessions

### DIFF
--- a/crates/infinity-agent-cli/src/session_picker.rs
+++ b/crates/infinity-agent-cli/src/session_picker.rs
@@ -45,7 +45,8 @@ impl SessionPicker {
     }
 
     pub fn visible_rows(&self) -> u16 {
-        (self.sessions.len() as u16).min(MAX_VISIBLE_ROWS)
+        // Reserve one row for the "no sessions" placeholder when empty.
+        (self.sessions.len() as u16).clamp(1, MAX_VISIBLE_ROWS)
     }
 
     pub fn preferred_height(&self) -> u16 {
@@ -74,6 +75,9 @@ impl SessionPicker {
     fn confirm(&mut self) {
         if let Some((id, _)) = self.sessions.get(self.selected) {
             self.result = Some(SessionPickerResult::Selected(id.clone()));
+        } else if self.sessions.is_empty() {
+            // Nothing to select — treat Enter as dismissal.
+            self.result = Some(SessionPickerResult::Cancelled);
         }
     }
 
@@ -83,6 +87,20 @@ impl SessionPicker {
 
     pub fn render(&self, area: Rect, buf: &mut Buffer) {
         if area.height == 0 || area.width == 0 {
+            return;
+        }
+        if self.sessions.is_empty() {
+            let msg = " No sessions to load — press esc to dismiss and start a new one.";
+            for (col, ch) in msg.chars().enumerate() {
+                let x = area.x + col as u16;
+                if x >= area.right() {
+                    break;
+                }
+                buf[(x, area.y)]
+                    .set_char(ch)
+                    .set_fg(Color::DarkGray)
+                    .set_style(Style::default().add_modifier(Modifier::ITALIC));
+            }
             return;
         }
         let visible = self.visible_rows() as usize;

--- a/crates/infinity-agent-cli/src/terminal.rs
+++ b/crates/infinity-agent-cli/src/terminal.rs
@@ -292,7 +292,7 @@ where
                 sessions.extend(updates);
 
                 if let Some(session_picker) = session_picker.as_mut() {
-                    let last_picked_id = session_picker.sessions[session_picker.selected].0.clone();
+                    let last_picked_id = session_picker.sessions.get(session_picker.selected).map(|s| s.0.clone());
 
                     let mut all_sessions: Vec<(String, infinity_protocol::SessionInfo)> = sessions.iter()
                         .map(|(id, info)| (id.clone(), info.clone()))
@@ -300,7 +300,7 @@ where
                     all_sessions.sort_by(|a, b| b.1.last_updated.cmp(&a.1.last_updated));
 
                     session_picker.sessions = all_sessions;
-                    if let Some(found) = session_picker.sessions.iter().position(|s| s.0 == last_picked_id) {
+                    if let Some(found) = last_picked_id.and_then(|id| session_picker.sessions.iter().position(|s| s.0 == id)) {
                         session_picker.selected = found;
                     }
                 }

--- a/crates/infinity-agent-cli/tests/snapshots/tui_flow_snapshots__picker_empty_dismissed.snap
+++ b/crates/infinity-agent-cli/tests/snapshots/tui_flow_snapshots__picker_empty_dismissed.snap
@@ -1,0 +1,21 @@
+---
+source: crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
+expression: h.screen()
+---
+┌────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│Infinity Agent CLI                                                              │
+│Type your messages below. /help for commands. Ctrl+C to exit.                   │
+│                                                                                │
+│                                                                                │
+│────────────────────────────────────────────────────────────────────────────────│
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│/help for commands                                 mock: mock-model · 0% context│
+└────────────────────────────────────────────────────────────────────────────────┘
+cursor: row=11 col=1

--- a/crates/infinity-agent-cli/tests/snapshots/tui_flow_snapshots__picker_empty_placeholder.snap
+++ b/crates/infinity-agent-cli/tests/snapshots/tui_flow_snapshots__picker_empty_placeholder.snap
@@ -1,0 +1,21 @@
+---
+source: crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
+expression: h.screen()
+---
+┌────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│Infinity Agent CLI                                                              │
+│Type your messages below. /help for commands. Ctrl+C to exit.                   │
+│                                                                                │
+│                                                                                │
+│                                                                                │
+│────────────────────────────────────────────────────────────────────────────────│
+│ No sessions to load — press esc to dismiss and start a new one.                │
+│                                                                                │
+│↑↓ navigate  enter select  esc cancel              mock: mock-model · 0% context│
+└────────────────────────────────────────────────────────────────────────────────┘
+cursor: row=7 col=0 (hidden)

--- a/crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
+++ b/crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
@@ -411,6 +411,23 @@ async fn sessions_updated_while_picker_open() {
     insta::assert_snapshot!("picker_after_update", h.screen());
 }
 
+/// Opening the session picker with no sessions must show a placeholder
+/// message instead of a blank area, and Enter must dismiss it.
+#[tokio::test(start_paused = true)]
+async fn empty_session_picker_shows_placeholder() {
+    let h = TuiHarness::spawn(80, 14).await;
+
+    h.type_str("/load");
+    h.key(KeyCode::Enter);
+    h.settle().await;
+    insta::assert_snapshot!("picker_empty_placeholder", h.screen());
+
+    // Enter on the empty picker dismisses it.
+    h.key(KeyCode::Enter);
+    h.settle().await;
+    insta::assert_snapshot!("picker_empty_dismissed", h.screen());
+}
+
 /// Feedback lines for commands that act without a session: /compact prints
 /// its trigger, /stop and /archive print "no active session" notes.
 #[tokio::test(start_paused = true)]


### PR DESCRIPTION
Previously, opening the session picker (/load or Ctrl+L) with no sessions
rendered a blank area with no indication of what was happening.

- session_picker.rs: render a dim italic placeholder line ("No sessions to
  load — press esc to dismiss and start a new one.") when the session list
  is empty; reserve one visible row for it via visible_rows(); make Enter
  dismiss the empty picker instead of doing nothing.
- terminal.rs: guard against an out-of-bounds panic when a sessions-updated
  notification arrives while the picker is open with an empty list (was
  indexing sessions[selected] unconditionally).
- tests: new snapshot test empty_session_picker_shows_placeholder covering
  both the placeholder rendering and Enter-to-dismiss behavior.