### PR TITLE
ci: install jj via taiki-e/install-action instead of cargo install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,9 @@ jobs:
       - uses: ./.github/actions/use-sccache
 
       - name: Install jj
-        run: cargo install --locked --bin jj jj-cli
+        uses: taiki-e/install-action@0758d235715de2f3551eacc980d9ae8fce9342c3 # v2
+        with:
+          tool: jj-cli
 
       - name: Run tests
         run: cargo test --all-targets


### PR DESCRIPTION
Replace the `cargo install --locked --bin jj jj-cli` step in the test job of
.github/workflows/ci.yml with taiki-e/install-action (tool: jj-cli), pinned to
the full SHA of the v2 tag per the repo's action-pinning convention. jj-cli is
not in install-action's built-in manifests, so it is installed via the
cargo-binstall fallback, fetching prebuilt binaries instead of compiling from
source, which speeds up CI.