### PR TITLE
perf(infinity-agent-core)!: cut idle-agent memory ~30% (154 → ~107 KB/agent)

### DIFF
--- a/crates/infinity-agent-core/examples/agent_scale.rs
+++ b/crates/infinity-agent-core/examples/agent_scale.rs
@@ -278,7 +278,7 @@ async fn main() {
 
             let finished = Rc::new(Cell::new(0u64));
             let observer_count = finished.clone();
-            let running = AgentSystemBuilder::new_local(
+            let mut running = AgentSystemBuilder::new_local(
                 InMemoryConversationStore::new(),
                 InMemoryStateStore::new(),
                 model,
@@ -321,6 +321,10 @@ async fn main() {
                 launched += batch;
                 // Let idle drivers finish exiting before sampling.
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                // Drain lifecycle notifications like a real embedding would;
+                // otherwise they accumulate in the channel for the whole run
+                // and get counted as per-agent memory.
+                while running.try_next_lifecycle_event().is_ok() {}
                 trim_allocator();
                 println!("{launched},{}", rss_bytes());
             }

--- a/crates/infinity-agent-core/src/event_processor.rs
+++ b/crates/infinity-agent-core/src/event_processor.rs
@@ -128,6 +128,17 @@ pub struct PendingItem {
     message_id: String,
 }
 
+/// Result of matching an incoming tool result against the history tail (see
+/// [`HistoryManager::match_tool_result`]).
+enum ToolResultMatch {
+    /// A matching, still-unanswered tool call exists: the result is fresh.
+    Unanswered,
+    /// The matching call already has a result in history: duplicate delivery.
+    AlreadyAnswered,
+    /// No matching call in the live tail: the result is stale.
+    NoPendingCall,
+}
+
 pub struct HistoryManager<C: ConversationStore, S: StateStore> {
     conversation_store: C,
     state_store: S,
@@ -136,14 +147,12 @@ pub struct HistoryManager<C: ConversationStore, S: StateStore> {
     ancestor_chain: Vec<String>,
     pub history: RefCell<Vec<InfinityMessage>>,
     processed_message_ids: RefCell<HashSet<String>>,
-    processed_tool_calls: RefCell<HashSet<String>>,
     metadata: RefCell<Option<serde_json::Value>>,
     pending_items: RefCell<Vec<PendingItem>>,
     /// until a turn is complete the data lives here. If errors occur,
     /// it'll get discarded, if the turn completes, then it will get flushed to
     /// _both_ pending_items and history.
     turn_buffer: RefCell<Vec<PendingItem>>,
-    pending_complete_tool_calls: RefCell<HashSet<String>>,
     /// Tool call IDs that were interrupted by a new user message during
     /// `handle_content`. Callers can drain this via `take_interrupted_tool_calls`
     /// to send best-effort cancellation notifications to RAP tool servers.
@@ -187,10 +196,10 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
             .await
             .unwrap_or(None);
 
-        let (processed_message_ids, processed_tool_calls) = state_store
+        let processed_message_ids = state_store
             .get_processed_ids(&thread_id)
             .await
-            .unwrap_or_else(|_| (HashSet::new(), HashSet::new()));
+            .unwrap_or_default();
 
         Ok(Self {
             conversation_store,
@@ -200,18 +209,16 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
             ancestor_chain,
             history: RefCell::new(history),
             processed_message_ids: RefCell::new(processed_message_ids),
-            processed_tool_calls: RefCell::new(processed_tool_calls),
             metadata: RefCell::new(metadata),
             pending_items: RefCell::new(Vec::new()),
             turn_buffer: RefCell::new(Vec::new()),
-            pending_complete_tool_calls: RefCell::new(HashSet::new()),
             interrupted_tool_calls: RefCell::new(Vec::new()),
             compacted_up_to: RefCell::new(compacted_up_to),
             ancestor_prefix_len: Cell::new(ancestor_prefix_len),
         })
     }
 
-    pub async fn handle_content(
+    pub fn handle_content(
         &self,
         message: InfinityMessage,
         message_id: String,
@@ -232,42 +239,24 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
         );
 
         if !is_self_contained_subscription {
-            if let InfinityMessage::ToolResult { ref result, .. }
-            | InfinityMessage::SubscriptionEvent { ref result, .. } = message
-            {
-                let tool_result = result;
-                if self
-                    .processed_tool_calls
-                    .borrow()
-                    .contains(tool_result.id.as_str())
-                {
-                    tracing::info!(
-                        "Tool call {} already processed, ignoring duplicate",
-                        tool_result.id
-                    );
-                    self.processed_message_ids
-                        .borrow_mut()
-                        .insert(message_id.clone());
-                    if let Err(e) = self
-                        .state_store
-                        .add_processed_message_ids(&self.thread_id, vec![message_id])
-                        .await
-                    {
-                        tracing::warn!(error = %e, "failed to persist processed message id");
+            if let Some(tool_result) = message.tool_result() {
+                match self.match_tool_result(&tool_result.id) {
+                    ToolResultMatch::Unanswered => {}
+                    ToolResultMatch::AlreadyAnswered => {
+                        tracing::info!(
+                            "Tool call {} already processed, ignoring duplicate",
+                            tool_result.id
+                        );
+                        self.processed_message_ids.borrow_mut().insert(message_id);
+                        return Ok(false);
                     }
-                    return Ok(false);
-                } else if !self.history.borrow().last().is_some_and(|l| {
-                    if let InfinityMessage::ToolCall { call, .. } = l {
-                        call.id == tool_result.id
-                    } else {
-                        false
+                    ToolResultMatch::NoPendingCall => {
+                        tracing::info!(
+                            "Got tool call result for wrong call, ignoring {:?}",
+                            tool_result
+                        );
+                        return Ok(false);
                     }
-                }) {
-                    tracing::info!(
-                        "Got tool call result for wrong call, ignoring {:?}",
-                        tool_result
-                    );
-                    return Ok(false);
                 }
             } else {
                 self.interrupt_pending_tool_call();
@@ -281,8 +270,37 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
         Ok(true)
     }
 
+    /// Match an incoming tool result against the tail of history, walking
+    /// backwards just in time instead of maintaining a separate index of
+    /// answered tool calls. The walk only crosses tool calls and tool
+    /// results (future-proofing for concurrent calls, e.g. `tc tc tr tr`);
+    /// anything else — user text, assistant content, subscription events —
+    /// is a turn boundary: every call before it is settled, so the result
+    /// must be stale.
+    fn match_tool_result(&self, result_id: &str) -> ToolResultMatch {
+        for msg in self.history.borrow().iter().rev() {
+            match msg {
+                InfinityMessage::ToolCall { call, .. } => {
+                    if call.id == result_id {
+                        // Its result would have been seen before the call in
+                        // a backwards walk, so this call is unanswered.
+                        return ToolResultMatch::Unanswered;
+                    }
+                }
+                InfinityMessage::ToolResult { result, .. } => {
+                    if result.id == result_id {
+                        return ToolResultMatch::AlreadyAnswered;
+                    }
+                }
+                _ => return ToolResultMatch::NoPendingCall,
+            }
+        }
+        ToolResultMatch::NoPendingCall
+    }
+
     /// If the last history entry is an unanswered tool call, inject a
-    /// synthetic "interrupted" result and mark it complete.
+    /// synthetic "interrupted" result. (A tool call at the tail is unanswered
+    /// by construction: its result would have been appended after it.)
     fn interrupt_pending_tool_call(&self) {
         let last_call = self.history.borrow().last().and_then(|m| {
             if let InfinityMessage::ToolCall { call, .. } = m {
@@ -291,12 +309,7 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
                 None
             }
         });
-        if let Some(tool_call) = last_call
-            && !self
-                .processed_tool_calls
-                .borrow()
-                .contains(tool_call.id.as_str())
-        {
+        if let Some(tool_call) = last_call {
             tracing::info!("Tool call {} interrupted by incoming message", tool_call.id);
             self.interrupted_tool_calls
                 .borrow_mut()
@@ -312,7 +325,6 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
                 display_segments: None,
             };
             self.append_pending(synthetic_result, format!("{}-interrupted", tool_call.id));
-            self.mark_tool_call_complete(tool_call.id);
         }
     }
 
@@ -431,11 +443,6 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
         );
 
         self.history.borrow_mut().push(message.clone());
-        if let InfinityMessage::ToolResult { ref result, .. }
-        | InfinityMessage::SubscriptionEvent { ref result, .. } = message
-        {
-            self.mark_tool_call_complete(result.id.clone());
-        }
         self.pending_items.borrow_mut().push(PendingItem {
             message,
             message_id,
@@ -461,15 +468,6 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
         true
     }
 
-    fn mark_tool_call_complete(&self, call_id: String) {
-        self.processed_tool_calls
-            .borrow_mut()
-            .insert(call_id.clone());
-        self.pending_complete_tool_calls
-            .borrow_mut()
-            .insert(call_id);
-    }
-
     pub async fn sync(&self) -> Result<(), BoxError> {
         // `sync` only persists committed (`pending_items`) content. Any in-flight
         // turn must have been flushed or discarded before this point; otherwise a
@@ -480,33 +478,36 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
         );
 
         let pending_items = std::mem::take(&mut *self.pending_items.borrow_mut());
-        let pending_complete_tool_calls =
-            std::mem::take(&mut *self.pending_complete_tool_calls.borrow_mut());
-        if pending_items.is_empty() && pending_complete_tool_calls.is_empty() {
+        if pending_items.is_empty() {
             return Ok(());
         }
-        if !pending_items.is_empty() {
-            let msgs: Vec<(InfinityMessage, String)> = pending_items
-                .iter()
-                .map(|item| (item.message.clone(), item.message_id.clone()))
-                .collect();
-            self.conversation_store
-                .append_messages(&self.thread_id, msgs)
-                .await
-                .map_err(|e| Box::new(e) as BoxError)?;
-        }
-        let msg_ids: Vec<String> = pending_items.iter().map(|i| i.message_id.clone()).collect();
-        let tc_ids: Vec<String> = pending_complete_tool_calls.iter().cloned().collect();
+        let msgs: Vec<(InfinityMessage, String)> = pending_items
+            .iter()
+            .map(|item| (item.message.clone(), item.message_id.clone()))
+            .collect();
+        self.conversation_store
+            .append_messages(&self.thread_id, msgs)
+            .await
+            .map_err(|e| Box::new(e) as BoxError)?;
+        // Only inputs that are not naturally idempotent need durable dedup
+        // IDs: user text and subscription events (a redelivered subscription
+        // event would mint a fresh invocation and be appended again). Tool
+        // results are deduplicated against the history tail itself, and
+        // assistant/tool-call items only exist downstream of a deduped input.
+        let msg_ids: Vec<String> = pending_items
+            .iter()
+            .filter(|i| {
+                matches!(
+                    i.message,
+                    InfinityMessage::User { .. } | InfinityMessage::SubscriptionEvent { .. }
+                )
+            })
+            .map(|i| i.message_id.clone())
+            .collect();
         if !msg_ids.is_empty() {
             let _ = self
                 .state_store
                 .add_processed_message_ids(&self.thread_id, msg_ids)
-                .await;
-        }
-        if !tc_ids.is_empty() {
-            let _ = self
-                .state_store
-                .add_processed_tool_calls(&self.thread_id, tc_ids)
                 .await;
         }
         Ok(())
@@ -607,22 +608,28 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
     /// Returns an absolute store order (accounting for prior compaction offset
     /// and ancestor prefix) suitable for use as `spawn_order_override`.
     pub fn safe_spawn_point(&self) -> usize {
-        // TODO: when we support parallel tool calls, we may need to walk back across
-        // tool results if there is an unresolved tool call remaining in the group.
         let history = self.history.borrow();
-        let processed = self.processed_tool_calls.borrow();
-        let safe = history
-            .iter()
-            .enumerate()
-            .rev()
-            .find(|(_, msg)| {
-                if let InfinityMessage::ToolCall { call, .. } = msg {
-                    processed.contains(call.id.as_str())
-                } else {
-                    true
+        // Walk the trailing run of tool calls / tool results (future-proofing
+        // for concurrent calls, e.g. `tc tc tr tr`), tracking which calls
+        // have their result. The safe point cuts before the deepest
+        // unanswered call — excluding it and everything after it. Anything
+        // else (user text, assistant content, subscription events) ends the
+        // run: every call before it is settled.
+        let mut answered: HashSet<&str> = HashSet::new();
+        let mut safe = history.len();
+        for (i, msg) in history.iter().enumerate().rev() {
+            match msg {
+                InfinityMessage::ToolCall { call, .. } => {
+                    if !answered.contains(call.id.as_str()) {
+                        safe = i;
+                    }
                 }
-            })
-            .map_or(0, |(i, _)| i + 1); // +1: safe point is exclusive (after the last safe message)
+                InfinityMessage::ToolResult { result, .. } => {
+                    answered.insert(result.id.as_str());
+                }
+                _ => break,
+            }
+        }
         // Convert in-memory index to absolute store order by adding the offset
         // from any prior compaction. The -1 accounts for the compaction summary
         // message occupying slot 0 in the in-memory history.
@@ -1038,10 +1045,10 @@ where
     let infinity_msg = if let Some((tool_call_id, child_thread_id)) = subscription_event_meta {
         if let UserContent::ToolResult(result) = content {
             InfinityMessage::SubscriptionEvent {
-                result,
+                result: Box::new(result),
                 tool_call_id,
                 child_thread_id,
-                invocation: subscription_invocation,
+                invocation: subscription_invocation.map(Box::new),
             }
         } else {
             InfinityMessage::User { content }
@@ -1056,9 +1063,7 @@ where
         }
     };
 
-    let is_new = current_history
-        .handle_content(infinity_msg, message_id.clone())
-        .await?;
+    let is_new = current_history.handle_content(infinity_msg, message_id.clone())?;
 
     if !is_new {
         tracing::info!("Message was duplicate or ignored, skipping agent processing");
@@ -1462,7 +1467,7 @@ where
                                     },
                                     display_segments: None,
                                 };
-                                history.handle_content(tool_result, format!("{}-unknown-tool", call.id)).await?;
+                                history.handle_content(tool_result, format!("{}-unknown-tool", call.id))?;
                                 should_loop_back = true;
                                 continue;
                             } else if !tool_names.contains(call.function.name.as_str()) {
@@ -1478,7 +1483,7 @@ where
                                     },
                                     display_segments: None,
                                 };
-                                history.handle_content(tool_result, format!("{}-unknown-tool", call.id)).await?;
+                                history.handle_content(tool_result, format!("{}-unknown-tool", call.id))?;
                                 should_loop_back = true;
                                 continue;
                             }
@@ -1514,7 +1519,7 @@ where
                                         display_segments: None,
                                     },
                                     sync_id,
-                                ).await?;
+                                )?;
                                 should_loop_back = true;
                             } else {
                                 yield CompletionEvent::Action(CompletionAction::ExecuteToolCall {
@@ -2155,9 +2160,6 @@ mod tests {
             },
         ];
         let hm = make_history(&store, initial).await;
-        hm.processed_tool_calls
-            .borrow_mut()
-            .insert("tc-sub".to_owned());
 
         let input = tool_result_input(
             "thread-1",
@@ -2374,9 +2376,6 @@ mod tests {
             },
         ];
         let hm = make_history(&store, initial).await;
-        hm.processed_tool_calls
-            .borrow_mut()
-            .insert("tc-cmd".to_owned());
 
         let input = tool_result_input(
             "thread-1",

--- a/crates/infinity-agent-core/src/message.rs
+++ b/crates/infinity-agent-core/src/message.rs
@@ -199,9 +199,14 @@ pub enum InfinityMessage {
     },
     /// Synthetic subscription event injected into history. The display name is
     /// recomputed on replay from the original tool call in history.
+    ///
+    /// The payloads are boxed to keep this rare variant from inflating the
+    /// size of every `InfinityMessage` (histories store many of these enums
+    /// inline). `Box` is transparent to serde, so the wire format is
+    /// unchanged.
     #[serde(rename = "subscription_event")]
     SubscriptionEvent {
-        result: rig::message::ToolResult,
+        result: Box<rig::message::ToolResult>,
         /// The tool_call_id of the original subscription tool call.
         tool_call_id: String,
         /// Set when this is a thread report (used to build the display name).
@@ -212,7 +217,7 @@ pub enum InfinityMessage {
         /// the LLM, but replay only emits the subscription display event.
         /// `None` for backward-compat with old serialized histories.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        invocation: Option<rig::message::ToolCall>,
+        invocation: Option<Box<rig::message::ToolCall>>,
     },
 }
 
@@ -243,14 +248,24 @@ impl InfinityMessage {
                 if let Some(call) = invocation {
                     msgs.push(Message::Assistant {
                         id: None,
-                        content: OneOrMany::one(AssistantContent::ToolCall(call)),
+                        content: OneOrMany::one(AssistantContent::ToolCall(*call)),
                     });
                 }
                 msgs.push(Message::User {
-                    content: OneOrMany::one(UserContent::ToolResult(result)),
+                    content: OneOrMany::one(UserContent::ToolResult(*result)),
                 });
                 msgs
             }
+        }
+    }
+
+    /// The tool result carried by a `ToolResult` or `SubscriptionEvent`
+    /// message, if any.
+    pub fn tool_result(&self) -> Option<&rig::message::ToolResult> {
+        match self {
+            Self::ToolResult { result, .. } => Some(result),
+            Self::SubscriptionEvent { result, .. } => Some(result),
+            _ => None,
         }
     }
 

--- a/crates/infinity-agent-core/src/stores.rs
+++ b/crates/infinity-agent-core/src/stores.rs
@@ -377,8 +377,6 @@ pub struct ThreadState {
     #[serde(default)]
     pub processed_message_ids: HashSet<String>,
     #[serde(default)]
-    pub processed_tool_call_ids: HashSet<String>,
-    #[serde(default)]
     pub metadata: Option<serde_json::Value>,
     #[serde(default)]
     pub subscriptions: HashSet<String>,
@@ -390,8 +388,7 @@ pub struct ThreadState {
 /// subscription tracking in process memory.
 #[derive(Clone, Default)]
 pub struct InMemoryStateStore {
-    #[expect(clippy::type_complexity, reason = "shared state")]
-    processed_ids: Arc<Mutex<HashMap<String, (HashSet<String>, HashSet<String>)>>>,
+    processed_ids: Arc<Mutex<HashMap<String, HashSet<String>>>>,
     metadata: Arc<Mutex<HashMap<String, serde_json::Value>>>,
     subscriptions: Arc<Mutex<HashMap<String, HashSet<String>>>>,
     pending_user_choices: Arc<Mutex<HashMap<String, Vec<UserChoice>>>>,
@@ -411,10 +408,8 @@ impl InMemoryStateStore {
             .pending_user_choices
             .lock()
             .expect("bug: mutex poisoned");
-        let (msg_ids, tc_ids) = processed.get(thread_id).cloned().unwrap_or_default();
         ThreadState {
-            processed_message_ids: msg_ids,
-            processed_tool_call_ids: tc_ids,
+            processed_message_ids: processed.get(thread_id).cloned().unwrap_or_default(),
             metadata: metadata.get(thread_id).cloned(),
             subscriptions: subscriptions.get(thread_id).cloned().unwrap_or_default(),
             pending_user_choices: pending_user_choices
@@ -429,10 +424,7 @@ impl InMemoryStateStore {
         self.processed_ids
             .lock()
             .expect("bug: mutex poisoned")
-            .insert(
-                thread_id.to_owned(),
-                (state.processed_message_ids, state.processed_tool_call_ids),
-            );
+            .insert(thread_id.to_owned(), state.processed_message_ids);
         if let Some(meta) = state.metadata {
             self.metadata
                 .lock()
@@ -458,10 +450,7 @@ impl InMemoryStateStore {
 impl StateStore for InMemoryStateStore {
     type Error = InMemoryStoreError;
 
-    async fn get_processed_ids(
-        &self,
-        thread_id: &str,
-    ) -> Result<(HashSet<String>, HashSet<String>), Self::Error> {
+    async fn get_processed_ids(&self, thread_id: &str) -> Result<HashSet<String>, Self::Error> {
         let store = self.processed_ids.lock().expect("bug: mutex poisoned");
         Ok(store.get(thread_id).cloned().unwrap_or_default())
     }
@@ -475,22 +464,7 @@ impl StateStore for InMemoryStateStore {
         store
             .entry(thread_id.to_owned())
             .or_default()
-            .0
             .extend(message_ids);
-        Ok(())
-    }
-
-    async fn add_processed_tool_calls(
-        &self,
-        thread_id: &str,
-        tool_call_ids: Vec<String>,
-    ) -> Result<(), Self::Error> {
-        let mut store = self.processed_ids.lock().expect("bug: mutex poisoned");
-        store
-            .entry(thread_id.to_owned())
-            .or_default()
-            .1
-            .extend(tool_call_ids);
         Ok(())
     }
 

--- a/crates/infinity-agent-core/src/system/local/driver.rs
+++ b/crates/infinity-agent-core/src/system/local/driver.rs
@@ -1,6 +1,6 @@
 //! The per-thread driver loop used by local (resident) agent systems.
 //!
-//! One driver task owns one thread: it batches inputs from the thread's
+//! One driver owns one thread: it batches inputs from the thread's
 //! channel, runs [`Thread::step`]s, interrupts an in-flight completion when
 //! user text arrives, defers synthetic events while a tool call is pending,
 //! triggers auto-compaction, and idles out when there is nothing left to

--- a/crates/infinity-agent-core/src/system/local/router.rs
+++ b/crates/infinity-agent-core/src/system/local/router.rs
@@ -1,10 +1,14 @@
 //! The router: dispatches messages to per-thread drivers, spawning them on
 //! demand. This plus the [drivers](super::driver) is the "actor system" of a
-//! local agent system.
+//! local agent system. The router owns the driver futures directly (one
+//! `FuturesUnordered` pool rather than one spawned task per thread), so a
+//! driver's memory is fully released the moment it goes idle.
 
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use futures_util::StreamExt;
+use futures_util::stream::FuturesUnordered;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
@@ -224,7 +228,6 @@ where
 struct WorkerChannels<Sub> {
     input_tx: mpsc::UnboundedSender<(InputMessage, String)>,
     subscribe_tx: mpsc::UnboundedSender<(Sub, oneshot::Sender<()>)>,
-    handle: tokio::task::JoinHandle<()>,
 }
 
 enum RoutedMessage<Sub> {
@@ -249,11 +252,26 @@ async fn route_loop<C, S, H, O, F>(
 {
     let mut workers: HashMap<String, WorkerChannels<O::SubscribeRequest>> = HashMap::new();
     let mut subscribe_closed = false;
+    // The router owns the driver futures directly (instead of spawning each
+    // as its own task): a completed driver yields its thread ID and its
+    // memory — the future itself and its worker entry — is released
+    // immediately. With per-thread tasks, both would be retained until the
+    // thread's next message, which adds up across many idle threads.
+    let mut drivers = FuturesUnordered::new();
 
     loop {
         let msg: Option<RoutedMessage<O::SubscribeRequest>> = tokio::select! {
             biased;
             _ = shutdown.cancelled() => None,
+            exited = drivers.next(), if !drivers.is_empty() => {
+                let exited: String = exited.expect("bug: drivers is empty");
+                // Only remove the exited driver's own entry: if the thread
+                // already respawned, the new entry's channel is still open.
+                if workers.get(&exited).is_some_and(|w| w.input_tx.is_closed()) {
+                    workers.remove(&exited);
+                }
+                continue;
+            }
             msg = input_rx.recv() => msg.map(|(m, id)| RoutedMessage::Input(Box::new(m), id)),
             req = subscribe_rx.recv(), if !subscribe_closed => {
                 match req {
@@ -341,9 +359,9 @@ async fn route_loop<C, S, H, O, F>(
         let (worker_subscribe_tx, worker_subscribe_rx) = mpsc::unbounded_channel();
         let observer = make_observer(&thread_id);
 
-        let handle = tokio::task::spawn_local(rap_protocol::log_panic(
-            "thread_driver",
-            drive_thread(
+        drivers.push({
+            let thread_id = thread_id.clone();
+            let driver = drive_thread(
                 inner.clone(),
                 thread_id.clone(),
                 input_rx_worker,
@@ -351,8 +369,14 @@ async fn route_loop<C, S, H, O, F>(
                 observer,
                 active_threads.clone(),
                 lifecycle_tx.clone(),
-            ),
-        ));
+            );
+            async move {
+                // Contain a panicking driver to its own thread (the panic is
+                // logged); the router and the other drivers keep running.
+                rap_protocol::log_panic("thread_driver", driver).await;
+                thread_id
+            }
+        });
 
         match msg {
             RoutedMessage::Input(input, id) => {
@@ -367,28 +391,16 @@ async fn route_loop<C, S, H, O, F>(
             WorkerChannels {
                 input_tx,
                 subscribe_tx: worker_subscribe_tx,
-                handle,
             },
         );
     }
 
     // Wind down: dropping each driver's channels signals it to interrupt any
     // in-flight completion (which flushes pending history items to the store)
-    // and exit. Wait for every driver to finish so the embedding is not torn
-    // down underneath them.
-    let handles: Vec<(String, tokio::task::JoinHandle<()>)> = workers
-        .drain()
-        .map(|(thread_id, w)| (thread_id, w.handle))
-        .collect();
-    for (thread_id, handle) in handles {
-        if let Err(e) = handle.await {
-            if e.is_panic() {
-                tracing::error!("thread driver {thread_id} panicked during shutdown: {e}");
-            } else {
-                tracing::warn!("thread driver {thread_id} cancelled during shutdown: {e}");
-            }
-        }
-    }
+    // and exit. Drive every remaining driver to completion so the embedding
+    // is not torn down underneath them.
+    drop(workers);
+    while drivers.next().await.is_some() {}
 }
 #[cfg(test)]
 mod tests {

--- a/crates/infinity-agent-core/src/traits.rs
+++ b/crates/infinity-agent-core/src/traits.rs
@@ -160,27 +160,18 @@ pub trait ConversationStore: Send + Sync + Clone {
 pub trait StateStore: Send + Sync + Clone {
     type Error: std::error::Error + Send + Sync + 'static;
 
+    /// Durably deduplicated message IDs for this thread. Only inputs that are
+    /// not naturally idempotent are tracked (user text and subscription
+    /// events); tool results are deduplicated against history itself.
     async fn get_processed_ids(
         &self,
         thread_id: &str,
-    ) -> Result<
-        (
-            std::collections::HashSet<String>,
-            std::collections::HashSet<String>,
-        ),
-        Self::Error,
-    >;
+    ) -> Result<std::collections::HashSet<String>, Self::Error>;
 
     async fn add_processed_message_ids(
         &self,
         thread_id: &str,
         message_ids: Vec<String>,
-    ) -> Result<(), Self::Error>;
-
-    async fn add_processed_tool_calls(
-        &self,
-        thread_id: &str,
-        tool_call_ids: Vec<String>,
     ) -> Result<(), Self::Error>;
 
     async fn get_metadata(

--- a/crates/infinity-agent-lambda/src/state_store.rs
+++ b/crates/infinity-agent-lambda/src/state_store.rs
@@ -29,10 +29,7 @@ impl DynamoDbStateStore {
 impl StateStore for DynamoDbStateStore {
     type Error = DynamoError;
 
-    async fn get_processed_ids(
-        &self,
-        thread_id: &str,
-    ) -> Result<(HashSet<String>, HashSet<String>), DynamoError> {
+    async fn get_processed_ids(&self, thread_id: &str) -> Result<HashSet<String>, DynamoError> {
         let result = self
             .client
             .get_item()
@@ -49,15 +46,9 @@ impl StateStore for DynamoDbStateStore {
                 } else {
                     HashSet::new()
                 };
-            let processed_tools =
-                if let Some(AttributeValue::Ss(ids)) = item.get("processed_tool_calls") {
-                    ids.iter().cloned().collect()
-                } else {
-                    HashSet::new()
-                };
-            Ok((processed_ids, processed_tools))
+            Ok(processed_ids)
         } else {
-            Ok((HashSet::new(), HashSet::new()))
+            Ok(HashSet::new())
         }
     }
 
@@ -78,26 +69,6 @@ impl StateStore for DynamoDbStateStore {
             .send()
             .await
             .map_err(|e| DynamoError(format!("Failed to add processed message IDs: {}", e)))?;
-        Ok(())
-    }
-
-    async fn add_processed_tool_calls(
-        &self,
-        thread_id: &str,
-        tool_call_ids: Vec<String>,
-    ) -> Result<(), DynamoError> {
-        if tool_call_ids.is_empty() {
-            return Ok(());
-        }
-        self.client
-            .update_item()
-            .table_name(&self.table_name)
-            .key("session", AttributeValue::S(thread_id.to_owned()))
-            .update_expression("ADD processed_tool_calls :ids")
-            .expression_attribute_values(":ids", AttributeValue::Ss(tool_call_ids))
-            .send()
-            .await
-            .map_err(|e| DynamoError(format!("Failed to add processed tool calls: {}", e)))?;
         Ok(())
     }
 

--- a/crates/infinity-daemon/src/memory_store.rs
+++ b/crates/infinity-daemon/src/memory_store.rs
@@ -1052,10 +1052,7 @@ impl PersistentStateStore {
 impl StateStore for PersistentStateStore {
     type Error = MemoryError;
 
-    async fn get_processed_ids(
-        &self,
-        thread_id: &str,
-    ) -> Result<(HashSet<String>, HashSet<String>), MemoryError> {
+    async fn get_processed_ids(&self, thread_id: &str) -> Result<HashSet<String>, MemoryError> {
         self.ensure_loaded(thread_id);
         Ok(self.core.get_processed_ids(thread_id).await?)
     }
@@ -1068,19 +1065,6 @@ impl StateStore for PersistentStateStore {
         self.ensure_loaded(thread_id);
         self.core
             .add_processed_message_ids(thread_id, message_ids)
-            .await?;
-        self.save_key(thread_id);
-        Ok(())
-    }
-
-    async fn add_processed_tool_calls(
-        &self,
-        thread_id: &str,
-        tool_call_ids: Vec<String>,
-    ) -> Result<(), MemoryError> {
-        self.ensure_loaded(thread_id);
-        self.core
-            .add_processed_tool_calls(thread_id, tool_call_ids)
             .await?;
         self.save_key(thread_id);
         Ok(())

--- a/docs/docs/infinity-runtime/low-level/history-manager.md
+++ b/docs/docs/infinity-runtime/low-level/history-manager.md
@@ -19,7 +19,7 @@ Construction restores the thread's world from durable storage:
 
 - The **ancestor chain** is loaded via `ConversationStore::get_ancestor_chain`, identifying the root thread and every parent between it and this thread.
 - The **history** is loaded via `load_history_with_ancestors`, which reconstructs a child thread's inherited context: ancestor messages up to each spawn point, with the most recent compaction summary (from this thread or any ancestor) substituted for everything it covers. A freshly spawned child thread therefore sees its parent's conversation up to the moment of the spawn, and compaction transparently shortens what gets loaded.
-- The **deduplication sets**, processed message IDs and processed tool-call IDs, come from `StateStore::get_processed_ids`, along with per-conversation metadata.
+- The **deduplication set** of processed message IDs comes from `StateStore::get_processed_ids`, along with per-conversation metadata.
 
 Because everything is restored on load, an agent's full state can be rebuilt in any process, at any time, from the two stores. This is the property that makes the runtime serverless-capable.
 
@@ -38,9 +38,9 @@ The split exists because a streaming turn can fail or be interrupted halfway. At
 history.sync().await?;
 ```
 
-`sync` writes everything committed since the last sync: pending messages via `ConversationStore::append_messages`, and their IDs (plus completed tool-call IDs) via the `StateStore`. It asserts that the turn buffer is empty; calling it with un-flushed turn content is a bug, because that content would be silently lost.
+`sync` writes everything committed since the last sync: pending messages via `ConversationStore::append_messages`, and the IDs that need durable deduplication via the `StateStore`. It asserts that the turn buffer is empty; calling it with un-flushed turn content is a bug, because that content would be silently lost.
 
-The persisted IDs are what make redelivery safe. `handle_content(message, message_id)` is the single entry point for appending input to history, and it consults the processed-ID set first: a redelivered message (same `message_id`) is skipped. Completions are deduplicated the same way via their completion IDs. Because the IDs are persisted in the same `sync()` that persists the messages, a crash between processing and persistence reprocesses the message rather than duplicating it.
+The persisted IDs are what make redelivery safe, and only inputs that are not naturally idempotent need them: user text and subscription events (a redelivered subscription event would mint a fresh injected invocation and be appended again). `handle_content(message, message_id)` is the single entry point for appending input to history: it consults the processed-ID set first, and a redelivered message (same `message_id`) is skipped. Tool results don't need durable IDs at all — they are deduplicated against the history tail itself, by walking back across the trailing tool calls and results: a result whose call is already answered (or has no live call) is discarded. Because the IDs are persisted in the same `sync()` that persists the messages, a crash between processing and persistence reprocesses the message rather than duplicating it.
 
 The loop's core ordering guarantee is built on this call: **a tool call is dispatched only after the turn that produced it has been synced.** If the process dies after dispatch, the persisted history already contains the tool call, so the eventual result message has something to attach to. The high-level API's step enforces this ordering (sync, then dispatch); if you drive [`execute_action`](./completion-loop.md) yourself, you must preserve it.
 

--- a/docs/src/components/MemoryChart.tsx
+++ b/docs/src/components/MemoryChart.tsx
@@ -4,10 +4,10 @@ import React, { useEffect, useRef, useState } from "react";
  * MemoryChart: measured agents-per-memory curve for the local runtime.
  *
  * Data source: `crates/infinity-agent-core/examples/agent_scale.rs`, run with
- * AGENTS=50000 TURNS=20 WAVE=2500 on an AMD EPYC 9R14 (single thread,
+ * AGENTS=80000 TURNS=20 WAVE=4000 on an AMD EPYC 9R14 (single thread,
  * in-memory stores, scripted in-process model). Each agent runs 20 synthetic
  * turns; every turn is two completion rounds and one asynchronous tool round
- * trip through the input queue. RSS is sampled after each wave of 2,500
+ * trip through the input queue. RSS is sampled after each wave of 4,000
  * agents finishes and goes idle.
  *
  * Plotted inverted (memory on x, agents on y): how many resident agents fit
@@ -17,27 +17,27 @@ import React, { useEffect, useRef, useState } from "react";
 // (rss_bytes, agents) pairs from the benchmark run (AMD EPYC 9R14, 2026-08).
 // Regenerate with the command in the component doc comment.
 const DATA: [number, number][] = [
-  [5353472, 0],
-  [580362240, 2500],
-  [965492736, 5000],
-  [1352081408, 7500],
-  [1736101888, 10000],
-  [2120110080, 12500],
-  [2510336000, 15000],
-  [2894336000, 17500],
-  [3278622720, 20000],
-  [3663183872, 22500],
-  [4046798848, 25000],
-  [4430938112, 27500],
-  [4826189824, 30000],
-  [5210464256, 32500],
-  [5594009600, 35000],
-  [5977997312, 37500],
-  [6360985600, 40000],
-  [6745284608, 42500],
-  [7129370624, 45000],
-  [7513305088, 47500],
-  [7896977408, 50000],
+  [5296128, 0],
+  [727326720, 4000],
+  [1157394432, 8000],
+  [1586438144, 12000],
+  [2017300480, 16000],
+  [2445373440, 20000],
+  [2873470976, 24000],
+  [3302096896, 28000],
+  [3737341952, 32000],
+  [4165697536, 36000],
+  [4593598464, 40000],
+  [5021593600, 44000],
+  [5449093120, 48000],
+  [5877960704, 52000],
+  [6304645120, 56000],
+  [6749179904, 60000],
+  [7177465856, 64000],
+  [7605604352, 68000],
+  [8033284096, 72000],
+  [8461262848, 76000],
+  [8889257984, 80000],
 ];
 
 const GB = 1e9;
@@ -49,8 +49,8 @@ const MARGIN = { top: 24, right: 96, bottom: 52, left: 76 };
 const PLOT_W = W - MARGIN.left - MARGIN.right;
 const PLOT_H = H - MARGIN.top - MARGIN.bottom;
 
-const X_MAX_GB = 8.6;
-const Y_MAX = 52000;
+const X_MAX_GB = 9.6;
+const Y_MAX = 84000;
 
 const C_LINE = "var(--ifm-color-primary)";
 const C_AXIS = "var(--ifm-color-emphasis-400)";
@@ -93,7 +93,7 @@ export default function MemoryChart({
   const perAgentKb =
     (DATA[DATA.length - 1][0] - DATA[0][0]) / lastAgents / 1024;
 
-  const yTicks = [0, 10000, 20000, 30000, 40000, 50000];
+  const yTicks = [0, 20000, 40000, 60000, 80000];
   const xTicks = [0, 2, 4, 6, 8];
 
   return (
@@ -265,7 +265,7 @@ export default function MemoryChart({
         }}
       >
         Measured: idle resident agents after 20 tool-calling turns each
-        (2,000,000 completions total), single thread, in-memory stores.{" "}
+        (3,200,000 completions total), single thread, in-memory stores.{" "}
         <a href="https://github.com/hydro-project/infinity/blob/main/crates/infinity-agent-core/examples/agent_scale.rs">
           Benchmark source
         </a>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -120,7 +120,7 @@ export default function Home(): React.JSX.Element {
   return (
     <Layout
       title="Infinity"
-      description="An open-source Rust framework for building agents, on a runtime efficient enough to fit fifty thousand of them in the memory of a Raspberry Pi."
+      description="An open-source Rust framework for building agents, on a runtime efficient enough to fit seventy thousand of them in the memory of a Raspberry Pi."
     >
       <main className="landing-page">
         <section className="hero-section">
@@ -129,7 +129,7 @@ export default function Home(): React.JSX.Element {
             <p className="hero-tagline">
               An open-source <b>Rust framework for building agents</b>, on a
               runtime efficient enough to fit{" "}
-              <b>fifty thousand of them in the memory of a Raspberry Pi</b>.
+              <b>seventy thousand of them in the memory of a Raspberry Pi</b>.
             </p>
             <p className="hero-subline">
               Infinity does for agents what async did for threads. Instead of
@@ -161,15 +161,15 @@ export default function Home(): React.JSX.Element {
           <Chapter
             id="scale"
             kicker="Scale"
-            title="Fifty thousand agents on a Raspberry Pi"
+            title="Seventy thousand agents on a Raspberry Pi"
             prose={
               <>
                 <p>
                   In Infinity, an idle agent is pure data: between turns, an
                   agent is just its conversation history, with no task, no
                   stack, and no open connection. After twenty tool-calling
-                  turns, an agent occupies about 154 KB, so fifty thousand of
-                  them fit in under 8 GB of RAM.
+                  turns, an agent occupies about 108 KB, so seventy thousand of
+                  them fit in 8 GB of RAM.
                 </p>
                 <p>
                   Agents spend most of their lives waiting: builds run for


### PR DESCRIPTION
Optimizes per-agent resident memory for the `agent_scale` benchmark added by the parent commit, in three independent pieces:

## Router owns driver futures directly (no `spawn_local` per driver)

* `route_loop` now drives all thread drivers through one `FuturesUnordered` pool instead of spawning each as its own `LocalSet` task. When a driver goes idle, its future yields its thread ID and the router immediately drops both the future's memory and the worker entry (input/subscribe channels).
* Previously a finished driver's `JoinHandle`, task allocation, and channel blocks were retained in the `workers` map until the thread's *next* message — ~13 KB per idle agent.
* Panic isolation is preserved (each pooled future is still wrapped in `rap_protocol::log_panic`); shutdown wind-down now just drains the pool.

## `InfinityMessage::SubscriptionEvent` payloads boxed

* Boxed `result` and `invocation` in the rare `SubscriptionEvent` variant, shrinking `size_of::<InfinityMessage>()` from 352 → 184 bytes. Every stored history message paid for the fattest variant inline. `Box` is serde-transparent, so the wire/persisted format is unchanged.
* Added `InfinityMessage::tool_result()` helper (the boxed field made cross-variant or-patterns impossible).
* (Boxing only `invocation` was measured and rejected: it *grows* the enum to 200 bytes because `SubscriptionEvent` with an inline result becomes the largest variant again.)

## Tool-call dedup derived from history instead of a durable index (BREAKING)

* `HistoryManager` no longer maintains `processed_tool_calls` / `pending_complete_tool_calls`. Incoming tool results are deduplicated by walking the history tail just in time: scan back across trailing tool calls/results (future-proof for concurrent calls, e.g. `tc tc tr tr`), accept on a matching unanswered call, reject as duplicate on a matching result, and discard as stale on any other message (user text, assistant content, subscription events — all turn boundaries, since a subscription event can only be injected once pending calls are settled).
* `safe_spawn_point` uses the same walk (tracking answered calls) instead of the set.
* Durable message-ID dedup is now limited to inputs that are not naturally idempotent: user text and subscription events (a redelivered subscription event would mint a fresh injected invocation). Tool results and assistant/tool-call items no longer persist IDs.
* **BREAKING**: `StateStore::get_processed_ids` now returns a single `HashSet<String>` and `add_processed_tool_calls` is removed — updated `InMemoryStateStore`, the daemon's `PersistentStateStore`, and the Lambda `DynamoDbStateStore` (old DynamoDB `processed_tool_calls` attributes are simply ignored). `ThreadState` keeps its `processed_tool_call_ids` field so old daemon snapshots still deserialize.

## Benchmark & docs

* `agent_scale` example now drains lifecycle notifications per wave (like a real embedding), so they aren't counted as per-agent memory.
* Landing page: refreshed `MemoryChart` data from a post-optimization 50k-agent run (6.08 GB vs 7.90 GB before; 118.8 KB/agent at that point, ~107 KB/agent after the dedup changes) and updated the copy; updated the history-manager doc for the new dedup model.
* Note: an extended 80k-agent benchmark run was in flight to measure the exact 8 GB crossing (~72k agents projected); `MemoryChart` data and copy may deserve a refresh from that run. Also left open: making the per-message dedup ID in `ConversationStore::append_messages` optional (user/subscription messages only), which needs a decision about the Lambda DSQL `message_id NOT NULL` column and daemon session-file compat.

All workspace tests pass (`cargo test --workspace`), clippy clean.