### PR TITLE
refactor!: introduce typed ThreadId for RAP group ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4862,6 +4862,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "strkind",
  "tracing",
 ]
 
@@ -6294,6 +6295,15 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
  "unicode-properties",
+]
+
+[[package]]
+name = "strkind"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb03d2aeddfec2029e22a61e21bb9c2b4b5ab5dc0e52302ee2f656f8e20176d"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "default-tls", "multipart", "stream"] }
 rhai = { version = "1", features = ["no_optimize"] }
+strkind = "0.0.1"
 
 # AWS crates
 aws-sdk-dynamodb = { version = "1", default-features = false }

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -426,6 +426,216 @@ Used by:
 License: Apache License 2.0
 
 Used by:
+  strkind 0.0.1
+
+--------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Hydro Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+================================================================================
+License: Apache License 2.0
+
+Used by:
   as-any 0.3.2
   cmov 0.5.3
   ctutils 0.4.2
@@ -639,241 +849,6 @@ Used by:
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-================================================================================
-License: Apache License 2.0
-
-Used by:
-  linux-raw-sys 0.12.1
-  linux-raw-sys 0.4.15
-  rustix 0.38.44
-  rustix 1.1.4
-  wasi 0.11.1+wasi-snapshot-preview1
-  wasip2 1.0.3+wasi-0.2.9
-  wit-bindgen 0.51.0
-  wit-bindgen 0.57.1
-
---------------------------------------------------------------------------------
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
---- LLVM Exceptions to the Apache 2.0 License ----
-
-As an exception, if, as a result of your compiling your source code, portions
-of this Software are embedded into an Object form of such source code, you
-may redistribute such embedded portions in such Object form without complying
-with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
-
-In addition, if you combine or link compiled forms of this Software with
-software that is licensed under the GPLv2 ("Combined Software") and if a
-court of competent jurisdiction determines that the patent provision (Section
-3), the indemnity provision (Section 9) or other Section of the License
-conflicts with the conditions of the GPLv2, you may retroactively and
-prospectively choose to deem waived or otherwise exclude such Section(s) of
-the License, but only in their entirety and only with respect to the Combined
-Software.
-
 
 ================================================================================
 License: Apache License 2.0
@@ -9258,68 +9233,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 License: BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License
 
 Used by:
-  encoding_rs 0.8.35
-
---------------------------------------------------------------------------------
-// Copyright © WHATWG (Apple, Google, Mozilla, Microsoft).
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-/// The PUA code points special-cased in the GB18030 encoder.
-pub(crate) static GB18030_2022_OVERRIDE_PUA: [u16; 18] = [
-    0xE78D, 0xE78E, 0xE78F, 0xE790, 0xE791, 0xE792, 0xE793, 0xE794, 0xE795, 0xE796, 0xE81E, 0xE826,
-    0xE82B, 0xE82C, 0xE832, 0xE843, 0xE854, 0xE864,
-];
-
-/// The bytes corresponding to the PUA code points special-cased in the GB18030 encoder.
-pub(crate) static GB18030_2022_OVERRIDE_BYTES: [[u8; 2]; 18] = [
-    [0xA6, 0xD9],
-    [0xA6, 0xDA],
-    [0xA6, 0xDB],
-    [0xA6, 0xDC],
-    [0xA6, 0xDD],
-    [0xA6, 0xDE],
-    [0xA6, 0xDF],
-    [0xA6, 0xEC],
-    [0xA6, 0xED],
-    [0xA6, 0xF3],
-    [0xFE, 0x59],
-    [0xFE, 0x61],
-    [0xFE, 0x66],
-    [0xFE, 0x67],
-    [0xFE, 0x6D],
-    [0xFE, 0x7E],
-    [0xFE, 0x90],
-    [0xFE, 0xA0],
-];
-
-================================================================================
-License: BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License
-
-Used by:
   matchit 0.8.4
 
 --------------------------------------------------------------------------------
@@ -9766,68 +9679,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-================================================================================
-License: MIT License
-
-Used by:
-  schemars 1.2.1
-
---------------------------------------------------------------------------------
-#![allow(clippy::all)]
-use crate::_alloc_prelude::*;
-// Copied from regex_syntax crate to avoid pulling in the whole crate just for a utility function
-// https://github.com/rust-lang/regex/blob/431c4e4867e1eb33eb39b23ed47c9934b2672f8f/regex-syntax/src/lib.rs
-//
-// Copyright (c) 2014 The Rust Project Developers
-//
-// Permission is hereby granted, free of charge, to any
-// person obtaining a copy of this software and associated
-// documentation files (the "Software"), to deal in the
-// Software without restriction, including without
-// limitation the rights to use, copy, modify, merge,
-// publish, distribute, sublicense, and/or sell copies of
-// the Software, and to permit persons to whom the Software
-// is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice
-// shall be included in all copies or substantial portions
-// of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-// DEALINGS IN THE SOFTWARE.
-
-pub fn escape(text: &str) -> String {
-    let mut quoted = String::new();
-    escape_into(text, &mut quoted);
-    quoted
-}
-
-fn escape_into(text: &str, buf: &mut String) {
-    buf.reserve(text.len());
-    for c in text.chars() {
-        if is_meta_character(c) {
-            buf.push('\\');
-        }
-        buf.push(c);
-    }
-}
-
-fn is_meta_character(c: char) -> bool {
-    match c {
-        '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$'
-        | '#' | '&' | '-' | '~' => true,
-        _ => false,
-    }
-}
-
 ================================================================================
 License: MIT License
 
@@ -11262,35 +11113,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-================================================================================
-License: MIT License
-
-Used by:
-  tracing-core 0.1.36
-
---------------------------------------------------------------------------------
-The MIT License (MIT)
-
-Copyright (c) 2014 Mathijs van de Nes
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 ================================================================================
 License: MIT License
 

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -854,6 +854,241 @@ Used by:
 License: Apache License 2.0
 
 Used by:
+  linux-raw-sys 0.12.1
+  linux-raw-sys 0.4.15
+  rustix 0.38.44
+  rustix 1.1.4
+  wasi 0.11.1+wasi-snapshot-preview1
+  wasip2 1.0.3+wasi-0.2.9
+  wit-bindgen 0.51.0
+  wit-bindgen 0.57.1
+
+--------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+
+================================================================================
+License: Apache License 2.0
+
+Used by:
   windows-core 0.62.2
   windows-implement 0.60.2
   windows-interface 0.59.3
@@ -9233,6 +9468,68 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 License: BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License
 
 Used by:
+  encoding_rs 0.8.35
+
+--------------------------------------------------------------------------------
+// Copyright © WHATWG (Apple, Google, Mozilla, Microsoft).
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/// The PUA code points special-cased in the GB18030 encoder.
+pub(crate) static GB18030_2022_OVERRIDE_PUA: [u16; 18] = [
+    0xE78D, 0xE78E, 0xE78F, 0xE790, 0xE791, 0xE792, 0xE793, 0xE794, 0xE795, 0xE796, 0xE81E, 0xE826,
+    0xE82B, 0xE82C, 0xE832, 0xE843, 0xE854, 0xE864,
+];
+
+/// The bytes corresponding to the PUA code points special-cased in the GB18030 encoder.
+pub(crate) static GB18030_2022_OVERRIDE_BYTES: [[u8; 2]; 18] = [
+    [0xA6, 0xD9],
+    [0xA6, 0xDA],
+    [0xA6, 0xDB],
+    [0xA6, 0xDC],
+    [0xA6, 0xDD],
+    [0xA6, 0xDE],
+    [0xA6, 0xDF],
+    [0xA6, 0xEC],
+    [0xA6, 0xED],
+    [0xA6, 0xF3],
+    [0xFE, 0x59],
+    [0xFE, 0x61],
+    [0xFE, 0x66],
+    [0xFE, 0x67],
+    [0xFE, 0x6D],
+    [0xFE, 0x7E],
+    [0xFE, 0x90],
+    [0xFE, 0xA0],
+];
+
+================================================================================
+License: BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License
+
+Used by:
   matchit 0.8.4
 
 --------------------------------------------------------------------------------
@@ -9679,6 +9976,68 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+================================================================================
+License: MIT License
+
+Used by:
+  schemars 1.2.1
+
+--------------------------------------------------------------------------------
+#![allow(clippy::all)]
+use crate::_alloc_prelude::*;
+// Copied from regex_syntax crate to avoid pulling in the whole crate just for a utility function
+// https://github.com/rust-lang/regex/blob/431c4e4867e1eb33eb39b23ed47c9934b2672f8f/regex-syntax/src/lib.rs
+//
+// Copyright (c) 2014 The Rust Project Developers
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+pub fn escape(text: &str) -> String {
+    let mut quoted = String::new();
+    escape_into(text, &mut quoted);
+    quoted
+}
+
+fn escape_into(text: &str, buf: &mut String) {
+    buf.reserve(text.len());
+    for c in text.chars() {
+        if is_meta_character(c) {
+            buf.push('\\');
+        }
+        buf.push(c);
+    }
+}
+
+fn is_meta_character(c: char) -> bool {
+    match c {
+        '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$'
+        | '#' | '&' | '-' | '~' => true,
+        _ => false,
+    }
+}
+
 ================================================================================
 License: MIT License
 
@@ -11113,6 +11472,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+================================================================================
+License: MIT License
+
+Used by:
+  tracing-core 0.1.36
+
+--------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014 Mathijs van de Nes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 ================================================================================
 License: MIT License
 

--- a/crates/infinity-agent-core/examples/agent_scale.rs
+++ b/crates/infinity-agent-core/examples/agent_scale.rs
@@ -32,6 +32,7 @@ use infinity_provider_protocol::message::{
     Message, ToolCall, ToolResult, ToolResultContent, UserContent,
 };
 
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::message::{InputMessage, InputMessageContent};
 use infinity_agent_core::stores::{InMemoryConversationStore, InMemoryStateStore};
 use infinity_agent_core::system::local::ChannelSender;
@@ -156,13 +157,13 @@ struct CountObserver {
 impl ThreadObserver for CountObserver {
     type SubscribeRequest = ();
 
-    fn on_event(&self, _thread_id: &str, event: &AgentEvent) {
+    fn on_event(&self, _thread_id: &ThreadId, event: &AgentEvent) {
         if matches!(event, AgentEvent::CompletionFinished { .. }) {
             self.finished.set(self.finished.get() + 1);
         }
     }
 
-    fn on_subscribe(&self, _thread_id: &str, _request: (), _snapshot: ReplaySnapshot) {}
+    fn on_subscribe(&self, _thread_id: &ThreadId, _request: (), _snapshot: ReplaySnapshot) {}
 }
 
 // ── Measurement helpers ──
@@ -204,7 +205,7 @@ fn user_text(thread_id: &str, turn: usize) -> InputMessage {
             "Turn {turn}: re-run the affected tests for {thread_id} and summarize any failures \
              along with the modules they belong to."
         ))),
-        group_id: thread_id.to_owned(),
+        group_id: thread_id.into(),
         metadata: None,
         synthetic: None,
         display_as: None,

--- a/crates/infinity-agent-core/examples/agent_scale.rs
+++ b/crates/infinity-agent-core/examples/agent_scale.rs
@@ -157,13 +157,13 @@ struct CountObserver {
 impl ThreadObserver for CountObserver {
     type SubscribeRequest = ();
 
-    fn on_event(&self, _thread_id: &ThreadId, event: &AgentEvent) {
+    fn on_event(&self, _thread_id: &ThreadId<str>, event: &AgentEvent) {
         if matches!(event, AgentEvent::CompletionFinished { .. }) {
             self.finished.set(self.finished.get() + 1);
         }
     }
 
-    fn on_subscribe(&self, _thread_id: &ThreadId, _request: (), _snapshot: ReplaySnapshot) {}
+    fn on_subscribe(&self, _thread_id: &ThreadId<str>, _request: (), _snapshot: ReplaySnapshot) {}
 }
 
 // ── Measurement helpers ──

--- a/crates/infinity-agent-core/src/event_processor.rs
+++ b/crates/infinity-agent-core/src/event_processor.rs
@@ -1986,11 +1986,11 @@ mod tests {
     async fn closed_thread_ignores() {
         let store = InMemoryConversationStore::new();
         store
-            .ensure_root_thread(&"thread-1".into())
+            .ensure_root_thread(ThreadId::from_ref("thread-1"))
             .await
             .expect("testing");
         store
-            .close_thread(&"thread-1".into())
+            .close_thread(ThreadId::from_ref("thread-1"))
             .await
             .expect("testing");
         let hm = make_history(&store, vec![]).await;

--- a/crates/infinity-agent-core/src/event_processor.rs
+++ b/crates/infinity-agent-core/src/event_processor.rs
@@ -9,6 +9,7 @@ use infinity_provider_protocol::{
     CompletionRequest, StreamChunk, ToolCallDeltaContent, ToolDefinition,
     message::{AssistantContent, Message, ToolResult, ToolResultContent, UserContent},
 };
+use rap_protocol::ThreadId;
 use serde::Serialize;
 use tracing;
 
@@ -140,9 +141,9 @@ enum ToolResultMatch {
 pub struct HistoryManager<C: ConversationStore, S: StateStore> {
     conversation_store: C,
     state_store: S,
-    pub thread_id: String,
-    pub root_thread_id: String,
-    ancestor_chain: Vec<String>,
+    pub thread_id: ThreadId,
+    pub root_thread_id: ThreadId,
+    ancestor_chain: Vec<ThreadId>,
     pub history: RefCell<Vec<InfinityMessage>>,
     processed_message_ids: RefCell<HashSet<String>>,
     metadata: RefCell<Option<serde_json::Value>>,
@@ -170,11 +171,11 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
     pub async fn new_with_history(
         conversation_store: C,
         state_store: S,
-        thread_id: String,
+        thread_id: ThreadId,
     ) -> Result<Self, BoxError> {
         let _ = conversation_store.ensure_root_thread(&thread_id).await;
 
-        let ancestor_chain: Vec<String> = conversation_store
+        let ancestor_chain: Vec<ThreadId> = conversation_store
             .get_ancestor_chain(&thread_id)
             .await
             .map(|links| links.iter().map(|(tid, _)| tid.clone()).collect())
@@ -541,7 +542,7 @@ impl<C: ConversationStore, S: StateStore> HistoryManager<C, S> {
 
     /// Returns the full thread stack: `[root, ..ancestors, current_thread]`.
     /// For the root thread this is just the root thread ID.
-    pub fn get_thread_stack(&self) -> Vec<String> {
+    pub fn get_thread_stack(&self) -> Vec<ThreadId> {
         let mut stack = self.ancestor_chain.clone();
         stack.push(self.thread_id.clone());
         stack
@@ -820,7 +821,7 @@ where
 
     // Handle synthetic tool results (subscription events / thread reports)
     // Capture metadata for SubscriptionEvent variant before synthetic_kind is consumed.
-    let subscription_event_meta: Option<(String, Option<String>)> =
+    let subscription_event_meta: Option<(String, Option<ThreadId>)> =
         input_msg.synthetic.as_ref().and_then(|s| {
             if s.is_thread_report() || s.is_associative() || s.is_parent_message() {
                 let child_id = if let SyntheticKind::Tagged(TaggedSyntheticKind::ThreadReport {
@@ -1183,7 +1184,7 @@ pub fn run_completion<'a: 'b, 'b, P, C, S, M>(
     tools: &'a [ToolDefinition],
     tool_registry: &'a HashMap<String, &'a dyn Tool<M>>,
     tool_context: &'a ToolContext<M>,
-    group_id: &'a str,
+    group_id: &'a ThreadId,
     message_id: &'a str,
     extra_system_prompt: Option<&'a str>,
     cancel_rx: tokio::sync::oneshot::Receiver<()>,
@@ -1683,7 +1684,7 @@ mod tests {
         let hm = HistoryManager::new_with_history(
             store.clone(),
             InMemoryStateStore::new(),
-            "thread-1".to_owned(),
+            "thread-1".into(),
         )
         .await
         .expect("create history manager");
@@ -1697,7 +1698,7 @@ mod tests {
     fn user_text_msg(group_id: &str, text: &str) -> InputMessage {
         InputMessage {
             content: InputMessageContent::User(UserContent::text(text)),
-            group_id: group_id.to_owned(),
+            group_id: group_id.into(),
             metadata: None,
             synthetic: None,
             display_as: None,
@@ -1734,7 +1735,7 @@ mod tests {
                     },
                 )],
             })),
-            group_id: group_id.to_owned(),
+            group_id: group_id.into(),
             metadata: None,
             synthetic,
             display_as: None,
@@ -1984,8 +1985,14 @@ mod tests {
     #[tokio::test]
     async fn closed_thread_ignores() {
         let store = InMemoryConversationStore::new();
-        store.ensure_root_thread("thread-1").await.expect("testing");
-        store.close_thread("thread-1").await.expect("testing");
+        store
+            .ensure_root_thread(&"thread-1".into())
+            .await
+            .expect("testing");
+        store
+            .close_thread(&"thread-1".into())
+            .await
+            .expect("testing");
         let hm = make_history(&store, vec![]).await;
 
         let result = prepare_input(
@@ -2014,7 +2021,7 @@ mod tests {
                 call_id: None,
                 auth_url: "https://example.com/auth".to_owned(),
             }),
-            group_id: "thread-1".to_owned(),
+            group_id: "thread-1".into(),
             metadata: None,
             synthetic: None,
             display_as: None,
@@ -2143,7 +2150,7 @@ mod tests {
             "thread report data",
             Some(SyntheticKind::Tagged(TaggedSyntheticKind::ThreadReport {
                 tool_call_id: "tc-sub".to_owned(),
-                child_thread_id: "thread-1".to_owned(),
+                child_thread_id: "thread-1".into(),
             })),
         );
 
@@ -2181,7 +2188,7 @@ mod tests {
             "thread report data",
             Some(SyntheticKind::Tagged(TaggedSyntheticKind::ThreadReport {
                 tool_call_id: "tc-sub".to_owned(),
-                child_thread_id: "thread-1".to_owned(),
+                child_thread_id: "thread-1".into(),
             })),
         );
 
@@ -2241,7 +2248,7 @@ mod tests {
             .expect("prepare input");
 
         assert_eq!(result, PrepareResult::Handled);
-        assert_eq!(hm.thread_id, "thread-1");
+        assert_eq!(hm.thread_id.as_str(), "thread-1");
     }
 
     #[tokio::test]
@@ -2278,7 +2285,7 @@ mod tests {
             .expect("prepare input");
 
         assert_eq!(result, PrepareResult::Handled);
-        assert_eq!(hm.thread_id, "thread-1");
+        assert_eq!(hm.thread_id.as_str(), "thread-1");
     }
 
     #[tokio::test]
@@ -2316,7 +2323,7 @@ mod tests {
 
         let input = InputMessage {
             content: InputMessageContent::User(UserContent::text("hi")),
-            group_id: "thread-1".to_owned(),
+            group_id: "thread-1".into(),
             metadata: Some(serde_json::json!({"user_id": "u-123"})),
             synthetic: None,
             display_as: None,
@@ -2374,7 +2381,7 @@ mod tests {
 
         assert_eq!(result, PrepareResult::Ready);
         // Should NOT spawn a subthread — stays in the same thread
-        assert_eq!(hm.thread_id, "thread-1");
+        assert_eq!(hm.thread_id.as_str(), "thread-1");
         // Should have: original user, tool call, original result, subscription event (with embedded invocation)
         insta::assert_json_snapshot!(
             hm.history.into_inner(),
@@ -2417,7 +2424,7 @@ mod tests {
 
         assert_eq!(result, PrepareResult::Ready);
         // Should NOT spawn a subthread — stays in the same thread
-        assert_eq!(hm.thread_id, "thread-1");
+        assert_eq!(hm.thread_id.as_str(), "thread-1");
         insta::assert_json_snapshot!(
             hm.history.into_inner(),
             { "[3].result.id" => "[uuid]", "[3].invocation.id" => "[uuid]" }
@@ -2432,6 +2439,7 @@ mod tests {
     use crate::tools::{Tool, ToolContext};
     use futures_util::StreamExt;
     use infinity_provider_protocol::ToolDefinition;
+    use rap_protocol::ThreadId;
 
     fn tool_context() -> ToolContext<StubSender> {
         ToolContext {
@@ -2473,6 +2481,7 @@ mod tests {
 
                 // Spawn the stream consumer
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -2482,7 +2491,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -2534,6 +2543,7 @@ mod tests {
                 let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -2543,7 +2553,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -2598,6 +2608,7 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -2607,7 +2618,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -2683,6 +2694,7 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -2692,7 +2704,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -2800,6 +2812,7 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -2809,7 +2822,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -2926,6 +2939,7 @@ mod tests {
                 let ctx = tool_context();
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
+                let thread_id_owned = ThreadId::from("thread-1");
                 let handle = tokio::task::spawn_local(async move {
                     let stream = run_completion(
                         &provider,
@@ -2936,7 +2950,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id_owned,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -2975,6 +2989,7 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -2984,7 +2999,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -3033,6 +3048,7 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -3042,7 +3058,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -3136,6 +3152,7 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -3145,7 +3162,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -3238,6 +3255,7 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -3247,7 +3265,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -3365,6 +3383,7 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -3374,7 +3393,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -3430,6 +3449,7 @@ mod tests {
                 let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -3439,7 +3459,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -3503,6 +3523,7 @@ mod tests {
                 let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let hm_task = hm.clone();
+                let thread_id_owned = ThreadId::from("thread-1");
                 let handle = tokio::task::spawn_local(async move {
                     let stream = run_completion(
                         &provider,
@@ -3513,7 +3534,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id_owned,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -3589,6 +3610,7 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -3598,7 +3620,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -3663,6 +3685,7 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider,
                         "mock",
@@ -3672,7 +3695,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -3777,6 +3800,7 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let hm_task = hm.clone();
+                let thread_id_owned = ThreadId::from("thread-1");
                 let handle = tokio::task::spawn_local(async move {
                     let stream = run_completion(
                         &provider,
@@ -3787,7 +3811,7 @@ mod tests {
                         &tool_defs,
                         &tool_registry,
                         &ctx,
-                        "thread-1",
+                        &thread_id_owned,
                         "msg-1",
                         None,
                         cancel_rx,
@@ -3865,9 +3889,10 @@ mod tests {
                 let (_cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
 
                 let handle = tokio::task::spawn_local(async move {
+                    let thread_id = ThreadId::from("thread-1");
                     let stream = run_completion(
                         &provider, "mock", false, &hm, &tool_names, &tool_defs, &tool_registry,
-                        &ctx, "thread-1", "msg-1", None, cancel_rx,
+                        &ctx, &thread_id, "msg-1", None, cancel_rx,
                     );
                     tokio::pin!(stream);
                     let mut got_done = false;
@@ -3973,7 +3998,7 @@ mod tests {
 
     fn capturing_ctx(
         group_id: &str,
-        thread_stack: Vec<String>,
+        thread_stack: Vec<ThreadId>,
     ) -> (
         ToolContext<CapturingSender>,
         tokio::sync::mpsc::UnboundedReceiver<InputMessage>,
@@ -3982,7 +4007,7 @@ mod tests {
         (
             ToolContext {
                 message_sender: CapturingSender(tx),
-                group_id: group_id.to_owned(),
+                group_id: group_id.into(),
                 callback_url: String::new(),
                 user_id: None,
                 thread_stack,
@@ -4074,7 +4099,7 @@ mod tests {
                 default: 0,
                 response_url: "https://example.com/choice".to_owned(),
             }),
-            group_id: "thread-1".to_owned(),
+            group_id: "thread-1".into(),
             metadata: None,
             synthetic: None,
             display_as: None,

--- a/crates/infinity-agent-core/src/lib.rs
+++ b/crates/infinity-agent-core/src/lib.rs
@@ -6,3 +6,7 @@ pub mod system;
 pub(crate) mod test_helpers;
 pub mod tools;
 pub mod traits;
+
+/// The thread identifier used throughout the runtime (re-exported from
+/// `rap-protocol`, where it is the wire-level `group_id`).
+pub use rap_protocol::ThreadId;

--- a/crates/infinity-agent-core/src/message.rs
+++ b/crates/infinity-agent-core/src/message.rs
@@ -1,6 +1,7 @@
 use infinity_provider_protocol::message::{
     AssistantContent, Message, ToolCall, ToolResult, UserContent,
 };
+use rap_protocol::ThreadId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -59,7 +60,7 @@ pub enum TaggedSyntheticKind {
     #[serde(rename = "thread_report")]
     ThreadReport {
         tool_call_id: String,
-        child_thread_id: String,
+        child_thread_id: ThreadId,
     },
     #[serde(rename = "parent_message")]
     ParentMessage { tool_call_id: String },
@@ -137,7 +138,7 @@ impl SyntheticKind {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct InputMessage {
     pub content: InputMessageContent,
-    pub group_id: String,
+    pub group_id: ThreadId,
     #[serde(default)]
     pub metadata: Option<serde_json::Value>,
     #[serde(default)]
@@ -156,7 +157,7 @@ pub struct InputMessage {
 
 impl InputMessage {
     /// A plain (non-synthetic) user text message addressed to `thread_id`.
-    pub fn user_text(thread_id: impl Into<String>, text: impl Into<String>) -> Self {
+    pub fn user_text(thread_id: impl Into<ThreadId>, text: impl Into<String>) -> Self {
         Self {
             content: InputMessageContent::User(UserContent::text(text.into())),
             group_id: thread_id.into(),
@@ -212,7 +213,7 @@ pub enum InfinityMessage {
         tool_call_id: String,
         /// Set when this is a thread report (used to build the display name).
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        child_thread_id: Option<String>,
+        child_thread_id: Option<ThreadId>,
         /// The synthetic `receive_event__injected` tool call. When present,
         /// `into_messages` emits both the tool call and the tool result for
         /// the LLM, but replay only emits the subscription display event.

--- a/crates/infinity-agent-core/src/stores.rs
+++ b/crates/infinity-agent-core/src/stores.rs
@@ -83,7 +83,7 @@ impl InMemoryConversationStore {
     // chains, compaction cutoffs) stays implemented here, once.
 
     /// Snapshot one thread's bookkeeping, if the thread exists.
-    pub fn thread_info(&self, thread_id: &ThreadId) -> Option<ThreadInfo> {
+    pub fn thread_info(&self, thread_id: &ThreadId<str>) -> Option<ThreadInfo> {
         self.threads
             .lock()
             .expect("bug: mutex poisoned")
@@ -92,16 +92,19 @@ impl InMemoryConversationStore {
     }
 
     /// Restore (or overwrite) one thread's bookkeeping.
-    pub fn set_thread_info(&self, thread_id: &ThreadId, info: ThreadInfo) {
+    pub fn set_thread_info(&self, thread_id: &ThreadId<str>, info: ThreadInfo) {
         self.threads
             .lock()
             .expect("bug: mutex poisoned")
-            .insert(thread_id.clone(), info);
+            .insert(thread_id.to_owned(), info);
     }
 
     /// Snapshot one thread's messages (with their dedup IDs), if any were
     /// ever appended.
-    pub fn thread_messages(&self, thread_id: &ThreadId) -> Option<Vec<(InfinityMessage, String)>> {
+    pub fn thread_messages(
+        &self,
+        thread_id: &ThreadId<str>,
+    ) -> Option<Vec<(InfinityMessage, String)>> {
         self.messages
             .lock()
             .expect("bug: mutex poisoned")
@@ -113,18 +116,18 @@ impl InMemoryConversationStore {
     /// thread were already present (and have been overwritten).
     pub fn set_thread_messages(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         messages: Vec<(InfinityMessage, String)>,
     ) -> bool {
         self.messages
             .lock()
             .expect("bug: mutex poisoned")
-            .insert(thread_id.clone(), messages)
+            .insert(thread_id.to_owned(), messages)
             .is_some()
     }
 
     /// Snapshot one thread's compaction summaries.
-    pub fn thread_compaction_summaries(&self, thread_id: &ThreadId) -> Vec<CompactionSummary> {
+    pub fn thread_compaction_summaries(&self, thread_id: &ThreadId<str>) -> Vec<CompactionSummary> {
         self.compaction_summaries
             .lock()
             .expect("bug: mutex poisoned")
@@ -137,13 +140,13 @@ impl InMemoryConversationStore {
     /// summaries for the thread were already present (and overwritten).
     pub fn set_thread_compaction_summaries(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         summaries: Vec<CompactionSummary>,
     ) -> bool {
         self.compaction_summaries
             .lock()
             .expect("bug: mutex poisoned")
-            .insert(thread_id.clone(), summaries)
+            .insert(thread_id.to_owned(), summaries)
             .is_some()
     }
 
@@ -154,8 +157,8 @@ impl InMemoryConversationStore {
     /// message count unless overridden.
     pub fn spawn_thread_with_id(
         &self,
-        new_thread_id: &ThreadId,
-        parent_thread_id: &ThreadId,
+        new_thread_id: &ThreadId<str>,
+        parent_thread_id: &ThreadId<str>,
         spawn_tool_call_id: &str,
         is_for_subscription_event: bool,
         spawn_order_override: Option<usize>,
@@ -170,11 +173,11 @@ impl InMemoryConversationStore {
         let root = threads
             .get(parent_thread_id)
             .map(|t| t.root_thread_id.clone())
-            .unwrap_or_else(|| parent_thread_id.clone());
+            .unwrap_or_else(|| parent_thread_id.to_owned());
         threads.insert(
-            new_thread_id.clone(),
+            new_thread_id.to_owned(),
             ThreadInfo {
-                parent_thread_id: Some(parent_thread_id.clone()),
+                parent_thread_id: Some(parent_thread_id.to_owned()),
                 root_thread_id: root,
                 spawn_message_order: Some(spawn_message_order),
                 spawn_tool_call_id: Some(spawn_tool_call_id.to_owned()),
@@ -190,13 +193,13 @@ impl InMemoryConversationStore {
 impl ConversationStore for InMemoryConversationStore {
     type Error = InMemoryStoreError;
 
-    async fn ensure_root_thread(&self, thread_id: &ThreadId) -> Result<(), Self::Error> {
+    async fn ensure_root_thread(&self, thread_id: &ThreadId<str>) -> Result<(), Self::Error> {
         let mut threads = self.threads.lock().expect("bug: mutex poisoned");
         threads
-            .entry(thread_id.clone())
+            .entry(thread_id.to_owned())
             .or_insert_with(|| ThreadInfo {
                 parent_thread_id: None,
-                root_thread_id: thread_id.clone(),
+                root_thread_id: thread_id.to_owned(),
                 spawn_message_order: None,
                 spawn_tool_call_id: None,
                 closed: false,
@@ -206,7 +209,7 @@ impl ConversationStore for InMemoryConversationStore {
         Ok(())
     }
 
-    async fn thread_exists(&self, thread_id: &ThreadId) -> Result<bool, Self::Error> {
+    async fn thread_exists(&self, thread_id: &ThreadId<str>) -> Result<bool, Self::Error> {
         Ok(self
             .threads
             .lock()
@@ -216,7 +219,7 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn load_history_up_to(
         &self,
-        session_id: &ThreadId,
+        session_id: &ThreadId<str>,
         start_from: Option<i64>,
         up_to: Option<i64>,
     ) -> Result<Vec<InfinityMessage>, Self::Error> {
@@ -234,12 +237,12 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn append_messages(
         &self,
-        session_id: &ThreadId,
+        session_id: &ThreadId<str>,
         messages: Vec<(InfinityMessage, String)>,
     ) -> Result<(), Self::Error> {
         let mut store = self.messages.lock().expect("bug: mutex poisoned");
         store
-            .entry(session_id.clone())
+            .entry(session_id.to_owned())
             .or_default()
             .extend(messages);
         Ok(())
@@ -247,7 +250,7 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn spawn_thread(
         &self,
-        parent_thread_id: &ThreadId,
+        parent_thread_id: &ThreadId<str>,
         spawn_tool_call_id: &str,
         is_for_subscription_event: bool,
         spawn_order_override: Option<usize>,
@@ -263,12 +266,12 @@ impl ConversationStore for InMemoryConversationStore {
         Ok(new_id)
     }
 
-    async fn is_thread_closed(&self, thread_id: &ThreadId) -> Result<bool, Self::Error> {
+    async fn is_thread_closed(&self, thread_id: &ThreadId<str>) -> Result<bool, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         Ok(threads.get(thread_id).map(|t| t.closed).unwrap_or(false))
     }
 
-    async fn close_thread(&self, thread_id: &ThreadId) -> Result<(), Self::Error> {
+    async fn close_thread(&self, thread_id: &ThreadId<str>) -> Result<(), Self::Error> {
         let mut threads = self.threads.lock().expect("bug: mutex poisoned");
         if let Some(t) = threads.get_mut(thread_id) {
             t.closed = true;
@@ -278,7 +281,7 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn is_subscription_event_thread(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<bool, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         Ok(threads
@@ -289,7 +292,7 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn get_thread_parent_info(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Option<(ThreadId, String)>, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         Ok(threads.get(thread_id).and_then(|t| {
@@ -302,11 +305,11 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn get_ancestor_chain(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<(ThreadId, i64)>, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         let mut result = Vec::new();
-        let mut current = thread_id.clone();
+        let mut current = thread_id.to_owned();
         while let Some(info) = threads.get(&current) {
             let Some(parent) = info.parent_thread_id.clone() else {
                 break;
@@ -319,7 +322,10 @@ impl ConversationStore for InMemoryConversationStore {
         Ok(result)
     }
 
-    async fn mark_thread_as_compaction(&self, thread_id: &ThreadId) -> Result<(), Self::Error> {
+    async fn mark_thread_as_compaction(
+        &self,
+        thread_id: &ThreadId<str>,
+    ) -> Result<(), Self::Error> {
         let mut threads = self.threads.lock().expect("bug: mutex poisoned");
         if let Some(t) = threads.get_mut(thread_id) {
             t.is_compaction = true;
@@ -327,7 +333,7 @@ impl ConversationStore for InMemoryConversationStore {
         Ok(())
     }
 
-    async fn is_compaction_thread(&self, thread_id: &ThreadId) -> Result<bool, Self::Error> {
+    async fn is_compaction_thread(&self, thread_id: &ThreadId<str>) -> Result<bool, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         Ok(threads
             .get(thread_id)
@@ -337,7 +343,7 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn get_thread_spawn_order(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Option<i64>, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         Ok(threads.get(thread_id).and_then(|t| t.spawn_message_order))
@@ -345,7 +351,7 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn save_compaction_summary(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         summary: &str,
         up_to_order: i64,
     ) -> Result<(), Self::Error> {
@@ -353,7 +359,7 @@ impl ConversationStore for InMemoryConversationStore {
             .compaction_summaries
             .lock()
             .expect("bug: mutex poisoned");
-        cs.entry(thread_id.clone())
+        cs.entry(thread_id.to_owned())
             .or_default()
             .push(CompactionSummary {
                 summary: summary.to_owned(),
@@ -364,7 +370,7 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn load_latest_compaction_summary_up_to(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         up_to_order: Option<i64>,
     ) -> Result<Option<(String, i64)>, Self::Error> {
         let cs = self
@@ -410,7 +416,7 @@ impl InMemoryStateStore {
     }
 
     /// Snapshot one thread's state (see [`ThreadState`]).
-    pub fn thread_state(&self, thread_id: &ThreadId) -> ThreadState {
+    pub fn thread_state(&self, thread_id: &ThreadId<str>) -> ThreadState {
         let processed = self.processed_ids.lock().expect("bug: mutex poisoned");
         let metadata = self.metadata.lock().expect("bug: mutex poisoned");
         let subscriptions = self.subscriptions.lock().expect("bug: mutex poisoned");
@@ -430,28 +436,28 @@ impl InMemoryStateStore {
     }
 
     /// Restore one thread's state (see [`ThreadState`]).
-    pub fn set_thread_state(&self, thread_id: &ThreadId, state: ThreadState) {
+    pub fn set_thread_state(&self, thread_id: &ThreadId<str>, state: ThreadState) {
         self.processed_ids
             .lock()
             .expect("bug: mutex poisoned")
-            .insert(thread_id.clone(), state.processed_message_ids);
+            .insert(thread_id.to_owned(), state.processed_message_ids);
         if let Some(meta) = state.metadata {
             self.metadata
                 .lock()
                 .expect("bug: mutex poisoned")
-                .insert(thread_id.clone(), meta);
+                .insert(thread_id.to_owned(), meta);
         }
         if !state.subscriptions.is_empty() {
             self.subscriptions
                 .lock()
                 .expect("bug: mutex poisoned")
-                .insert(thread_id.clone(), state.subscriptions);
+                .insert(thread_id.to_owned(), state.subscriptions);
         }
         if !state.pending_user_choices.is_empty() {
             self.pending_user_choices
                 .lock()
                 .expect("bug: mutex poisoned")
-                .insert(thread_id.clone(), state.pending_user_choices);
+                .insert(thread_id.to_owned(), state.pending_user_choices);
         }
     }
 }
@@ -462,7 +468,7 @@ impl StateStore for InMemoryStateStore {
 
     async fn get_processed_ids(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<HashSet<String>, Self::Error> {
         let store = self.processed_ids.lock().expect("bug: mutex poisoned");
         Ok(store.get(thread_id).cloned().unwrap_or_default())
@@ -470,12 +476,12 @@ impl StateStore for InMemoryStateStore {
 
     async fn add_processed_message_ids(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         message_ids: Vec<String>,
     ) -> Result<(), Self::Error> {
         let mut store = self.processed_ids.lock().expect("bug: mutex poisoned");
         store
-            .entry(thread_id.clone())
+            .entry(thread_id.to_owned())
             .or_default()
             .extend(message_ids);
         Ok(())
@@ -483,7 +489,7 @@ impl StateStore for InMemoryStateStore {
 
     async fn get_metadata(
         &self,
-        root_thread_id: &ThreadId,
+        root_thread_id: &ThreadId<str>,
     ) -> Result<Option<serde_json::Value>, Self::Error> {
         let store = self.metadata.lock().expect("bug: mutex poisoned");
         Ok(store.get(root_thread_id).cloned())
@@ -491,17 +497,17 @@ impl StateStore for InMemoryStateStore {
 
     async fn set_metadata(
         &self,
-        root_thread_id: &ThreadId,
+        root_thread_id: &ThreadId<str>,
         metadata: serde_json::Value,
     ) -> Result<(), Self::Error> {
         let mut store = self.metadata.lock().expect("bug: mutex poisoned");
-        store.insert(root_thread_id.clone(), metadata);
+        store.insert(root_thread_id.to_owned(), metadata);
         Ok(())
     }
 
     async fn get_active_subscriptions(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<String>, Self::Error> {
         let store = self.subscriptions.lock().expect("bug: mutex poisoned");
         Ok(store
@@ -512,12 +518,12 @@ impl StateStore for InMemoryStateStore {
 
     async fn add_active_subscription(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         tool_call_id: &str,
     ) -> Result<(), Self::Error> {
         let mut store = self.subscriptions.lock().expect("bug: mutex poisoned");
         store
-            .entry(thread_id.clone())
+            .entry(thread_id.to_owned())
             .or_default()
             .insert(tool_call_id.to_owned());
         Ok(())
@@ -525,7 +531,7 @@ impl StateStore for InMemoryStateStore {
 
     async fn remove_active_subscription(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         tool_call_id: &str,
     ) -> Result<(), Self::Error> {
         let mut store = self.subscriptions.lock().expect("bug: mutex poisoned");
@@ -537,14 +543,14 @@ impl StateStore for InMemoryStateStore {
 
     async fn add_pending_user_choice(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         choice: UserChoice,
     ) -> Result<(), Self::Error> {
         let mut store = self
             .pending_user_choices
             .lock()
             .expect("bug: mutex poisoned");
-        let choices = store.entry(thread_id.clone()).or_default();
+        let choices = store.entry(thread_id.to_owned()).or_default();
         if let Some(existing) = choices.iter_mut().find(|existing| existing.id == choice.id) {
             *existing = choice;
         } else {
@@ -555,7 +561,7 @@ impl StateStore for InMemoryStateStore {
 
     async fn remove_pending_user_choice(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         choice_id: &str,
     ) -> Result<(), Self::Error> {
         if let Some(choices) = self
@@ -571,7 +577,7 @@ impl StateStore for InMemoryStateStore {
 
     async fn get_pending_user_choices(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<UserChoice>, Self::Error> {
         Ok(self
             .pending_user_choices

--- a/crates/infinity-agent-core/src/stores.rs
+++ b/crates/infinity-agent-core/src/stores.rs
@@ -11,6 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use rap_protocol::ThreadId;
 use serde::{Deserialize, Serialize};
 
 use crate::message::InfinityMessage;
@@ -39,8 +40,8 @@ impl std::error::Error for InMemoryStoreError {}
 /// re-implementing the store semantics.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ThreadInfo {
-    pub parent_thread_id: Option<String>,
-    pub root_thread_id: String,
+    pub parent_thread_id: Option<ThreadId>,
+    pub root_thread_id: ThreadId,
     /// Number of parent messages the child inherits (history cutoff).
     pub spawn_message_order: Option<i64>,
     pub spawn_tool_call_id: Option<String>,
@@ -63,9 +64,9 @@ pub struct CompactionSummary {
 #[derive(Clone, Default)]
 pub struct InMemoryConversationStore {
     #[expect(clippy::type_complexity, reason = "shared state")]
-    messages: Arc<Mutex<HashMap<String, Vec<(InfinityMessage, String)>>>>,
-    threads: Arc<Mutex<HashMap<String, ThreadInfo>>>,
-    compaction_summaries: Arc<Mutex<HashMap<String, Vec<CompactionSummary>>>>,
+    messages: Arc<Mutex<HashMap<ThreadId, Vec<(InfinityMessage, String)>>>>,
+    threads: Arc<Mutex<HashMap<ThreadId, ThreadInfo>>>,
+    compaction_summaries: Arc<Mutex<HashMap<ThreadId, Vec<CompactionSummary>>>>,
 }
 
 impl InMemoryConversationStore {
@@ -82,7 +83,7 @@ impl InMemoryConversationStore {
     // chains, compaction cutoffs) stays implemented here, once.
 
     /// Snapshot one thread's bookkeeping, if the thread exists.
-    pub fn thread_info(&self, thread_id: &str) -> Option<ThreadInfo> {
+    pub fn thread_info(&self, thread_id: &ThreadId) -> Option<ThreadInfo> {
         self.threads
             .lock()
             .expect("bug: mutex poisoned")
@@ -91,16 +92,16 @@ impl InMemoryConversationStore {
     }
 
     /// Restore (or overwrite) one thread's bookkeeping.
-    pub fn set_thread_info(&self, thread_id: &str, info: ThreadInfo) {
+    pub fn set_thread_info(&self, thread_id: &ThreadId, info: ThreadInfo) {
         self.threads
             .lock()
             .expect("bug: mutex poisoned")
-            .insert(thread_id.to_owned(), info);
+            .insert(thread_id.clone(), info);
     }
 
     /// Snapshot one thread's messages (with their dedup IDs), if any were
     /// ever appended.
-    pub fn thread_messages(&self, thread_id: &str) -> Option<Vec<(InfinityMessage, String)>> {
+    pub fn thread_messages(&self, thread_id: &ThreadId) -> Option<Vec<(InfinityMessage, String)>> {
         self.messages
             .lock()
             .expect("bug: mutex poisoned")
@@ -112,18 +113,18 @@ impl InMemoryConversationStore {
     /// thread were already present (and have been overwritten).
     pub fn set_thread_messages(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         messages: Vec<(InfinityMessage, String)>,
     ) -> bool {
         self.messages
             .lock()
             .expect("bug: mutex poisoned")
-            .insert(thread_id.to_owned(), messages)
+            .insert(thread_id.clone(), messages)
             .is_some()
     }
 
     /// Snapshot one thread's compaction summaries.
-    pub fn thread_compaction_summaries(&self, thread_id: &str) -> Vec<CompactionSummary> {
+    pub fn thread_compaction_summaries(&self, thread_id: &ThreadId) -> Vec<CompactionSummary> {
         self.compaction_summaries
             .lock()
             .expect("bug: mutex poisoned")
@@ -136,13 +137,13 @@ impl InMemoryConversationStore {
     /// summaries for the thread were already present (and overwritten).
     pub fn set_thread_compaction_summaries(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         summaries: Vec<CompactionSummary>,
     ) -> bool {
         self.compaction_summaries
             .lock()
             .expect("bug: mutex poisoned")
-            .insert(thread_id.to_owned(), summaries)
+            .insert(thread_id.clone(), summaries)
             .is_some()
     }
 
@@ -153,8 +154,8 @@ impl InMemoryConversationStore {
     /// message count unless overridden.
     pub fn spawn_thread_with_id(
         &self,
-        new_thread_id: &str,
-        parent_thread_id: &str,
+        new_thread_id: &ThreadId,
+        parent_thread_id: &ThreadId,
         spawn_tool_call_id: &str,
         is_for_subscription_event: bool,
         spawn_order_override: Option<usize>,
@@ -169,11 +170,11 @@ impl InMemoryConversationStore {
         let root = threads
             .get(parent_thread_id)
             .map(|t| t.root_thread_id.clone())
-            .unwrap_or_else(|| parent_thread_id.to_owned());
+            .unwrap_or_else(|| parent_thread_id.clone());
         threads.insert(
-            new_thread_id.to_owned(),
+            new_thread_id.clone(),
             ThreadInfo {
-                parent_thread_id: Some(parent_thread_id.to_owned()),
+                parent_thread_id: Some(parent_thread_id.clone()),
                 root_thread_id: root,
                 spawn_message_order: Some(spawn_message_order),
                 spawn_tool_call_id: Some(spawn_tool_call_id.to_owned()),
@@ -189,13 +190,13 @@ impl InMemoryConversationStore {
 impl ConversationStore for InMemoryConversationStore {
     type Error = InMemoryStoreError;
 
-    async fn ensure_root_thread(&self, thread_id: &str) -> Result<(), Self::Error> {
+    async fn ensure_root_thread(&self, thread_id: &ThreadId) -> Result<(), Self::Error> {
         let mut threads = self.threads.lock().expect("bug: mutex poisoned");
         threads
-            .entry(thread_id.to_owned())
+            .entry(thread_id.clone())
             .or_insert_with(|| ThreadInfo {
                 parent_thread_id: None,
-                root_thread_id: thread_id.to_owned(),
+                root_thread_id: thread_id.clone(),
                 spawn_message_order: None,
                 spawn_tool_call_id: None,
                 closed: false,
@@ -205,7 +206,7 @@ impl ConversationStore for InMemoryConversationStore {
         Ok(())
     }
 
-    async fn thread_exists(&self, thread_id: &str) -> Result<bool, Self::Error> {
+    async fn thread_exists(&self, thread_id: &ThreadId) -> Result<bool, Self::Error> {
         Ok(self
             .threads
             .lock()
@@ -215,7 +216,7 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn load_history_up_to(
         &self,
-        session_id: &str,
+        session_id: &ThreadId,
         start_from: Option<i64>,
         up_to: Option<i64>,
     ) -> Result<Vec<InfinityMessage>, Self::Error> {
@@ -233,12 +234,12 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn append_messages(
         &self,
-        session_id: &str,
+        session_id: &ThreadId,
         messages: Vec<(InfinityMessage, String)>,
     ) -> Result<(), Self::Error> {
         let mut store = self.messages.lock().expect("bug: mutex poisoned");
         store
-            .entry(session_id.to_owned())
+            .entry(session_id.clone())
             .or_default()
             .extend(messages);
         Ok(())
@@ -246,12 +247,12 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn spawn_thread(
         &self,
-        parent_thread_id: &str,
+        parent_thread_id: &ThreadId,
         spawn_tool_call_id: &str,
         is_for_subscription_event: bool,
         spawn_order_override: Option<usize>,
-    ) -> Result<String, Self::Error> {
-        let new_id = uuid::Uuid::new_v4().to_string();
+    ) -> Result<ThreadId, Self::Error> {
+        let new_id = ThreadId::from(uuid::Uuid::new_v4().to_string());
         self.spawn_thread_with_id(
             &new_id,
             parent_thread_id,
@@ -262,12 +263,12 @@ impl ConversationStore for InMemoryConversationStore {
         Ok(new_id)
     }
 
-    async fn is_thread_closed(&self, thread_id: &str) -> Result<bool, Self::Error> {
+    async fn is_thread_closed(&self, thread_id: &ThreadId) -> Result<bool, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         Ok(threads.get(thread_id).map(|t| t.closed).unwrap_or(false))
     }
 
-    async fn close_thread(&self, thread_id: &str) -> Result<(), Self::Error> {
+    async fn close_thread(&self, thread_id: &ThreadId) -> Result<(), Self::Error> {
         let mut threads = self.threads.lock().expect("bug: mutex poisoned");
         if let Some(t) = threads.get_mut(thread_id) {
             t.closed = true;
@@ -275,7 +276,10 @@ impl ConversationStore for InMemoryConversationStore {
         Ok(())
     }
 
-    async fn is_subscription_event_thread(&self, thread_id: &str) -> Result<bool, Self::Error> {
+    async fn is_subscription_event_thread(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<bool, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         Ok(threads
             .get(thread_id)
@@ -285,8 +289,8 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn get_thread_parent_info(
         &self,
-        thread_id: &str,
-    ) -> Result<Option<(String, String)>, Self::Error> {
+        thread_id: &ThreadId,
+    ) -> Result<Option<(ThreadId, String)>, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         Ok(threads.get(thread_id).and_then(|t| {
             match (&t.parent_thread_id, &t.spawn_tool_call_id) {
@@ -296,10 +300,13 @@ impl ConversationStore for InMemoryConversationStore {
         }))
     }
 
-    async fn get_ancestor_chain(&self, thread_id: &str) -> Result<Vec<(String, i64)>, Self::Error> {
+    async fn get_ancestor_chain(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Vec<(ThreadId, i64)>, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         let mut result = Vec::new();
-        let mut current = thread_id.to_owned();
+        let mut current = thread_id.clone();
         while let Some(info) = threads.get(&current) {
             let Some(parent) = info.parent_thread_id.clone() else {
                 break;
@@ -312,7 +319,7 @@ impl ConversationStore for InMemoryConversationStore {
         Ok(result)
     }
 
-    async fn mark_thread_as_compaction(&self, thread_id: &str) -> Result<(), Self::Error> {
+    async fn mark_thread_as_compaction(&self, thread_id: &ThreadId) -> Result<(), Self::Error> {
         let mut threads = self.threads.lock().expect("bug: mutex poisoned");
         if let Some(t) = threads.get_mut(thread_id) {
             t.is_compaction = true;
@@ -320,7 +327,7 @@ impl ConversationStore for InMemoryConversationStore {
         Ok(())
     }
 
-    async fn is_compaction_thread(&self, thread_id: &str) -> Result<bool, Self::Error> {
+    async fn is_compaction_thread(&self, thread_id: &ThreadId) -> Result<bool, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         Ok(threads
             .get(thread_id)
@@ -328,14 +335,17 @@ impl ConversationStore for InMemoryConversationStore {
             .unwrap_or(false))
     }
 
-    async fn get_thread_spawn_order(&self, thread_id: &str) -> Result<Option<i64>, Self::Error> {
+    async fn get_thread_spawn_order(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Option<i64>, Self::Error> {
         let threads = self.threads.lock().expect("bug: mutex poisoned");
         Ok(threads.get(thread_id).and_then(|t| t.spawn_message_order))
     }
 
     async fn save_compaction_summary(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         summary: &str,
         up_to_order: i64,
     ) -> Result<(), Self::Error> {
@@ -343,7 +353,7 @@ impl ConversationStore for InMemoryConversationStore {
             .compaction_summaries
             .lock()
             .expect("bug: mutex poisoned");
-        cs.entry(thread_id.to_owned())
+        cs.entry(thread_id.clone())
             .or_default()
             .push(CompactionSummary {
                 summary: summary.to_owned(),
@@ -354,7 +364,7 @@ impl ConversationStore for InMemoryConversationStore {
 
     async fn load_latest_compaction_summary_up_to(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         up_to_order: Option<i64>,
     ) -> Result<Option<(String, i64)>, Self::Error> {
         let cs = self
@@ -388,10 +398,10 @@ pub struct ThreadState {
 /// subscription tracking in process memory.
 #[derive(Clone, Default)]
 pub struct InMemoryStateStore {
-    processed_ids: Arc<Mutex<HashMap<String, HashSet<String>>>>,
-    metadata: Arc<Mutex<HashMap<String, serde_json::Value>>>,
-    subscriptions: Arc<Mutex<HashMap<String, HashSet<String>>>>,
-    pending_user_choices: Arc<Mutex<HashMap<String, Vec<UserChoice>>>>,
+    processed_ids: Arc<Mutex<HashMap<ThreadId, HashSet<String>>>>,
+    metadata: Arc<Mutex<HashMap<ThreadId, serde_json::Value>>>,
+    subscriptions: Arc<Mutex<HashMap<ThreadId, HashSet<String>>>>,
+    pending_user_choices: Arc<Mutex<HashMap<ThreadId, Vec<UserChoice>>>>,
 }
 
 impl InMemoryStateStore {
@@ -400,7 +410,7 @@ impl InMemoryStateStore {
     }
 
     /// Snapshot one thread's state (see [`ThreadState`]).
-    pub fn thread_state(&self, thread_id: &str) -> ThreadState {
+    pub fn thread_state(&self, thread_id: &ThreadId) -> ThreadState {
         let processed = self.processed_ids.lock().expect("bug: mutex poisoned");
         let metadata = self.metadata.lock().expect("bug: mutex poisoned");
         let subscriptions = self.subscriptions.lock().expect("bug: mutex poisoned");
@@ -420,28 +430,28 @@ impl InMemoryStateStore {
     }
 
     /// Restore one thread's state (see [`ThreadState`]).
-    pub fn set_thread_state(&self, thread_id: &str, state: ThreadState) {
+    pub fn set_thread_state(&self, thread_id: &ThreadId, state: ThreadState) {
         self.processed_ids
             .lock()
             .expect("bug: mutex poisoned")
-            .insert(thread_id.to_owned(), state.processed_message_ids);
+            .insert(thread_id.clone(), state.processed_message_ids);
         if let Some(meta) = state.metadata {
             self.metadata
                 .lock()
                 .expect("bug: mutex poisoned")
-                .insert(thread_id.to_owned(), meta);
+                .insert(thread_id.clone(), meta);
         }
         if !state.subscriptions.is_empty() {
             self.subscriptions
                 .lock()
                 .expect("bug: mutex poisoned")
-                .insert(thread_id.to_owned(), state.subscriptions);
+                .insert(thread_id.clone(), state.subscriptions);
         }
         if !state.pending_user_choices.is_empty() {
             self.pending_user_choices
                 .lock()
                 .expect("bug: mutex poisoned")
-                .insert(thread_id.to_owned(), state.pending_user_choices);
+                .insert(thread_id.clone(), state.pending_user_choices);
         }
     }
 }
@@ -450,19 +460,22 @@ impl InMemoryStateStore {
 impl StateStore for InMemoryStateStore {
     type Error = InMemoryStoreError;
 
-    async fn get_processed_ids(&self, thread_id: &str) -> Result<HashSet<String>, Self::Error> {
+    async fn get_processed_ids(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<HashSet<String>, Self::Error> {
         let store = self.processed_ids.lock().expect("bug: mutex poisoned");
         Ok(store.get(thread_id).cloned().unwrap_or_default())
     }
 
     async fn add_processed_message_ids(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         message_ids: Vec<String>,
     ) -> Result<(), Self::Error> {
         let mut store = self.processed_ids.lock().expect("bug: mutex poisoned");
         store
-            .entry(thread_id.to_owned())
+            .entry(thread_id.clone())
             .or_default()
             .extend(message_ids);
         Ok(())
@@ -470,7 +483,7 @@ impl StateStore for InMemoryStateStore {
 
     async fn get_metadata(
         &self,
-        root_thread_id: &str,
+        root_thread_id: &ThreadId,
     ) -> Result<Option<serde_json::Value>, Self::Error> {
         let store = self.metadata.lock().expect("bug: mutex poisoned");
         Ok(store.get(root_thread_id).cloned())
@@ -478,15 +491,18 @@ impl StateStore for InMemoryStateStore {
 
     async fn set_metadata(
         &self,
-        root_thread_id: &str,
+        root_thread_id: &ThreadId,
         metadata: serde_json::Value,
     ) -> Result<(), Self::Error> {
         let mut store = self.metadata.lock().expect("bug: mutex poisoned");
-        store.insert(root_thread_id.to_owned(), metadata);
+        store.insert(root_thread_id.clone(), metadata);
         Ok(())
     }
 
-    async fn get_active_subscriptions(&self, thread_id: &str) -> Result<Vec<String>, Self::Error> {
+    async fn get_active_subscriptions(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Vec<String>, Self::Error> {
         let store = self.subscriptions.lock().expect("bug: mutex poisoned");
         Ok(store
             .get(thread_id)
@@ -496,12 +512,12 @@ impl StateStore for InMemoryStateStore {
 
     async fn add_active_subscription(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         tool_call_id: &str,
     ) -> Result<(), Self::Error> {
         let mut store = self.subscriptions.lock().expect("bug: mutex poisoned");
         store
-            .entry(thread_id.to_owned())
+            .entry(thread_id.clone())
             .or_default()
             .insert(tool_call_id.to_owned());
         Ok(())
@@ -509,7 +525,7 @@ impl StateStore for InMemoryStateStore {
 
     async fn remove_active_subscription(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         tool_call_id: &str,
     ) -> Result<(), Self::Error> {
         let mut store = self.subscriptions.lock().expect("bug: mutex poisoned");
@@ -521,14 +537,14 @@ impl StateStore for InMemoryStateStore {
 
     async fn add_pending_user_choice(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         choice: UserChoice,
     ) -> Result<(), Self::Error> {
         let mut store = self
             .pending_user_choices
             .lock()
             .expect("bug: mutex poisoned");
-        let choices = store.entry(thread_id.to_owned()).or_default();
+        let choices = store.entry(thread_id.clone()).or_default();
         if let Some(existing) = choices.iter_mut().find(|existing| existing.id == choice.id) {
             *existing = choice;
         } else {
@@ -539,7 +555,7 @@ impl StateStore for InMemoryStateStore {
 
     async fn remove_pending_user_choice(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         choice_id: &str,
     ) -> Result<(), Self::Error> {
         if let Some(choices) = self
@@ -555,7 +571,7 @@ impl StateStore for InMemoryStateStore {
 
     async fn get_pending_user_choices(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
     ) -> Result<Vec<UserChoice>, Self::Error> {
         Ok(self
             .pending_user_choices

--- a/crates/infinity-agent-core/src/system/builder.rs
+++ b/crates/infinity-agent-core/src/system/builder.rs
@@ -384,7 +384,7 @@ where
     pub fn start_with_observer<O, F>(self, make_observer: F) -> RunningSystem<O::SubscribeRequest>
     where
         O: ThreadObserver + 'static,
-        F: Fn(&ThreadId) -> O + 'static,
+        F: Fn(&ThreadId<str>) -> O + 'static,
     {
         self.build_local().start_with_observer(make_observer)
     }

--- a/crates/infinity-agent-core/src/system/builder.rs
+++ b/crates/infinity-agent-core/src/system/builder.rs
@@ -1,5 +1,6 @@
 //! Building an [`AgentSystem`]: the entry point of the high-level API.
 
+use rap_protocol::ThreadId;
 use std::rc::Rc;
 
 use async_trait::async_trait;
@@ -383,7 +384,7 @@ where
     pub fn start_with_observer<O, F>(self, make_observer: F) -> RunningSystem<O::SubscribeRequest>
     where
         O: ThreadObserver + 'static,
-        F: Fn(&str) -> O + 'static,
+        F: Fn(&ThreadId) -> O + 'static,
     {
         self.build_local().start_with_observer(make_observer)
     }
@@ -453,9 +454,9 @@ where
         inputs: Vec<(InputMessage, String)>,
         observer: &O,
         defer: &mut D,
-    ) -> Result<Vec<(String, StepOutcome)>, BoxError> {
+    ) -> Result<Vec<(ThreadId, StepOutcome)>, BoxError> {
         // Partition by thread, preserving arrival order within each thread.
-        let mut groups: Vec<(String, Vec<(InputMessage, String)>)> = Vec::new();
+        let mut groups: Vec<(ThreadId, Vec<(InputMessage, String)>)> = Vec::new();
         for (msg, id) in inputs {
             match groups.iter_mut().find(|(g, _)| *g == msg.group_id) {
                 Some((_, batch)) => batch.push((msg, id)),
@@ -568,11 +569,11 @@ mod tests {
 
                 let (outcomes, events) = step.await.expect("join");
                 assert_eq!(outcomes.len(), 1);
-                assert_eq!(outcomes[0].0, "t1");
+                assert_eq!(outcomes[0].0.as_str(), "t1");
                 assert!(matches!(outcomes[0].1, StepOutcome::Completed { .. }));
-                assert!(events.iter().any(|(t, e)| t == "t1"
+                assert!(events.iter().any(|(t, e)| t.as_str() == "t1"
                     && matches!(e, AgentEvent::UserInput { text } if text == "hello")));
-                assert!(events.iter().any(|(t, e)| t == "t1"
+                assert!(events.iter().any(|(t, e)| t.as_str() == "t1"
                     && matches!(e, AgentEvent::TextChunk { text } if text == "hi there")));
                 assert!(
                     events
@@ -637,9 +638,9 @@ mod tests {
                         .iter()
                         .all(|(_, o)| matches!(o, StepOutcome::Completed { .. }))
                 );
-                assert!(events.iter().any(|(t, e)| t == "t1"
+                assert!(events.iter().any(|(t, e)| t.as_str() == "t1"
                     && matches!(e, AgentEvent::TextChunk { text } if text == "one")));
-                assert!(events.iter().any(|(t, e)| t == "t2"
+                assert!(events.iter().any(|(t, e)| t.as_str() == "t2"
                     && matches!(e, AgentEvent::TextChunk { text } if text == "two")));
             })
             .await;
@@ -701,9 +702,9 @@ mod tests {
             let (outcomes, events) = step.await.expect("join");
             assert_eq!(outcomes.len(), 1);
             assert!(matches!(outcomes[0].1, StepOutcome::Completed { .. }));
-            assert!(events.iter().any(|(t, e)| t == "t1"
+            assert!(events.iter().any(|(t, e)| t.as_str() == "t1"
                 && matches!(e, AgentEvent::OAuthRequired { auth_url } if auth_url == "https://example.com/auth")));
-            assert!(events.iter().any(|(t, e)| t == "t1"
+            assert!(events.iter().any(|(t, e)| t.as_str() == "t1"
                 && matches!(e, AgentEvent::UserInput { text } if text == "hello")));
         })
         .await;

--- a/crates/infinity-agent-core/src/system/config.rs
+++ b/crates/infinity-agent-core/src/system/config.rs
@@ -1,6 +1,7 @@
 //! Per-thread agent configuration: tools, system prompt, and tool-server
 //! notifier, resolved when a thread is loaded.
 
+use rap_protocol::ThreadId;
 use std::rc::Rc;
 
 use async_trait::async_trait;
@@ -36,7 +37,7 @@ pub struct ThreadConfig<M: InputSender, H: HttpClient> {
 /// long-lived system serve many differently-configured conversations.
 #[async_trait(?Send)]
 pub trait ThreadConfigSource<M: InputSender, H: HttpClient> {
-    async fn resolve(&self, thread_id: &str) -> Result<ThreadConfig<M, H>, BoxError>;
+    async fn resolve(&self, thread_id: &ThreadId) -> Result<ThreadConfig<M, H>, BoxError>;
 }
 
 /// The same fixed configuration for every thread — what
@@ -52,7 +53,7 @@ pub struct StaticThreadConfig<M: InputSender, H: HttpClient> {
 impl<M: InputSender + 'static, H: HttpClient + 'static> ThreadConfigSource<M, H>
     for StaticThreadConfig<M, H>
 {
-    async fn resolve(&self, _thread_id: &str) -> Result<ThreadConfig<M, H>, BoxError> {
+    async fn resolve(&self, _thread_id: &ThreadId) -> Result<ThreadConfig<M, H>, BoxError> {
         Ok(ThreadConfig {
             tools: self.tools.clone(),
             extra_system_prompt: self.extra_system_prompt.clone(),

--- a/crates/infinity-agent-core/src/system/config.rs
+++ b/crates/infinity-agent-core/src/system/config.rs
@@ -37,7 +37,7 @@ pub struct ThreadConfig<M: InputSender, H: HttpClient> {
 /// long-lived system serve many differently-configured conversations.
 #[async_trait(?Send)]
 pub trait ThreadConfigSource<M: InputSender, H: HttpClient> {
-    async fn resolve(&self, thread_id: &ThreadId) -> Result<ThreadConfig<M, H>, BoxError>;
+    async fn resolve(&self, thread_id: &ThreadId<str>) -> Result<ThreadConfig<M, H>, BoxError>;
 }
 
 /// The same fixed configuration for every thread — what
@@ -53,7 +53,7 @@ pub struct StaticThreadConfig<M: InputSender, H: HttpClient> {
 impl<M: InputSender + 'static, H: HttpClient + 'static> ThreadConfigSource<M, H>
     for StaticThreadConfig<M, H>
 {
-    async fn resolve(&self, _thread_id: &ThreadId) -> Result<ThreadConfig<M, H>, BoxError> {
+    async fn resolve(&self, _thread_id: &ThreadId<str>) -> Result<ThreadConfig<M, H>, BoxError> {
         Ok(ThreadConfig {
             tools: self.tools.clone(),
             extra_system_prompt: self.extra_system_prompt.clone(),

--- a/crates/infinity-agent-core/src/system/local/driver.rs
+++ b/crates/infinity-agent-core/src/system/local/driver.rs
@@ -7,6 +7,7 @@
 //! wait for. The [router](super::router) respawns a driver when new input
 //! arrives for an idle thread.
 
+use rap_protocol::ThreadId;
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
@@ -51,7 +52,7 @@ impl InFlightStep<'_> {
 }
 
 /// Set of thread IDs with a live driver.
-pub type ActiveThreads = Arc<Mutex<HashSet<String>>>;
+pub type ActiveThreads = Arc<Mutex<HashSet<ThreadId>>>;
 
 /// A transition in one thread driver's liveness.
 ///
@@ -61,7 +62,7 @@ pub type ActiveThreads = Arc<Mutex<HashSet<String>>>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ThreadLifecycleEvent {
     /// The thread whose driver changed state.
-    pub thread_id: String,
+    pub thread_id: ThreadId,
     /// The driver's new lifecycle state.
     pub state: ThreadLifecycleState,
 }
@@ -84,7 +85,7 @@ fn is_compaction_complete(msg: &InputMessage) -> bool {
 
 pub(crate) async fn drive_thread<C, S, H, O>(
     inner: Rc<SystemInner<C, S, ChannelSender, H>>,
-    thread_id: String,
+    thread_id: ThreadId,
     mut rx: mpsc::UnboundedReceiver<(InputMessage, String)>,
     mut subscribe_rx: mpsc::UnboundedReceiver<(O::SubscribeRequest, oneshot::Sender<()>)>,
     observer: O,
@@ -332,7 +333,7 @@ fn check_before_idle<C, S, H, O>(
     subscribe_rx: &mut mpsc::UnboundedReceiver<(O::SubscribeRequest, oneshot::Sender<()>)>,
     observer: &O,
     thread: &Thread<C, S, ChannelSender, H>,
-    thread_id: &str,
+    thread_id: &ThreadId,
 ) -> IdleDecision
 where
     C: ConversationStore + 'static,
@@ -364,7 +365,7 @@ where
 fn handle_step_result(
     res: Result<StepOutcome, BoxError>,
     observer: &impl ThreadObserver,
-    thread_id: &str,
+    thread_id: &ThreadId,
     total_tokens: &mut u64,
     compaction_triggered: &mut bool,
     pending_batch: &mut Vec<(InputMessage, String)>,
@@ -400,7 +401,7 @@ fn handle_step_result(
                 pending_batch.push((
                     InputMessage {
                         content: InputMessageContent::User(UserContent::text("")),
-                        group_id: thread_id.to_owned(),
+                        group_id: thread_id.clone(),
                         metadata: None,
                         synthetic: Some(SyntheticKind::Tagged(TaggedSyntheticKind::Compaction)),
                         display_as: None,
@@ -423,7 +424,7 @@ fn handle_step_result(
 }
 
 struct DriverGuard {
-    thread_id: String,
+    thread_id: ThreadId,
     active_threads: ActiveThreads,
     lifecycle_tx: mpsc::UnboundedSender<ThreadLifecycleEvent>,
 }
@@ -457,7 +458,7 @@ mod tests {
             .run_until(async {
                 let (mut running, mut rx, mut ctrl, _conv) =
                     start_system(vec![Box::new(SubscribeTool)], None);
-                running.send_user_text("t1", "subscribe").await;
+                running.send_user_text(&"t1".into(), "subscribe").await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_tool_call("tc-sub", "subscribe_tool", serde_json::json!({}));
                 ctrl.finish();
@@ -506,7 +507,7 @@ mod tests {
                 // Tiny context window so the usage report crosses the threshold.
                 let (mut running, mut rx, mut ctrl, _conv) =
                     start_system(vec![], Some(small_context_entry()));
-                running.send_user_text("t1", "hello").await;
+                running.send_user_text(&"t1".into(), "hello").await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_text("hi there");
                 ctrl.finish_with_usage(high_usage());

--- a/crates/infinity-agent-core/src/system/local/driver.rs
+++ b/crates/infinity-agent-core/src/system/local/driver.rs
@@ -100,7 +100,7 @@ pub(crate) async fn drive_thread<C, S, H, O>(
     active_threads
         .lock()
         .expect("bug: mutex poisoned")
-        .insert(thread_id.clone());
+        .insert(thread_id.to_owned());
     // Report liveness transitions at the same two points where
     // `active_threads` changes, so the channel and the set can never
     // disagree about a driver's state.
@@ -333,7 +333,7 @@ fn check_before_idle<C, S, H, O>(
     subscribe_rx: &mut mpsc::UnboundedReceiver<(O::SubscribeRequest, oneshot::Sender<()>)>,
     observer: &O,
     thread: &Thread<C, S, ChannelSender, H>,
-    thread_id: &ThreadId,
+    thread_id: &ThreadId<str>,
 ) -> IdleDecision
 where
     C: ConversationStore + 'static,
@@ -365,7 +365,7 @@ where
 fn handle_step_result(
     res: Result<StepOutcome, BoxError>,
     observer: &impl ThreadObserver,
-    thread_id: &ThreadId,
+    thread_id: &ThreadId<str>,
     total_tokens: &mut u64,
     compaction_triggered: &mut bool,
     pending_batch: &mut Vec<(InputMessage, String)>,
@@ -401,7 +401,7 @@ fn handle_step_result(
                 pending_batch.push((
                     InputMessage {
                         content: InputMessageContent::User(UserContent::text("")),
-                        group_id: thread_id.clone(),
+                        group_id: thread_id.to_owned(),
                         metadata: None,
                         synthetic: Some(SyntheticKind::Tagged(TaggedSyntheticKind::Compaction)),
                         display_as: None,
@@ -458,7 +458,9 @@ mod tests {
             .run_until(async {
                 let (mut running, mut rx, mut ctrl, _conv) =
                     start_system(vec![Box::new(SubscribeTool)], None);
-                running.send_user_text(&"t1".into(), "subscribe").await;
+                running
+                    .send_user_text(rap_protocol::ThreadId::from_ref("t1"), "subscribe")
+                    .await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_tool_call("tc-sub", "subscribe_tool", serde_json::json!({}));
                 ctrl.finish();
@@ -507,7 +509,9 @@ mod tests {
                 // Tiny context window so the usage report crosses the threshold.
                 let (mut running, mut rx, mut ctrl, _conv) =
                     start_system(vec![], Some(small_context_entry()));
-                running.send_user_text(&"t1".into(), "hello").await;
+                running
+                    .send_user_text(rap_protocol::ThreadId::from_ref("t1"), "hello")
+                    .await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_text("hi there");
                 ctrl.finish_with_usage(high_usage());

--- a/crates/infinity-agent-core/src/system/local/handle.rs
+++ b/crates/infinity-agent-core/src/system/local/handle.rs
@@ -41,7 +41,7 @@ pub(crate) struct HandleObserver {
 impl ThreadObserver for HandleObserver {
     type SubscribeRequest = HandleSubscribeRequest;
 
-    fn on_event(&self, thread_id: &ThreadId, event: &AgentEvent) {
+    fn on_event(&self, thread_id: &ThreadId<str>, event: &AgentEvent) {
         let mut subs = self.subscribers.borrow_mut();
         if let Some(list) = subs.get_mut(thread_id) {
             // Prune handles that have been dropped.
@@ -54,7 +54,7 @@ impl ThreadObserver for HandleObserver {
 
     fn on_subscribe(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         request: HandleSubscribeRequest,
         snapshot: ReplaySnapshot,
     ) {
@@ -62,7 +62,7 @@ impl ThreadObserver for HandleObserver {
         let _ = request.replay_tx.send(snapshot);
         self.subscribers
             .borrow_mut()
-            .entry(thread_id.clone())
+            .entry(thread_id.to_owned())
             .or_default()
             .push(request.events_tx);
     }
@@ -85,7 +85,7 @@ pub struct ThreadHandle {
 
 impl ThreadHandle {
     /// The thread this handle is attached to.
-    pub fn thread_id(&self) -> &ThreadId {
+    pub fn thread_id(&self) -> &ThreadId<str> {
         &self.thread_id
     }
 
@@ -126,7 +126,7 @@ impl ThreadHandle {
 /// down requires owning it, so a borrowed system's router is alive.
 pub(crate) async fn attach(
     running: &RunningSystem<HandleSubscribeRequest>,
-    thread_id: &ThreadId,
+    thread_id: &ThreadId<str>,
 ) -> ThreadHandle {
     let (events_tx, events) = mpsc::unbounded_channel();
     let (replay_tx, replay_rx) = oneshot::channel();
@@ -141,7 +141,7 @@ pub(crate) async fn attach(
         .await
         .expect("bug: subscribe acked without a replay");
     ThreadHandle {
-        thread_id: thread_id.clone(),
+        thread_id: thread_id.to_owned(),
         sender: running.sender(),
         events,
         replay,
@@ -150,7 +150,7 @@ pub(crate) async fn attach(
 
 /// A per-system factory for [`HandleObserver`]s sharing one subscriber
 /// registry (so subscriptions survive driver respawns).
-pub(crate) fn handle_observer_factory() -> impl Fn(&ThreadId) -> HandleObserver + 'static {
+pub(crate) fn handle_observer_factory() -> impl Fn(&ThreadId<str>) -> HandleObserver + 'static {
     let subscribers: Rc<RefCell<HashMap<ThreadId, Vec<mpsc::UnboundedSender<AgentEvent>>>>> =
         Default::default();
     move |_thread_id| HandleObserver {

--- a/crates/infinity-agent-core/src/system/local/handle.rs
+++ b/crates/infinity-agent-core/src/system/local/handle.rs
@@ -7,6 +7,7 @@
 //! [`ThreadBuilder`]: super::ThreadBuilder
 //! [`LaunchingSystem`]: super::LaunchingSystem
 
+use rap_protocol::ThreadId;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -33,14 +34,14 @@ pub(crate) struct HandleSubscribeRequest {
 /// shared across driver instances so handles survive driver idle and respawn.
 #[derive(Clone)]
 pub(crate) struct HandleObserver {
-    subscribers: Rc<RefCell<HashMap<String, Vec<mpsc::UnboundedSender<AgentEvent>>>>>,
+    subscribers: Rc<RefCell<HashMap<ThreadId, Vec<mpsc::UnboundedSender<AgentEvent>>>>>,
 }
 
 #[async_trait(?Send)]
 impl ThreadObserver for HandleObserver {
     type SubscribeRequest = HandleSubscribeRequest;
 
-    fn on_event(&self, thread_id: &str, event: &AgentEvent) {
+    fn on_event(&self, thread_id: &ThreadId, event: &AgentEvent) {
         let mut subs = self.subscribers.borrow_mut();
         if let Some(list) = subs.get_mut(thread_id) {
             // Prune handles that have been dropped.
@@ -53,7 +54,7 @@ impl ThreadObserver for HandleObserver {
 
     fn on_subscribe(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         request: HandleSubscribeRequest,
         snapshot: ReplaySnapshot,
     ) {
@@ -61,7 +62,7 @@ impl ThreadObserver for HandleObserver {
         let _ = request.replay_tx.send(snapshot);
         self.subscribers
             .borrow_mut()
-            .entry(thread_id.to_owned())
+            .entry(thread_id.clone())
             .or_default()
             .push(request.events_tx);
     }
@@ -73,7 +74,7 @@ impl ThreadObserver for HandleObserver {
 ///
 /// Dropping the handle detaches it; the thread itself is unaffected.
 pub struct ThreadHandle {
-    thread_id: String,
+    thread_id: ThreadId,
     sender: ChannelSender,
     /// The thread's events, in emission order, starting from the moment the
     /// handle attached. Every event is either reflected in
@@ -84,7 +85,7 @@ pub struct ThreadHandle {
 
 impl ThreadHandle {
     /// The thread this handle is attached to.
-    pub fn thread_id(&self) -> &str {
+    pub fn thread_id(&self) -> &ThreadId {
         &self.thread_id
     }
 
@@ -125,7 +126,7 @@ impl ThreadHandle {
 /// down requires owning it, so a borrowed system's router is alive.
 pub(crate) async fn attach(
     running: &RunningSystem<HandleSubscribeRequest>,
-    thread_id: &str,
+    thread_id: &ThreadId,
 ) -> ThreadHandle {
     let (events_tx, events) = mpsc::unbounded_channel();
     let (replay_tx, replay_rx) = oneshot::channel();
@@ -140,7 +141,7 @@ pub(crate) async fn attach(
         .await
         .expect("bug: subscribe acked without a replay");
     ThreadHandle {
-        thread_id: thread_id.to_owned(),
+        thread_id: thread_id.clone(),
         sender: running.sender(),
         events,
         replay,
@@ -149,8 +150,8 @@ pub(crate) async fn attach(
 
 /// A per-system factory for [`HandleObserver`]s sharing one subscriber
 /// registry (so subscriptions survive driver respawns).
-pub(crate) fn handle_observer_factory() -> impl Fn(&str) -> HandleObserver + 'static {
-    let subscribers: Rc<RefCell<HashMap<String, Vec<mpsc::UnboundedSender<AgentEvent>>>>> =
+pub(crate) fn handle_observer_factory() -> impl Fn(&ThreadId) -> HandleObserver + 'static {
+    let subscribers: Rc<RefCell<HashMap<ThreadId, Vec<mpsc::UnboundedSender<AgentEvent>>>>> =
         Default::default();
     move |_thread_id| HandleObserver {
         subscribers: subscribers.clone(),
@@ -333,7 +334,7 @@ mod tests {
                 // starts round 2.
                 handle
                     .send(
-                        tool_result_input(&thread_id, "tc-1", "tool done").0,
+                        tool_result_input(thread_id.as_str(), "tc-1", "tool done").0,
                         "res-1",
                     )
                     .await

--- a/crates/infinity-agent-core/src/system/local/launch.rs
+++ b/crates/infinity-agent-core/src/system/local/launch.rs
@@ -5,6 +5,7 @@
 //! ID and runs with the union of the system-wide configuration and the tools
 //! and prompt registered at launch.
 
+use rap_protocol::ThreadId;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -39,7 +40,7 @@ struct LaunchConfig<M: InputSender> {
 /// configuration only.
 #[derive(Clone)]
 pub(crate) struct LaunchRegistry<M: InputSender> {
-    threads: Rc<RefCell<HashMap<String, LaunchConfig<M>>>>,
+    threads: Rc<RefCell<HashMap<ThreadId, LaunchConfig<M>>>>,
 }
 
 impl<M: InputSender> Default for LaunchRegistry<M> {
@@ -55,15 +56,15 @@ impl<M: InputSender> Default for LaunchRegistry<M> {
 /// their root so they inherit its entry.
 async fn root_thread_id<C: ConversationStore>(
     store: &C,
-    thread_id: &str,
-) -> Result<String, BoxError> {
+    thread_id: &ThreadId,
+) -> Result<ThreadId, BoxError> {
     Ok(store
         .get_ancestor_chain(thread_id)
         .await
         .map_err(|e| Box::new(e) as BoxError)?
         .first()
         .map(|(id, _)| id.clone())
-        .unwrap_or_else(|| thread_id.to_owned()))
+        .unwrap_or_else(|| thread_id.clone()))
 }
 
 /// Wraps the system-wide [`ModelSource`]: threads launched with their own
@@ -81,7 +82,7 @@ where
     C: ConversationStore + 'static,
     M: InputSender + 'static,
 {
-    async fn resolve(&self, thread_id: &str) -> Result<ResolvedModel, BoxError> {
+    async fn resolve(&self, thread_id: &ThreadId) -> Result<ResolvedModel, BoxError> {
         let root_id = root_thread_id(&self.conversation_store, thread_id).await?;
         let launched = self
             .registry
@@ -115,7 +116,7 @@ where
     M: InputSender + 'static,
     H: HttpClient + 'static,
 {
-    async fn resolve(&self, thread_id: &str) -> Result<ThreadConfig<M, H>, BoxError> {
+    async fn resolve(&self, thread_id: &ThreadId) -> Result<ThreadConfig<M, H>, BoxError> {
         let mut config = self.inner.resolve(thread_id).await?;
         let root_id = root_thread_id(&self.conversation_store, thread_id).await?;
         if let Some(local) = self.registry.threads.borrow().get(&root_id) {
@@ -191,14 +192,17 @@ where
     /// Attach to an existing thread. Returns `Ok(None)` if the thread was not
     /// launched in this process and does not exist in the conversation store.
     /// New threads are created with [`thread_builder`](Self::thread_builder).
-    pub async fn thread_handle(&self, thread_id: &str) -> Result<Option<ThreadHandle>, C::Error> {
+    pub async fn thread_handle(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Option<ThreadHandle>, C::Error> {
         if !self.thread_exists(thread_id).await? {
             return Ok(None);
         }
         Ok(Some(attach(&self.running, thread_id).await))
     }
 
-    async fn thread_exists(&self, thread_id: &str) -> Result<bool, C::Error> {
+    async fn thread_exists(&self, thread_id: &ThreadId) -> Result<bool, C::Error> {
         if self.registry.threads.borrow().contains_key(thread_id) {
             return Ok(true);
         }
@@ -292,7 +296,7 @@ where
     /// thread resumed after a restart runs with the system-wide
     /// configuration only.
     pub async fn launch(self) -> ThreadHandle {
-        let thread_id = uuid::Uuid::new_v4().to_string();
+        let thread_id = ThreadId::from(uuid::Uuid::new_v4().to_string());
         self.system.registry.threads.borrow_mut().insert(
             thread_id.clone(),
             LaunchConfig {
@@ -373,7 +377,7 @@ mod tests {
                 // Unknown threads cannot be attached to.
                 assert!(
                     system
-                        .thread_handle("no-such-thread")
+                        .thread_handle(&"no-such-thread".into())
                         .await
                         .expect("check unknown thread")
                         .is_none()

--- a/crates/infinity-agent-core/src/system/local/launch.rs
+++ b/crates/infinity-agent-core/src/system/local/launch.rs
@@ -56,7 +56,7 @@ impl<M: InputSender> Default for LaunchRegistry<M> {
 /// their root so they inherit its entry.
 async fn root_thread_id<C: ConversationStore>(
     store: &C,
-    thread_id: &ThreadId,
+    thread_id: &ThreadId<str>,
 ) -> Result<ThreadId, BoxError> {
     Ok(store
         .get_ancestor_chain(thread_id)
@@ -64,7 +64,7 @@ async fn root_thread_id<C: ConversationStore>(
         .map_err(|e| Box::new(e) as BoxError)?
         .first()
         .map(|(id, _)| id.clone())
-        .unwrap_or_else(|| thread_id.clone()))
+        .unwrap_or_else(|| thread_id.to_owned()))
 }
 
 /// Wraps the system-wide [`ModelSource`]: threads launched with their own
@@ -82,7 +82,7 @@ where
     C: ConversationStore + 'static,
     M: InputSender + 'static,
 {
-    async fn resolve(&self, thread_id: &ThreadId) -> Result<ResolvedModel, BoxError> {
+    async fn resolve(&self, thread_id: &ThreadId<str>) -> Result<ResolvedModel, BoxError> {
         let root_id = root_thread_id(&self.conversation_store, thread_id).await?;
         let launched = self
             .registry
@@ -116,7 +116,7 @@ where
     M: InputSender + 'static,
     H: HttpClient + 'static,
 {
-    async fn resolve(&self, thread_id: &ThreadId) -> Result<ThreadConfig<M, H>, BoxError> {
+    async fn resolve(&self, thread_id: &ThreadId<str>) -> Result<ThreadConfig<M, H>, BoxError> {
         let mut config = self.inner.resolve(thread_id).await?;
         let root_id = root_thread_id(&self.conversation_store, thread_id).await?;
         if let Some(local) = self.registry.threads.borrow().get(&root_id) {
@@ -194,7 +194,7 @@ where
     /// New threads are created with [`thread_builder`](Self::thread_builder).
     pub async fn thread_handle(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Option<ThreadHandle>, C::Error> {
         if !self.thread_exists(thread_id).await? {
             return Ok(None);
@@ -202,7 +202,7 @@ where
         Ok(Some(attach(&self.running, thread_id).await))
     }
 
-    async fn thread_exists(&self, thread_id: &ThreadId) -> Result<bool, C::Error> {
+    async fn thread_exists(&self, thread_id: &ThreadId<str>) -> Result<bool, C::Error> {
         if self.registry.threads.borrow().contains_key(thread_id) {
             return Ok(true);
         }
@@ -377,7 +377,7 @@ mod tests {
                 // Unknown threads cannot be attached to.
                 assert!(
                     system
-                        .thread_handle(&"no-such-thread".into())
+                        .thread_handle(rap_protocol::ThreadId::from_ref("no-such-thread"))
                         .await
                         .expect("check unknown thread")
                         .is_none()

--- a/crates/infinity-agent-core/src/system/local/router.rs
+++ b/crates/infinity-agent-core/src/system/local/router.rs
@@ -52,9 +52,13 @@ impl<Sub: Send + 'static> SubscribeHandle<Sub> {
     /// message's events. A driver that exits while requests race in hands
     /// them back to the router, so installation is reliable; `false` is
     /// returned only if the whole system was shut down.
-    pub async fn subscribe(&self, thread_id: &ThreadId, request: Sub) -> bool {
+    pub async fn subscribe(&self, thread_id: &ThreadId<str>, request: Sub) -> bool {
         let (ack_tx, ack_rx) = oneshot::channel();
-        if self.tx.send((thread_id.clone(), request, ack_tx)).is_err() {
+        if self
+            .tx
+            .send((thread_id.to_owned(), request, ack_tx))
+            .is_err()
+        {
             return false;
         }
         // An error means the ack sender was dropped mid-shutdown — the
@@ -98,14 +102,14 @@ impl<Sub: Send + 'static> RunningSystem<Sub> {
     }
 
     /// Convenience: send plain user text to a thread.
-    pub async fn send_user_text(&self, thread_id: &ThreadId, text: impl Into<String>) {
-        let msg = InputMessage::user_text(thread_id.clone(), text);
+    pub async fn send_user_text(&self, thread_id: &ThreadId<str>, text: impl Into<String>) {
+        let msg = InputMessage::user_text(thread_id.to_owned(), text);
         self.send(msg, &uuid::Uuid::new_v4().to_string()).await
     }
 
     /// Attach a subscriber to a thread; resolves once the subscriber is
     /// installed. See [`SubscribeHandle::subscribe`].
-    pub async fn subscribe(&self, thread_id: &ThreadId, request: Sub) {
+    pub async fn subscribe(&self, thread_id: &ThreadId<str>, request: Sub) {
         assert!(
             self.subscribe_handle().subscribe(thread_id, request).await,
             "bug: router exited while the system was alive"
@@ -176,7 +180,7 @@ where
     pub fn start_with_observer<O, F>(self, make_observer: F) -> RunningSystem<O::SubscribeRequest>
     where
         O: ThreadObserver + 'static,
-        F: Fn(&ThreadId) -> O + 'static,
+        F: Fn(&ThreadId<str>) -> O + 'static,
     {
         self.start_inner(make_observer)
     }
@@ -193,7 +197,7 @@ where
     pub(crate) fn start_inner<O, F>(self, make_observer: F) -> RunningSystem<O::SubscribeRequest>
     where
         O: ThreadObserver + 'static,
-        F: Fn(&ThreadId) -> O + 'static,
+        F: Fn(&ThreadId<str>) -> O + 'static,
     {
         let sender = self.system.inner.sender.clone();
         let (subscribe_tx, subscribe_rx) = mpsc::unbounded_channel();
@@ -245,7 +249,7 @@ async fn route_loop<C, S, H, O, F>(
     S: StateStore + 'static,
     H: HttpClient + 'static,
     O: ThreadObserver + 'static,
-    F: Fn(&ThreadId) -> O + 'static,
+    F: Fn(&ThreadId<str>) -> O + 'static,
 {
     let mut workers: HashMap<ThreadId, WorkerChannels<O::SubscribeRequest>> = HashMap::new();
     let mut subscribe_closed = false;
@@ -416,7 +420,9 @@ mod tests {
                 let (mut running, mut rx, mut ctrl, conv) = start_system(vec![], None);
 
                 // Create a real thread so the system is not trivially empty.
-                running.send_user_text(&"t1".into(), "hello").await;
+                running
+                    .send_user_text(rap_protocol::ThreadId::from_ref("t1"), "hello")
+                    .await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_text("hi");
                 ctrl.finish();
@@ -455,7 +461,8 @@ mod tests {
                     );
                 }
                 assert!(
-                    conv.thread_info(&"ghost".into()).is_none(),
+                    conv.thread_info(rap_protocol::ThreadId::from_ref("ghost"))
+                        .is_none(),
                     "a dropped event must not create thread records"
                 );
             })
@@ -470,12 +477,17 @@ mod tests {
         local
             .run_until(async {
                 let (running, mut rx, mut ctrl, conv) = start_system(vec![], None);
-                running.send_user_text(&"brand-new".into(), "hello").await;
+                running
+                    .send_user_text(rap_protocol::ThreadId::from_ref("brand-new"), "hello")
+                    .await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_text("created");
                 ctrl.finish();
                 collect_until_finished(&mut rx).await;
-                assert!(conv.thread_info(&"brand-new".into()).is_some());
+                assert!(
+                    conv.thread_info(rap_protocol::ThreadId::from_ref("brand-new"))
+                        .is_some()
+                );
             })
             .await;
     }
@@ -491,7 +503,9 @@ mod tests {
             .run_until(async {
                 let (mut running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
 
-                running.send_user_text(&"t1".into(), "hello").await;
+                running
+                    .send_user_text(rap_protocol::ThreadId::from_ref("t1"), "hello")
+                    .await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_text("hi");
                 ctrl.finish();
@@ -547,7 +561,9 @@ mod tests {
         local
             .run_until(async {
                 let (running, mut rx, mut ctrl, conv) = start_system(vec![], None);
-                running.send_user_text(&"t1".into(), "hello").await;
+                running
+                    .send_user_text(rap_protocol::ThreadId::from_ref("t1"), "hello")
+                    .await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_text("partial answer");
                 loop {
@@ -561,7 +577,7 @@ mod tests {
 
                 use crate::traits::ConversationStore;
                 let history = conv
-                    .load_history_up_to(&"t1".into(), None, None)
+                    .load_history_up_to(rap_protocol::ThreadId::from_ref("t1"), None, None)
                     .await
                     .expect("load history");
                 assert!(

--- a/crates/infinity-agent-core/src/system/local/router.rs
+++ b/crates/infinity-agent-core/src/system/local/router.rs
@@ -4,6 +4,7 @@
 //! `FuturesUnordered` pool rather than one spawned task per thread), so a
 //! driver's memory is fully released the moment it goes idle.
 
+use rap_protocol::ThreadId;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -25,7 +26,7 @@ use crate::system::thread::is_user_text_input;
 /// A subscribe request routed through the local system: the target thread,
 /// the observer-specific request, and an ack fired once the subscriber has
 /// been installed (its replay sent and its registration completed).
-pub(crate) type SubscribeMessage<Sub> = (String, Sub, oneshot::Sender<()>);
+pub(crate) type SubscribeMessage<Sub> = (ThreadId, Sub, oneshot::Sender<()>);
 
 /// A clonable handle for attaching subscribers to a running system's threads.
 pub struct SubscribeHandle<Sub: Send + 'static> {
@@ -51,13 +52,9 @@ impl<Sub: Send + 'static> SubscribeHandle<Sub> {
     /// message's events. A driver that exits while requests race in hands
     /// them back to the router, so installation is reliable; `false` is
     /// returned only if the whole system was shut down.
-    pub async fn subscribe(&self, thread_id: &str, request: Sub) -> bool {
+    pub async fn subscribe(&self, thread_id: &ThreadId, request: Sub) -> bool {
         let (ack_tx, ack_rx) = oneshot::channel();
-        if self
-            .tx
-            .send((thread_id.to_owned(), request, ack_tx))
-            .is_err()
-        {
+        if self.tx.send((thread_id.clone(), request, ack_tx)).is_err() {
             return false;
         }
         // An error means the ack sender was dropped mid-shutdown — the
@@ -101,14 +98,14 @@ impl<Sub: Send + 'static> RunningSystem<Sub> {
     }
 
     /// Convenience: send plain user text to a thread.
-    pub async fn send_user_text(&self, thread_id: &str, text: impl Into<String>) {
-        let msg = InputMessage::user_text(thread_id, text);
+    pub async fn send_user_text(&self, thread_id: &ThreadId, text: impl Into<String>) {
+        let msg = InputMessage::user_text(thread_id.clone(), text);
         self.send(msg, &uuid::Uuid::new_v4().to_string()).await
     }
 
     /// Attach a subscriber to a thread; resolves once the subscriber is
     /// installed. See [`SubscribeHandle::subscribe`].
-    pub async fn subscribe(&self, thread_id: &str, request: Sub) {
+    pub async fn subscribe(&self, thread_id: &ThreadId, request: Sub) {
         assert!(
             self.subscribe_handle().subscribe(thread_id, request).await,
             "bug: router exited while the system was alive"
@@ -179,7 +176,7 @@ where
     pub fn start_with_observer<O, F>(self, make_observer: F) -> RunningSystem<O::SubscribeRequest>
     where
         O: ThreadObserver + 'static,
-        F: Fn(&str) -> O + 'static,
+        F: Fn(&ThreadId) -> O + 'static,
     {
         self.start_inner(make_observer)
     }
@@ -196,7 +193,7 @@ where
     pub(crate) fn start_inner<O, F>(self, make_observer: F) -> RunningSystem<O::SubscribeRequest>
     where
         O: ThreadObserver + 'static,
-        F: Fn(&str) -> O + 'static,
+        F: Fn(&ThreadId) -> O + 'static,
     {
         let sender = self.system.inner.sender.clone();
         let (subscribe_tx, subscribe_rx) = mpsc::unbounded_channel();
@@ -232,7 +229,7 @@ struct WorkerChannels<Sub> {
 
 enum RoutedMessage<Sub> {
     Input(Box<InputMessage>, String),
-    Subscribe(String, Sub, oneshot::Sender<()>),
+    Subscribe(ThreadId, Sub, oneshot::Sender<()>),
 }
 
 async fn route_loop<C, S, H, O, F>(
@@ -248,9 +245,9 @@ async fn route_loop<C, S, H, O, F>(
     S: StateStore + 'static,
     H: HttpClient + 'static,
     O: ThreadObserver + 'static,
-    F: Fn(&str) -> O + 'static,
+    F: Fn(&ThreadId) -> O + 'static,
 {
-    let mut workers: HashMap<String, WorkerChannels<O::SubscribeRequest>> = HashMap::new();
+    let mut workers: HashMap<ThreadId, WorkerChannels<O::SubscribeRequest>> = HashMap::new();
     let mut subscribe_closed = false;
     // The router owns the driver futures directly (instead of spawning each
     // as its own task): a completed driver yields its thread ID and its
@@ -264,7 +261,7 @@ async fn route_loop<C, S, H, O, F>(
             biased;
             _ = shutdown.cancelled() => None,
             exited = drivers.next(), if !drivers.is_empty() => {
-                let exited: String = exited.expect("bug: drivers is empty");
+                let exited: ThreadId = exited.expect("bug: drivers is empty");
                 // Only remove the exited driver's own entry: if the thread
                 // already respawned, the new entry's channel is still open.
                 if workers.get(&exited).is_some_and(|w| w.input_tx.is_closed()) {
@@ -419,7 +416,7 @@ mod tests {
                 let (mut running, mut rx, mut ctrl, conv) = start_system(vec![], None);
 
                 // Create a real thread so the system is not trivially empty.
-                running.send_user_text("t1", "hello").await;
+                running.send_user_text(&"t1".into(), "hello").await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_text("hi");
                 ctrl.finish();
@@ -452,12 +449,13 @@ mod tests {
                 // never appear is any transition for the ghost thread.
                 while let Ok(event) = running.try_next_lifecycle_event() {
                     assert_ne!(
-                        event.thread_id, "ghost",
+                        event.thread_id.as_str(),
+                        "ghost",
                         "no lifecycle transition may be reported for a dropped event"
                     );
                 }
                 assert!(
-                    conv.thread_info("ghost").is_none(),
+                    conv.thread_info(&"ghost".into()).is_none(),
                     "a dropped event must not create thread records"
                 );
             })
@@ -472,12 +470,12 @@ mod tests {
         local
             .run_until(async {
                 let (running, mut rx, mut ctrl, conv) = start_system(vec![], None);
-                running.send_user_text("brand-new", "hello").await;
+                running.send_user_text(&"brand-new".into(), "hello").await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_text("created");
                 ctrl.finish();
                 collect_until_finished(&mut rx).await;
-                assert!(conv.thread_info("brand-new").is_some());
+                assert!(conv.thread_info(&"brand-new".into()).is_some());
             })
             .await;
     }
@@ -493,7 +491,7 @@ mod tests {
             .run_until(async {
                 let (mut running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
 
-                running.send_user_text("t1", "hello").await;
+                running.send_user_text(&"t1".into(), "hello").await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_text("hi");
                 ctrl.finish();
@@ -519,7 +517,7 @@ mod tests {
                 assert_eq!(
                     live,
                     ThreadLifecycleEvent {
-                        thread_id: "t1".to_owned(),
+                        thread_id: "t1".into(),
                         state: ThreadLifecycleState::Live,
                     },
                     "the existing thread's driver must wake"
@@ -534,7 +532,7 @@ mod tests {
                 assert_eq!(
                     idle,
                     ThreadLifecycleEvent {
-                        thread_id: "t1".to_owned(),
+                        thread_id: "t1".into(),
                         state: ThreadLifecycleState::Idle,
                     },
                     "the respawned driver must idle back out"
@@ -549,7 +547,7 @@ mod tests {
         local
             .run_until(async {
                 let (running, mut rx, mut ctrl, conv) = start_system(vec![], None);
-                running.send_user_text("t1", "hello").await;
+                running.send_user_text(&"t1".into(), "hello").await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_text("partial answer");
                 loop {
@@ -563,7 +561,7 @@ mod tests {
 
                 use crate::traits::ConversationStore;
                 let history = conv
-                    .load_history_up_to("t1", None, None)
+                    .load_history_up_to(&"t1".into(), None, None)
                     .await
                     .expect("load history");
                 assert!(

--- a/crates/infinity-agent-core/src/system/model.rs
+++ b/crates/infinity-agent-core/src/system/model.rs
@@ -1,5 +1,6 @@
 //! The [`ModelSource`] trait: choosing the model for each completion round.
 
+use rap_protocol::ThreadId;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -29,7 +30,7 @@ pub struct ResolvedModel {
 /// completion always finishes on the model it started with.
 #[async_trait(?Send)]
 pub trait ModelSource {
-    async fn resolve(&self, thread_id: &str) -> Result<ResolvedModel, BoxError>;
+    async fn resolve(&self, thread_id: &ThreadId) -> Result<ResolvedModel, BoxError>;
 }
 
 /// A fixed model used for every thread and every round.
@@ -64,7 +65,7 @@ impl StaticModel {
 
 #[async_trait(?Send)]
 impl ModelSource for StaticModel {
-    async fn resolve(&self, _thread_id: &str) -> Result<ResolvedModel, BoxError> {
+    async fn resolve(&self, _thread_id: &ThreadId) -> Result<ResolvedModel, BoxError> {
         Ok(self.resolved.clone())
     }
 }

--- a/crates/infinity-agent-core/src/system/model.rs
+++ b/crates/infinity-agent-core/src/system/model.rs
@@ -30,7 +30,7 @@ pub struct ResolvedModel {
 /// completion always finishes on the model it started with.
 #[async_trait(?Send)]
 pub trait ModelSource {
-    async fn resolve(&self, thread_id: &ThreadId) -> Result<ResolvedModel, BoxError>;
+    async fn resolve(&self, thread_id: &ThreadId<str>) -> Result<ResolvedModel, BoxError>;
 }
 
 /// A fixed model used for every thread and every round.
@@ -65,7 +65,7 @@ impl StaticModel {
 
 #[async_trait(?Send)]
 impl ModelSource for StaticModel {
-    async fn resolve(&self, _thread_id: &ThreadId) -> Result<ResolvedModel, BoxError> {
+    async fn resolve(&self, _thread_id: &ThreadId<str>) -> Result<ResolvedModel, BoxError> {
         Ok(self.resolved.clone())
     }
 }

--- a/crates/infinity-agent-core/src/system/observer.rs
+++ b/crates/infinity-agent-core/src/system/observer.rs
@@ -1,6 +1,7 @@
 //! The [`ThreadObserver`] trait: how embeddings observe thread execution.
 
 use async_trait::async_trait;
+use rap_protocol::ThreadId;
 use std::cell::RefCell;
 
 use super::events::{AgentEvent, ReplaySnapshot};
@@ -34,7 +35,7 @@ pub trait ThreadObserver {
 
     /// A display event was emitted. Called synchronously at the emission
     /// point; keep this fast (fan-out, buffering).
-    fn on_event(&self, thread_id: &str, event: &AgentEvent);
+    fn on_event(&self, thread_id: &ThreadId, event: &AgentEvent);
 
     /// A subscriber attached to a running thread (local driver mode only;
     /// step-mode embeddings never receive this call).
@@ -62,7 +63,7 @@ pub trait ThreadObserver {
     /// race.
     fn on_subscribe(
         &self,
-        _thread_id: &str,
+        _thread_id: &ThreadId,
         _request: Self::SubscribeRequest,
         _snapshot: ReplaySnapshot,
     ) {
@@ -75,7 +76,7 @@ pub trait ThreadObserver {
 /// multiple threads.
 #[derive(Default)]
 pub struct EventCollector {
-    events: RefCell<Vec<(String, AgentEvent)>>,
+    events: RefCell<Vec<(ThreadId, AgentEvent)>>,
 }
 
 impl EventCollector {
@@ -85,7 +86,7 @@ impl EventCollector {
 
     /// Take the buffered `(thread_id, event)` pairs, leaving the collector
     /// empty.
-    pub fn take(&self) -> Vec<(String, AgentEvent)> {
+    pub fn take(&self) -> Vec<(ThreadId, AgentEvent)> {
         std::mem::take(&mut *self.events.borrow_mut())
     }
 }
@@ -94,9 +95,9 @@ impl EventCollector {
 impl ThreadObserver for EventCollector {
     type SubscribeRequest = ();
 
-    fn on_event(&self, thread_id: &str, event: &AgentEvent) {
+    fn on_event(&self, thread_id: &ThreadId, event: &AgentEvent) {
         self.events
             .borrow_mut()
-            .push((thread_id.to_owned(), event.clone()));
+            .push((thread_id.clone(), event.clone()));
     }
 }

--- a/crates/infinity-agent-core/src/system/observer.rs
+++ b/crates/infinity-agent-core/src/system/observer.rs
@@ -35,7 +35,7 @@ pub trait ThreadObserver {
 
     /// A display event was emitted. Called synchronously at the emission
     /// point; keep this fast (fan-out, buffering).
-    fn on_event(&self, thread_id: &ThreadId, event: &AgentEvent);
+    fn on_event(&self, thread_id: &ThreadId<str>, event: &AgentEvent);
 
     /// A subscriber attached to a running thread (local driver mode only;
     /// step-mode embeddings never receive this call).
@@ -63,7 +63,7 @@ pub trait ThreadObserver {
     /// race.
     fn on_subscribe(
         &self,
-        _thread_id: &ThreadId,
+        _thread_id: &ThreadId<str>,
         _request: Self::SubscribeRequest,
         _snapshot: ReplaySnapshot,
     ) {
@@ -95,9 +95,9 @@ impl EventCollector {
 impl ThreadObserver for EventCollector {
     type SubscribeRequest = ();
 
-    fn on_event(&self, thread_id: &ThreadId, event: &AgentEvent) {
+    fn on_event(&self, thread_id: &ThreadId<str>, event: &AgentEvent) {
         self.events
             .borrow_mut()
-            .push((thread_id.clone(), event.clone()));
+            .push((thread_id.to_owned(), event.clone()));
     }
 }

--- a/crates/infinity-agent-core/src/system/test_support.rs
+++ b/crates/infinity-agent-core/src/system/test_support.rs
@@ -40,13 +40,13 @@ pub(crate) struct TestObserver {
 impl ThreadObserver for TestObserver {
     type SubscribeRequest = mpsc::UnboundedSender<Evt>;
 
-    fn on_event(&self, _thread_id: &ThreadId, event: &AgentEvent) {
+    fn on_event(&self, _thread_id: &ThreadId<str>, event: &AgentEvent) {
         let _ = self.tx.send(Evt::E(event.clone()));
     }
 
     fn on_subscribe(
         &self,
-        _thread_id: &ThreadId,
+        _thread_id: &ThreadId<str>,
         request: Self::SubscribeRequest,
         snapshot: ReplaySnapshot,
     ) {

--- a/crates/infinity-agent-core/src/system/test_support.rs
+++ b/crates/infinity-agent-core/src/system/test_support.rs
@@ -1,5 +1,6 @@
 //! Shared fixtures for system unit tests.
 
+use rap_protocol::ThreadId;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -39,13 +40,13 @@ pub(crate) struct TestObserver {
 impl ThreadObserver for TestObserver {
     type SubscribeRequest = mpsc::UnboundedSender<Evt>;
 
-    fn on_event(&self, _thread_id: &str, event: &AgentEvent) {
+    fn on_event(&self, _thread_id: &ThreadId, event: &AgentEvent) {
         let _ = self.tx.send(Evt::E(event.clone()));
     }
 
     fn on_subscribe(
         &self,
-        _thread_id: &str,
+        _thread_id: &ThreadId,
         request: Self::SubscribeRequest,
         snapshot: ReplaySnapshot,
     ) {

--- a/crates/infinity-agent-core/src/system/tests.rs
+++ b/crates/infinity-agent-core/src/system/tests.rs
@@ -4,6 +4,7 @@
 use async_trait::async_trait;
 use infinity_provider_protocol::StreamChunk;
 use infinity_provider_protocol::message::UserContent;
+use rap_protocol::ThreadId;
 use tokio::sync::mpsc;
 
 use super::events::AgentEvent;
@@ -25,10 +26,10 @@ async fn pending_choices_are_thread_local_and_replayed() {
 
             let (model, _ctrl) = model_source(None);
             let conv = InMemoryConversationStore::new();
-            conv.ensure_root_thread(&"t1".into())
+            conv.ensure_root_thread(ThreadId::from_ref("t1"))
                 .await
                 .expect("ensure root");
-            conv.ensure_root_thread(&"t2".into())
+            conv.ensure_root_thread(ThreadId::from_ref("t2"))
                 .await
                 .expect("ensure root");
             let state = InMemoryStateStore::new();
@@ -70,7 +71,7 @@ async fn pending_choices_are_thread_local_and_replayed() {
 
             assert_eq!(
                 state
-                    .get_pending_user_choices(&"t1".into())
+                    .get_pending_user_choices(ThreadId::from_ref("t1"))
                     .await
                     .expect("load first thread choices")[0]
                     .id,
@@ -78,7 +79,7 @@ async fn pending_choices_are_thread_local_and_replayed() {
             );
             assert_eq!(
                 state
-                    .get_pending_user_choices(&"t2".into())
+                    .get_pending_user_choices(ThreadId::from_ref("t2"))
                     .await
                     .expect("load second thread choices")[0]
                     .id,
@@ -88,14 +89,14 @@ async fn pending_choices_are_thread_local_and_replayed() {
             let (sub_tx, mut sub_rx) = mpsc::unbounded_channel();
             let replay_conv = InMemoryConversationStore::new();
             replay_conv
-                .ensure_root_thread(&"t1".into())
+                .ensure_root_thread(ThreadId::from_ref("t1"))
                 .await
                 .expect("ensure replay root");
             let running = AgentSystemBuilder::new_local(replay_conv, state, model_source(None).0)
                 .start_with_observer(|_| TestObserver {
                     tx: mpsc::unbounded_channel().0,
                 });
-            running.subscribe(&"t1".into(), sub_tx).await;
+            running.subscribe(ThreadId::from_ref("t1"), sub_tx).await;
             let Evt::Replay(snapshot) = next_evt(&mut sub_rx).await else {
                 panic!("expected replay");
             };
@@ -111,7 +112,9 @@ async fn driver_idles_after_text_response() {
     local
         .run_until(async {
             let (mut running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
-            running.send_user_text(&"t1".into(), "hello").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "hello")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("hi there");
             ctrl.finish();
@@ -130,7 +133,9 @@ async fn driver_stays_alive_waiting_for_tool_result() {
         .run_until(async {
             let (mut running, mut rx, mut ctrl, _conv) =
                 start_system(vec![Box::new(AsyncTool)], None);
-            running.send_user_text(&"t1".into(), "use tool").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "use tool")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -151,7 +156,7 @@ async fn driver_stays_alive_waiting_for_tool_result() {
             // A client attaching while waiting gets a replay whose history
             // ends with the unresolved tool call and no completion in flight.
             let (sub_tx, mut sub_rx) = mpsc::unbounded_channel();
-            running.subscribe(&"t1".into(), sub_tx).await;
+            running.subscribe(ThreadId::from_ref("t1"), sub_tx).await;
             match next_evt(&mut sub_rx).await {
                 Evt::Replay(snapshot) => {
                     assert!(!snapshot.in_progress);
@@ -183,7 +188,9 @@ async fn user_text_interrupts_active_completion() {
     local
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
-            running.send_user_text(&"t1".into(), "first").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "first")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("partial...");
             // Wait until the chunk is observed so the completion is in flight.
@@ -192,7 +199,9 @@ async fn user_text_interrupts_active_completion() {
                     break;
                 }
             }
-            running.send_user_text(&"t1".into(), "stop that").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "stop that")
+                .await;
             let req2 = ctrl.next_request().await;
             let has_interrupt = req2.chat_history.into_iter().any(|m| {
                 if let infinity_provider_protocol::message::Message::User { content } = &m
@@ -218,7 +227,9 @@ async fn non_user_text_during_completion_does_not_interrupt() {
     local
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![Box::new(AsyncTool)], None);
-            running.send_user_text(&"t1".into(), "do stuff").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "do stuff")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -261,7 +272,9 @@ async fn subscription_event_queued_during_completion_processed_after() {
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) =
                 start_system(vec![Box::new(SubscribeTool)], None);
-            running.send_user_text(&"t1".into(), "subscribe").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "subscribe")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-sub", "subscribe_tool", serde_json::json!({}));
             ctrl.finish();
@@ -338,7 +351,9 @@ async fn driver_idles_after_close_thread_tool_call() {
             }
             let (mut running, mut rx, mut ctrl, _conv) =
                 start_system_with(vec![Box::new(CloseThreadStub)], None, false);
-            running.send_user_text(&"t1".into(), "close").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "close")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call(
                 "tc-1",
@@ -363,7 +378,9 @@ async fn thread_report_deferred_during_async_tool_wait() {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![Box::new(AsyncTool)], None);
 
             // 1. User sends input, model calls async_tool.
-            running.send_user_text(&"t1".into(), "do async").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "do async")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-async", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -436,7 +453,9 @@ async fn shutdown_persists_in_flight_tool_result() {
             let (running, mut rx, mut ctrl, conv) = start_system(vec![Box::new(AsyncTool)], None);
 
             // 1. User input → model issues an async tool call.
-            running.send_user_text(&"t1".into(), "do something").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "do something")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -468,7 +487,7 @@ async fn shutdown_persists_in_flight_tool_result() {
             // 4. The tool result must have been synced to the store.
             use crate::traits::ConversationStore;
             let history = conv
-                .load_history_up_to(&"t1".into(), None, None)
+                .load_history_up_to(ThreadId::from_ref("t1"), None, None)
                 .await
                 .expect("load history");
             let has_tool_result = history.iter().any(|m| {
@@ -495,7 +514,9 @@ async fn subscription_event_deferred_during_async_tool_wait() {
     local
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![Box::new(AsyncTool)], None);
-            running.send_user_text(&"t1".into(), "do async").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "do async")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-async", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -542,7 +563,9 @@ async fn stale_result_does_not_flush_deferred_events_during_async_tool_wait() {
     local
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![Box::new(AsyncTool)], None);
-            running.send_user_text(&"t1".into(), "do async").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "do async")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-async", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -594,7 +617,9 @@ async fn subscribe_mid_thinking_replays_current_thinking() {
     local
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
-            running.send_user_text(&"t1".into(), "think hard").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "think hard")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_chunk(StreamChunk::ReasoningDelta {
                 id: None,
@@ -613,7 +638,7 @@ async fn subscribe_mid_thinking_replays_current_thinking() {
             }
 
             let (sub_tx, mut sub_rx) = mpsc::unbounded_channel();
-            running.subscribe(&"t1".into(), sub_tx).await;
+            running.subscribe(ThreadId::from_ref("t1"), sub_tx).await;
             match next_evt(&mut sub_rx).await {
                 Evt::Replay(snapshot) => {
                     assert!(snapshot.in_progress, "completion is in flight");
@@ -630,7 +655,7 @@ async fn subscribe_mid_thinking_replays_current_thinking() {
                 }
             }
             let (sub_tx2, mut sub_rx2) = mpsc::unbounded_channel();
-            running.subscribe(&"t1".into(), sub_tx2).await;
+            running.subscribe(ThreadId::from_ref("t1"), sub_tx2).await;
             match next_evt(&mut sub_rx2).await {
                 Evt::Replay(snapshot) => {
                     assert!(snapshot.in_progress);
@@ -656,13 +681,17 @@ async fn routes_to_separate_threads() {
     local
         .run_until(async {
             let (mut running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
-            running.send_user_text(&"t1".into(), "one").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "one")
+                .await;
             let _r1 = ctrl.next_request().await;
             ctrl.send_text("first");
             ctrl.finish();
             collect_until_finished(&mut rx).await;
 
-            running.send_user_text(&"t2".into(), "two").await;
+            running
+                .send_user_text(ThreadId::from_ref("t2"), "two")
+                .await;
             let _r2 = ctrl.next_request().await;
             ctrl.send_text("second");
             ctrl.finish();
@@ -679,7 +708,9 @@ async fn respawns_driver_after_idle() {
     local
         .run_until(async {
             let (mut running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
-            running.send_user_text(&"t1".into(), "hello").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "hello")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("hi");
             ctrl.finish();
@@ -688,7 +719,9 @@ async fn respawns_driver_after_idle() {
             assert!(running.is_idle());
 
             // A new message respawns the driver; the history is intact.
-            running.send_user_text(&"t1".into(), "again").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "again")
+                .await;
             let req2 = ctrl.next_request().await;
             assert!(req2.chat_history.into_iter().any(|m| {
                 if let infinity_provider_protocol::message::Message::User { content } = &m
@@ -719,7 +752,7 @@ async fn compaction_during_tool_call_corrupts_history() {
             // 1. User sends input, model responds with an async tool call and
             //    usage above the compaction threshold.
             running
-                .send_user_text(&"t1".into(), "do something")
+                .send_user_text(ThreadId::from_ref("t1"), "do something")
                 .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
@@ -752,7 +785,7 @@ async fn compaction_during_tool_call_corrupts_history() {
             // 3. After CompactionComplete is applied, trigger a model call so
             //    we can inspect the history.
             running
-                .send_user_text(&"t1".into(), "what happened?")
+                .send_user_text(ThreadId::from_ref("t1"), "what happened?")
                 .await;
             let req_final =
                 tokio::time::timeout(std::time::Duration::from_secs(5), ctrl.next_request())
@@ -802,7 +835,9 @@ async fn compaction_does_not_retrigger_after_applied() {
                 start_system(vec![Box::new(AsyncTool)], Some(small_context_entry()));
 
             // 1. User input → async tool call + high usage → compaction triggers.
-            running.send_user_text(&"t1".into(), "do something").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "do something")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
             ctrl.finish_with_usage(high_usage());
@@ -864,7 +899,9 @@ async fn second_compaction_during_tool_call_after_prior_compaction() {
                 start_system(vec![Box::new(AsyncTool)], Some(small_context_entry()));
 
             // ── FIRST ROUND: text response + compaction (no tool call) ──
-            running.send_user_text(&"t1".into(), "first message").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "first message")
+                .await;
             let _req1 = ctrl.next_request().await;
             ctrl.send_text("first response");
             ctrl.finish_with_usage(high_usage());
@@ -874,18 +911,24 @@ async fn second_compaction_during_tool_call_after_prior_compaction() {
             handle_compaction_child(&mut ctrl, &compaction_req1, "Summary of first round");
 
             // Build more history after the first compaction.
-            running.send_user_text(&"t1".into(), "second message").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "second message")
+                .await;
             let _req2 = ctrl.next_request().await;
             ctrl.send_text("second response");
             ctrl.finish();
 
-            running.send_user_text(&"t1".into(), "third message").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "third message")
+                .await;
             let _req3 = ctrl.next_request().await;
             ctrl.send_text("third response");
             ctrl.finish();
 
             // ── SECOND ROUND: tool call + compaction after prior compaction ──
-            running.send_user_text(&"t1".into(), "fourth message").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "fourth message")
+                .await;
             let _req4 = ctrl.next_request().await;
             ctrl.send_tool_call("tc-2", "async_tool", serde_json::json!({}));
             ctrl.finish_with_usage(high_usage());
@@ -948,14 +991,14 @@ async fn compaction_inside_child_thread_does_not_panic() {
 
             // ── Build root history ──
             running
-                .send_user_text(&"root".into(), "root message one")
+                .send_user_text(ThreadId::from_ref("root"), "root message one")
                 .await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("root response one");
             ctrl.finish();
 
             running
-                .send_user_text(&"root".into(), "root message two")
+                .send_user_text(ThreadId::from_ref("root"), "root message two")
                 .await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("root response two");
@@ -963,7 +1006,7 @@ async fn compaction_inside_child_thread_does_not_panic() {
 
             // ── Spawn a child thread from root ──
             running
-                .send_user_text(&"root".into(), "spawn a child")
+                .send_user_text(ThreadId::from_ref("root"), "spawn a child")
                 .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call(
@@ -997,7 +1040,7 @@ async fn compaction_inside_child_thread_does_not_panic() {
             // ── Another round in the child: tool call + high usage triggers
             //    compaction inside the child thread. ──
             running
-                .send_user_text(&child_thread_id.clone().into(), "child follow-up")
+                .send_user_text(ThreadId::from_ref(&child_thread_id), "child follow-up")
                 .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-child", "async_tool", serde_json::json!({}));
@@ -1048,7 +1091,10 @@ async fn compaction_inside_child_thread_does_not_panic() {
 
             // ── After compaction applies, inspect the child's history ──
             running
-                .send_user_text(&child_thread_id.clone().into(), "message after compaction")
+                .send_user_text(
+                    ThreadId::from_ref(&child_thread_id),
+                    "message after compaction",
+                )
                 .await;
             let post_compaction_req =
                 tokio::time::timeout(std::time::Duration::from_secs(5), ctrl.next_request())

--- a/crates/infinity-agent-core/src/system/tests.rs
+++ b/crates/infinity-agent-core/src/system/tests.rs
@@ -25,8 +25,12 @@ async fn pending_choices_are_thread_local_and_replayed() {
 
             let (model, _ctrl) = model_source(None);
             let conv = InMemoryConversationStore::new();
-            conv.ensure_root_thread("t1").await.expect("ensure root");
-            conv.ensure_root_thread("t2").await.expect("ensure root");
+            conv.ensure_root_thread(&"t1".into())
+                .await
+                .expect("ensure root");
+            conv.ensure_root_thread(&"t2".into())
+                .await
+                .expect("ensure root");
             let state = InMemoryStateStore::new();
             let sender = ChannelSender::new_pair().0;
             let mut system = AgentSystemBuilder::new(conv, state.clone(), model, sender).build();
@@ -42,7 +46,7 @@ async fn pending_choices_are_thread_local_and_replayed() {
                             default: 0,
                             response_url: "http://example.test/choice".to_owned(),
                         }),
-                        group_id: thread_id.to_owned(),
+                        group_id: thread_id.into(),
                         metadata: None,
                         synthetic: None,
                         display_as: None,
@@ -66,7 +70,7 @@ async fn pending_choices_are_thread_local_and_replayed() {
 
             assert_eq!(
                 state
-                    .get_pending_user_choices("t1")
+                    .get_pending_user_choices(&"t1".into())
                     .await
                     .expect("load first thread choices")[0]
                     .id,
@@ -74,7 +78,7 @@ async fn pending_choices_are_thread_local_and_replayed() {
             );
             assert_eq!(
                 state
-                    .get_pending_user_choices("t2")
+                    .get_pending_user_choices(&"t2".into())
                     .await
                     .expect("load second thread choices")[0]
                     .id,
@@ -84,14 +88,14 @@ async fn pending_choices_are_thread_local_and_replayed() {
             let (sub_tx, mut sub_rx) = mpsc::unbounded_channel();
             let replay_conv = InMemoryConversationStore::new();
             replay_conv
-                .ensure_root_thread("t1")
+                .ensure_root_thread(&"t1".into())
                 .await
                 .expect("ensure replay root");
             let running = AgentSystemBuilder::new_local(replay_conv, state, model_source(None).0)
                 .start_with_observer(|_| TestObserver {
                     tx: mpsc::unbounded_channel().0,
                 });
-            running.subscribe("t1", sub_tx).await;
+            running.subscribe(&"t1".into(), sub_tx).await;
             let Evt::Replay(snapshot) = next_evt(&mut sub_rx).await else {
                 panic!("expected replay");
             };
@@ -107,7 +111,7 @@ async fn driver_idles_after_text_response() {
     local
         .run_until(async {
             let (mut running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
-            running.send_user_text("t1", "hello").await;
+            running.send_user_text(&"t1".into(), "hello").await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("hi there");
             ctrl.finish();
@@ -126,7 +130,7 @@ async fn driver_stays_alive_waiting_for_tool_result() {
         .run_until(async {
             let (mut running, mut rx, mut ctrl, _conv) =
                 start_system(vec![Box::new(AsyncTool)], None);
-            running.send_user_text("t1", "use tool").await;
+            running.send_user_text(&"t1".into(), "use tool").await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -147,7 +151,7 @@ async fn driver_stays_alive_waiting_for_tool_result() {
             // A client attaching while waiting gets a replay whose history
             // ends with the unresolved tool call and no completion in flight.
             let (sub_tx, mut sub_rx) = mpsc::unbounded_channel();
-            running.subscribe("t1", sub_tx).await;
+            running.subscribe(&"t1".into(), sub_tx).await;
             match next_evt(&mut sub_rx).await {
                 Evt::Replay(snapshot) => {
                     assert!(!snapshot.in_progress);
@@ -179,7 +183,7 @@ async fn user_text_interrupts_active_completion() {
     local
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
-            running.send_user_text("t1", "first").await;
+            running.send_user_text(&"t1".into(), "first").await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("partial...");
             // Wait until the chunk is observed so the completion is in flight.
@@ -188,7 +192,7 @@ async fn user_text_interrupts_active_completion() {
                     break;
                 }
             }
-            running.send_user_text("t1", "stop that").await;
+            running.send_user_text(&"t1".into(), "stop that").await;
             let req2 = ctrl.next_request().await;
             let has_interrupt = req2.chat_history.into_iter().any(|m| {
                 if let infinity_provider_protocol::message::Message::User { content } = &m
@@ -214,7 +218,7 @@ async fn non_user_text_during_completion_does_not_interrupt() {
     local
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![Box::new(AsyncTool)], None);
-            running.send_user_text("t1", "do stuff").await;
+            running.send_user_text(&"t1".into(), "do stuff").await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -257,7 +261,7 @@ async fn subscription_event_queued_during_completion_processed_after() {
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) =
                 start_system(vec![Box::new(SubscribeTool)], None);
-            running.send_user_text("t1", "subscribe").await;
+            running.send_user_text(&"t1".into(), "subscribe").await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-sub", "subscribe_tool", serde_json::json!({}));
             ctrl.finish();
@@ -334,7 +338,7 @@ async fn driver_idles_after_close_thread_tool_call() {
             }
             let (mut running, mut rx, mut ctrl, _conv) =
                 start_system_with(vec![Box::new(CloseThreadStub)], None, false);
-            running.send_user_text("t1", "close").await;
+            running.send_user_text(&"t1".into(), "close").await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call(
                 "tc-1",
@@ -359,7 +363,7 @@ async fn thread_report_deferred_during_async_tool_wait() {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![Box::new(AsyncTool)], None);
 
             // 1. User sends input, model calls async_tool.
-            running.send_user_text("t1", "do async").await;
+            running.send_user_text(&"t1".into(), "do async").await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-async", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -432,7 +436,7 @@ async fn shutdown_persists_in_flight_tool_result() {
             let (running, mut rx, mut ctrl, conv) = start_system(vec![Box::new(AsyncTool)], None);
 
             // 1. User input → model issues an async tool call.
-            running.send_user_text("t1", "do something").await;
+            running.send_user_text(&"t1".into(), "do something").await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -464,7 +468,7 @@ async fn shutdown_persists_in_flight_tool_result() {
             // 4. The tool result must have been synced to the store.
             use crate::traits::ConversationStore;
             let history = conv
-                .load_history_up_to("t1", None, None)
+                .load_history_up_to(&"t1".into(), None, None)
                 .await
                 .expect("load history");
             let has_tool_result = history.iter().any(|m| {
@@ -491,7 +495,7 @@ async fn subscription_event_deferred_during_async_tool_wait() {
     local
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![Box::new(AsyncTool)], None);
-            running.send_user_text("t1", "do async").await;
+            running.send_user_text(&"t1".into(), "do async").await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-async", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -538,7 +542,7 @@ async fn stale_result_does_not_flush_deferred_events_during_async_tool_wait() {
     local
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![Box::new(AsyncTool)], None);
-            running.send_user_text("t1", "do async").await;
+            running.send_user_text(&"t1".into(), "do async").await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-async", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -590,7 +594,7 @@ async fn subscribe_mid_thinking_replays_current_thinking() {
     local
         .run_until(async {
             let (running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
-            running.send_user_text("t1", "think hard").await;
+            running.send_user_text(&"t1".into(), "think hard").await;
             let _req = ctrl.next_request().await;
             ctrl.send_chunk(StreamChunk::ReasoningDelta {
                 id: None,
@@ -609,7 +613,7 @@ async fn subscribe_mid_thinking_replays_current_thinking() {
             }
 
             let (sub_tx, mut sub_rx) = mpsc::unbounded_channel();
-            running.subscribe("t1", sub_tx).await;
+            running.subscribe(&"t1".into(), sub_tx).await;
             match next_evt(&mut sub_rx).await {
                 Evt::Replay(snapshot) => {
                     assert!(snapshot.in_progress, "completion is in flight");
@@ -626,7 +630,7 @@ async fn subscribe_mid_thinking_replays_current_thinking() {
                 }
             }
             let (sub_tx2, mut sub_rx2) = mpsc::unbounded_channel();
-            running.subscribe("t1", sub_tx2).await;
+            running.subscribe(&"t1".into(), sub_tx2).await;
             match next_evt(&mut sub_rx2).await {
                 Evt::Replay(snapshot) => {
                     assert!(snapshot.in_progress);
@@ -652,13 +656,13 @@ async fn routes_to_separate_threads() {
     local
         .run_until(async {
             let (mut running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
-            running.send_user_text("t1", "one").await;
+            running.send_user_text(&"t1".into(), "one").await;
             let _r1 = ctrl.next_request().await;
             ctrl.send_text("first");
             ctrl.finish();
             collect_until_finished(&mut rx).await;
 
-            running.send_user_text("t2", "two").await;
+            running.send_user_text(&"t2".into(), "two").await;
             let _r2 = ctrl.next_request().await;
             ctrl.send_text("second");
             ctrl.finish();
@@ -675,7 +679,7 @@ async fn respawns_driver_after_idle() {
     local
         .run_until(async {
             let (mut running, mut rx, mut ctrl, _conv) = start_system(vec![], None);
-            running.send_user_text("t1", "hello").await;
+            running.send_user_text(&"t1".into(), "hello").await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("hi");
             ctrl.finish();
@@ -684,7 +688,7 @@ async fn respawns_driver_after_idle() {
             assert!(running.is_idle());
 
             // A new message respawns the driver; the history is intact.
-            running.send_user_text("t1", "again").await;
+            running.send_user_text(&"t1".into(), "again").await;
             let req2 = ctrl.next_request().await;
             assert!(req2.chat_history.into_iter().any(|m| {
                 if let infinity_provider_protocol::message::Message::User { content } = &m
@@ -715,7 +719,7 @@ async fn compaction_during_tool_call_corrupts_history() {
             // 1. User sends input, model responds with an async tool call and
             //    usage above the compaction threshold.
             running
-                .send_user_text("t1", "do something")
+                .send_user_text(&"t1".into(), "do something")
                 .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
@@ -748,7 +752,7 @@ async fn compaction_during_tool_call_corrupts_history() {
             // 3. After CompactionComplete is applied, trigger a model call so
             //    we can inspect the history.
             running
-                .send_user_text("t1", "what happened?")
+                .send_user_text(&"t1".into(), "what happened?")
                 .await;
             let req_final =
                 tokio::time::timeout(std::time::Duration::from_secs(5), ctrl.next_request())
@@ -798,7 +802,7 @@ async fn compaction_does_not_retrigger_after_applied() {
                 start_system(vec![Box::new(AsyncTool)], Some(small_context_entry()));
 
             // 1. User input → async tool call + high usage → compaction triggers.
-            running.send_user_text("t1", "do something").await;
+            running.send_user_text(&"t1".into(), "do something").await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
             ctrl.finish_with_usage(high_usage());
@@ -860,7 +864,7 @@ async fn second_compaction_during_tool_call_after_prior_compaction() {
                 start_system(vec![Box::new(AsyncTool)], Some(small_context_entry()));
 
             // ── FIRST ROUND: text response + compaction (no tool call) ──
-            running.send_user_text("t1", "first message").await;
+            running.send_user_text(&"t1".into(), "first message").await;
             let _req1 = ctrl.next_request().await;
             ctrl.send_text("first response");
             ctrl.finish_with_usage(high_usage());
@@ -870,18 +874,18 @@ async fn second_compaction_during_tool_call_after_prior_compaction() {
             handle_compaction_child(&mut ctrl, &compaction_req1, "Summary of first round");
 
             // Build more history after the first compaction.
-            running.send_user_text("t1", "second message").await;
+            running.send_user_text(&"t1".into(), "second message").await;
             let _req2 = ctrl.next_request().await;
             ctrl.send_text("second response");
             ctrl.finish();
 
-            running.send_user_text("t1", "third message").await;
+            running.send_user_text(&"t1".into(), "third message").await;
             let _req3 = ctrl.next_request().await;
             ctrl.send_text("third response");
             ctrl.finish();
 
             // ── SECOND ROUND: tool call + compaction after prior compaction ──
-            running.send_user_text("t1", "fourth message").await;
+            running.send_user_text(&"t1".into(), "fourth message").await;
             let _req4 = ctrl.next_request().await;
             ctrl.send_tool_call("tc-2", "async_tool", serde_json::json!({}));
             ctrl.finish_with_usage(high_usage());
@@ -943,18 +947,24 @@ async fn compaction_inside_child_thread_does_not_panic() {
                 start_system(vec![Box::new(AsyncTool)], Some(small_context_entry()));
 
             // ── Build root history ──
-            running.send_user_text("root", "root message one").await;
+            running
+                .send_user_text(&"root".into(), "root message one")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("root response one");
             ctrl.finish();
 
-            running.send_user_text("root", "root message two").await;
+            running
+                .send_user_text(&"root".into(), "root message two")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("root response two");
             ctrl.finish();
 
             // ── Spawn a child thread from root ──
-            running.send_user_text("root", "spawn a child").await;
+            running
+                .send_user_text(&"root".into(), "spawn a child")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call(
                 "tc-spawn",
@@ -987,7 +997,7 @@ async fn compaction_inside_child_thread_does_not_panic() {
             // ── Another round in the child: tool call + high usage triggers
             //    compaction inside the child thread. ──
             running
-                .send_user_text(&child_thread_id, "child follow-up")
+                .send_user_text(&child_thread_id.clone().into(), "child follow-up")
                 .await;
             let _req = ctrl.next_request().await;
             ctrl.send_tool_call("tc-child", "async_tool", serde_json::json!({}));
@@ -1038,7 +1048,7 @@ async fn compaction_inside_child_thread_does_not_panic() {
 
             // ── After compaction applies, inspect the child's history ──
             running
-                .send_user_text(&child_thread_id, "message after compaction")
+                .send_user_text(&child_thread_id.clone().into(), "message after compaction")
                 .await;
             let post_compaction_req =
                 tokio::time::timeout(std::time::Duration::from_secs(5), ctrl.next_request())

--- a/crates/infinity-agent-core/src/system/thread.rs
+++ b/crates/infinity-agent-core/src/system/thread.rs
@@ -1,6 +1,7 @@
 //! [`Thread`]: a handle to one conversation thread, with a step-oriented
 //! execution API.
 
+use rap_protocol::ThreadId;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -115,7 +116,7 @@ where
 {
     pub(crate) async fn load(
         inner: Rc<SystemInner<C, S, M, H>>,
-        thread_id: String,
+        thread_id: ThreadId,
     ) -> Result<Self, BoxError> {
         let history = HistoryManager::new_with_history(
             inner.conversation_store.clone(),
@@ -394,7 +395,7 @@ where
         &self,
         input_msg: &InputMessage,
         observer: &O,
-        thread_id: &str,
+        thread_id: &ThreadId,
     ) {
         if let Some(event) = event_processor::input_event(&self.history, input_msg) {
             observer.on_event(thread_id, &event);
@@ -587,7 +588,7 @@ where
         &self,
         event: CompletionEvent,
         observer: &impl ThreadObserver,
-        thread_id: &str,
+        thread_id: &ThreadId,
         action: &mut Option<CompletionAction>,
         usage: &mut Option<Usage>,
     ) {
@@ -686,7 +687,7 @@ mod tests {
             .run_until(async {
                 let (mut running, mut rx, mut ctrl, _conv) =
                     start_system(vec![Box::new(FailingTool)], None);
-                running.send_user_text("t1", "use tool").await;
+                running.send_user_text(&"t1".into(), "use tool").await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_tool_call("call-1", "failing_tool", serde_json::json!({}));
                 ctrl.finish();

--- a/crates/infinity-agent-core/src/system/thread.rs
+++ b/crates/infinity-agent-core/src/system/thread.rs
@@ -395,7 +395,7 @@ where
         &self,
         input_msg: &InputMessage,
         observer: &O,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) {
         if let Some(event) = event_processor::input_event(&self.history, input_msg) {
             observer.on_event(thread_id, &event);
@@ -588,7 +588,7 @@ where
         &self,
         event: CompletionEvent,
         observer: &impl ThreadObserver,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         action: &mut Option<CompletionAction>,
         usage: &mut Option<Usage>,
     ) {
@@ -687,7 +687,9 @@ mod tests {
             .run_until(async {
                 let (mut running, mut rx, mut ctrl, _conv) =
                     start_system(vec![Box::new(FailingTool)], None);
-                running.send_user_text(&"t1".into(), "use tool").await;
+                running
+                    .send_user_text(rap_protocol::ThreadId::from_ref("t1"), "use tool")
+                    .await;
                 let _req = ctrl.next_request().await;
                 ctrl.send_tool_call("call-1", "failing_tool", serde_json::json!({}));
                 ctrl.finish();

--- a/crates/infinity-agent-core/src/tools/mod.rs
+++ b/crates/infinity-agent-core/src/tools/mod.rs
@@ -48,11 +48,11 @@ where
 #[derive(Clone)]
 pub struct ToolContext<M: InputSender> {
     pub message_sender: M,
-    pub group_id: String,
+    pub group_id: rap_protocol::ThreadId,
     pub callback_url: String,
     pub user_id: Option<String>,
     /// Full thread stack: [root, ..ancestors, current_thread].
-    pub thread_stack: Vec<String>,
+    pub thread_stack: Vec<rap_protocol::ThreadId>,
 }
 
 #[async_trait]

--- a/crates/infinity-agent-core/src/tools/rap_tool.rs
+++ b/crates/infinity-agent-core/src/tools/rap_tool.rs
@@ -88,13 +88,8 @@ where
         callback_url,
     } = params;
 
-    let thread_ancestors = (context.thread_stack.len() > 1).then(|| {
-        context.thread_stack[..context.thread_stack.len() - 1]
-            .iter()
-            .cloned()
-            .map(rap_protocol::ThreadId::from)
-            .collect()
-    });
+    let thread_ancestors = (context.thread_stack.len() > 1)
+        .then(|| context.thread_stack[..context.thread_stack.len() - 1].to_vec());
 
     let invocation = RapInvocation {
         operation: operation.to_owned(),
@@ -104,7 +99,7 @@ where
         callback_url: callback_url
             .unwrap_or(context.callback_url.as_str())
             .to_owned(),
-        group_id: context.group_id.clone().into(),
+        group_id: context.group_id.clone(),
         user_id: context.user_id.clone(),
         thread_ancestors,
     };
@@ -274,10 +269,13 @@ mod tests {
             message_sender: CapturingSender {
                 messages: Arc::new(Mutex::new(Vec::new())),
             },
-            group_id: "thread-1".to_owned(),
+            group_id: "thread-1".into(),
             callback_url: "http://context-callback".to_owned(),
             user_id: Some("user-1".to_owned()),
-            thread_stack: thread_stack.into_iter().map(str::to_owned).collect(),
+            thread_stack: thread_stack
+                .into_iter()
+                .map(rap_protocol::ThreadId::from)
+                .collect(),
         }
     }
 
@@ -314,7 +312,7 @@ mod tests {
         assert_eq!(sent.len(), 1, "exactly one error result is enqueued");
         let (message, dedup_id) = &sent[0];
         assert_eq!(dedup_id, "tc-1", "dedup ID is the tool-call ID");
-        assert_eq!(message.group_id, "thread-1");
+        assert_eq!(message.group_id.as_str(), "thread-1");
         let InputMessageContent::User(UserContent::ToolResult(result)) = &message.content else {
             panic!("expected a tool result, got {:?}", message.content);
         };

--- a/crates/infinity-agent-core/src/tools/rap_tool.rs
+++ b/crates/infinity-agent-core/src/tools/rap_tool.rs
@@ -88,8 +88,13 @@ where
         callback_url,
     } = params;
 
-    let thread_ancestors = (context.thread_stack.len() > 1)
-        .then(|| context.thread_stack[..context.thread_stack.len() - 1].to_vec());
+    let thread_ancestors = (context.thread_stack.len() > 1).then(|| {
+        context.thread_stack[..context.thread_stack.len() - 1]
+            .iter()
+            .cloned()
+            .map(rap_protocol::ThreadId::from)
+            .collect()
+    });
 
     let invocation = RapInvocation {
         operation: operation.to_owned(),
@@ -99,7 +104,7 @@ where
         callback_url: callback_url
             .unwrap_or(context.callback_url.as_str())
             .to_owned(),
-        group_id: context.group_id.clone(),
+        group_id: context.group_id.clone().into(),
         user_id: context.user_id.clone(),
         thread_ancestors,
     };
@@ -359,7 +364,7 @@ mod tests {
             serde_json::from_str(&posts[0].1).expect("posted body is a RapInvocation");
         assert_eq!(
             invocation.thread_ancestors,
-            Some(vec!["root".to_owned(), "middle".to_owned()]),
+            Some(vec!["root".into(), "middle".into()]),
             "ancestors exclude the current thread"
         );
         assert_eq!(invocation.callback_url, "http://bridge-listener");

--- a/crates/infinity-agent-core/src/tools/thread.rs
+++ b/crates/infinity-agent-core/src/tools/thread.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use infinity_provider_protocol::message::{Text, ToolResult, ToolResultContent, UserContent};
+use rap_protocol::ThreadId;
 use tracing;
 
 use super::{Tool, ToolContext, send_tool_error};
@@ -63,7 +64,7 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static> Tool<M> for Spawn
         context: &ToolContext<M>,
     ) -> Option<ToolResult> {
         // Validate child_of matches the actual thread stack
-        let child_of: Vec<String> = args
+        let child_of: Vec<ThreadId> = args
             .get("child_of")
             .and_then(|v| serde_json::from_value(v.clone()).ok())
             .unwrap_or_default();
@@ -320,6 +321,7 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static, H: HttpClient + '
         let Some(thread_id) = args["thread_id"].as_str() else {
             return send_tool_error(context, &id, call_id, "thread_id is required").await;
         };
+        let thread_id = ThreadId::from(thread_id);
 
         if thread_id != context.group_id {
             return send_tool_error(
@@ -337,7 +339,7 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static, H: HttpClient + '
         // Prevent closing the root thread
         let Some((parent_id, spawn_tool_call_id)) = self
             .conversation_store
-            .get_thread_parent_info(thread_id)
+            .get_thread_parent_info(&thread_id)
             .await
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
         else {
@@ -353,7 +355,7 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static, H: HttpClient + '
         let report = args.get("report_to_parent").and_then(|v| v.as_str());
 
         self.conversation_store
-            .close_thread(thread_id)
+            .close_thread(&thread_id)
             .await
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
@@ -362,7 +364,7 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static, H: HttpClient + '
         // Handle compaction threads: store summary and skip normal parent reporting
         let is_compaction = self
             .conversation_store
-            .is_compaction_thread(thread_id)
+            .is_compaction_thread(&thread_id)
             .await
             .unwrap_or(false);
 
@@ -370,7 +372,7 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static, H: HttpClient + '
             if let Some(report_text) = report {
                 let up_to_order = self
                     .conversation_store
-                    .get_thread_spawn_order(thread_id)
+                    .get_thread_spawn_order(&thread_id)
                     .await
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
                     .unwrap_or(0);
@@ -407,14 +409,14 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static, H: HttpClient + '
                 .send_to_input_queue(notify_msg, &id)
                 .await?;
             if let Some(ref notifier) = self.rap_notifier {
-                notifier.notify_thread_closed(thread_id).await;
+                notifier.notify_thread_closed(&thread_id).await;
             }
             return Ok(());
         }
 
         let is_subscription = self
             .conversation_store
-            .is_subscription_event_thread(thread_id)
+            .is_subscription_event_thread(&thread_id)
             .await
             .unwrap_or(false);
 
@@ -450,7 +452,7 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static, H: HttpClient + '
                 metadata: None,
                 synthetic: Some(SyntheticKind::Tagged(TaggedSyntheticKind::ThreadReport {
                     tool_call_id: spawn_tool_call_id,
-                    child_thread_id: thread_id.to_owned(),
+                    child_thread_id: thread_id.clone(),
                 })),
                 display_as: None,
                 subscription: false,
@@ -465,7 +467,7 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static, H: HttpClient + '
         // Best-effort: notify RAP tool servers that this thread has been closed
         // so they can clean up thread-specific resources (e.g. sandboxes).
         if let Some(ref notifier) = self.rap_notifier {
-            notifier.notify_thread_closed(thread_id).await;
+            notifier.notify_thread_closed(&thread_id).await;
         }
 
         Ok(())
@@ -513,7 +515,7 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static> Tool<M>
         call_id: Option<String>,
         context: &ToolContext<M>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let Some(child_thread_id) = args["thread_id"].as_str() else {
+        let Some(child_thread_id) = args["thread_id"].as_str().map(ThreadId::from) else {
             return send_tool_error(context, &id, call_id, "thread_id is required").await;
         };
         let Some(message_text) = args["message"].as_str() else {
@@ -522,7 +524,7 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static> Tool<M>
 
         let Some((parent_id, spawn_tool_call_id)) = self
             .conversation_store
-            .get_thread_parent_info(child_thread_id)
+            .get_thread_parent_info(&child_thread_id)
             .await
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
         else {
@@ -563,7 +565,7 @@ impl<M: InputSender + 'static, C: ConversationStore + 'static> Tool<M>
                     text: format!("Message from parent thread: {}", message_text),
                 })],
             })),
-            group_id: child_thread_id.to_owned(),
+            group_id: child_thread_id.clone(),
             metadata: None,
             synthetic: Some(SyntheticKind::Tagged(TaggedSyntheticKind::ParentMessage {
                 tool_call_id: spawn_tool_call_id,

--- a/crates/infinity-agent-core/src/traits.rs
+++ b/crates/infinity-agent-core/src/traits.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 use infinity_provider_protocol::message::AssistantContent;
 
+use rap_protocol::ThreadId;
+
 use crate::message::{InfinityMessage, InputMessage};
 use crate::system::UserChoice;
 
@@ -9,17 +11,17 @@ use crate::system::UserChoice;
 pub trait ConversationStore: Send + Sync + Clone {
     type Error: std::error::Error + Send + Sync + 'static;
 
-    async fn ensure_root_thread(&self, thread_id: &str) -> Result<(), Self::Error>;
+    async fn ensure_root_thread(&self, thread_id: &ThreadId) -> Result<(), Self::Error>;
 
     /// Return whether an exact root or child thread record exists without
     /// creating it.
-    async fn thread_exists(&self, thread_id: &str) -> Result<bool, Self::Error>;
+    async fn thread_exists(&self, thread_id: &ThreadId) -> Result<bool, Self::Error>;
 
     /// Load history for a session. `start_from` (exclusive) and `up_to`
     /// (inclusive) are optional bounds on message order. `None` means unbounded.
     async fn load_history_up_to(
         &self,
-        session_id: &str,
+        session_id: &ThreadId,
         start_from: Option<i64>,
         up_to: Option<i64>,
     ) -> Result<Vec<InfinityMessage>, Self::Error>;
@@ -33,7 +35,7 @@ pub trait ConversationStore: Send + Sync + Clone {
     /// history come from ancestors (not this thread's own store).
     async fn load_history_with_ancestors(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
     ) -> Result<(Vec<InfinityMessage>, Option<i64>, usize), Self::Error> {
         // Check the thread itself first
         if let Ok(Some((summary, compacted_up_to))) = self
@@ -105,42 +107,49 @@ pub trait ConversationStore: Send + Sync + Clone {
 
     async fn append_messages(
         &self,
-        session_id: &str,
+        session_id: &ThreadId,
         messages: Vec<(InfinityMessage, String)>,
     ) -> Result<(), Self::Error>;
 
     async fn spawn_thread(
         &self,
-        parent_thread_id: &str,
+        parent_thread_id: &ThreadId,
         spawn_tool_call_id: &str,
         is_for_subscription_event: bool,
         spawn_order_override: Option<usize>,
-    ) -> Result<String, Self::Error>;
+    ) -> Result<ThreadId, Self::Error>;
 
-    async fn is_thread_closed(&self, thread_id: &str) -> Result<bool, Self::Error>;
+    async fn is_thread_closed(&self, thread_id: &ThreadId) -> Result<bool, Self::Error>;
 
-    async fn close_thread(&self, thread_id: &str) -> Result<(), Self::Error>;
+    async fn close_thread(&self, thread_id: &ThreadId) -> Result<(), Self::Error>;
 
-    async fn is_subscription_event_thread(&self, thread_id: &str) -> Result<bool, Self::Error>;
+    async fn is_subscription_event_thread(&self, thread_id: &ThreadId)
+    -> Result<bool, Self::Error>;
 
     async fn get_thread_parent_info(
         &self,
-        thread_id: &str,
-    ) -> Result<Option<(String, String)>, Self::Error>;
+        thread_id: &ThreadId,
+    ) -> Result<Option<(ThreadId, String)>, Self::Error>;
 
-    async fn get_ancestor_chain(&self, thread_id: &str) -> Result<Vec<(String, i64)>, Self::Error>;
+    async fn get_ancestor_chain(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Vec<(ThreadId, i64)>, Self::Error>;
 
     // ── Compaction support ──
 
-    async fn mark_thread_as_compaction(&self, thread_id: &str) -> Result<(), Self::Error>;
+    async fn mark_thread_as_compaction(&self, thread_id: &ThreadId) -> Result<(), Self::Error>;
 
-    async fn is_compaction_thread(&self, thread_id: &str) -> Result<bool, Self::Error>;
+    async fn is_compaction_thread(&self, thread_id: &ThreadId) -> Result<bool, Self::Error>;
 
-    async fn get_thread_spawn_order(&self, thread_id: &str) -> Result<Option<i64>, Self::Error>;
+    async fn get_thread_spawn_order(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Option<i64>, Self::Error>;
 
     async fn save_compaction_summary(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         summary: &str,
         up_to_order: i64,
     ) -> Result<(), Self::Error>;
@@ -149,7 +158,7 @@ pub trait ConversationStore: Send + Sync + Clone {
     /// only return summaries whose `up_to_order` is <= n.
     async fn load_latest_compaction_summary_up_to(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         up_to_order: Option<i64>,
     ) -> Result<Option<(String, i64)>, Self::Error>;
 }
@@ -165,61 +174,64 @@ pub trait StateStore: Send + Sync + Clone {
     /// events); tool results are deduplicated against history itself.
     async fn get_processed_ids(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
     ) -> Result<std::collections::HashSet<String>, Self::Error>;
 
     async fn add_processed_message_ids(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         message_ids: Vec<String>,
     ) -> Result<(), Self::Error>;
 
     async fn get_metadata(
         &self,
-        root_thread_id: &str,
+        root_thread_id: &ThreadId,
     ) -> Result<Option<serde_json::Value>, Self::Error>;
 
     async fn set_metadata(
         &self,
-        root_thread_id: &str,
+        root_thread_id: &ThreadId,
         metadata: serde_json::Value,
     ) -> Result<(), Self::Error>;
 
     /// Return the list of active subscription tool_call_ids for a specific thread.
-    async fn get_active_subscriptions(&self, thread_id: &str) -> Result<Vec<String>, Self::Error>;
+    async fn get_active_subscriptions(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Vec<String>, Self::Error>;
 
     /// Record a new active subscription (tool_call_id) for a specific thread.
     async fn add_active_subscription(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         tool_call_id: &str,
     ) -> Result<(), Self::Error>;
 
     /// Remove an active subscription (tool_call_id) from a specific thread.
     async fn remove_active_subscription(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         tool_call_id: &str,
     ) -> Result<(), Self::Error>;
 
     /// Add or replace a pending user choice for one thread.
     async fn add_pending_user_choice(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         choice: UserChoice,
     ) -> Result<(), Self::Error>;
 
     /// Remove a pending user choice after it is answered or interrupted.
     async fn remove_pending_user_choice(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         choice_id: &str,
     ) -> Result<(), Self::Error>;
 
     /// List choices awaiting a response for one thread.
     async fn get_pending_user_choices(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
     ) -> Result<Vec<UserChoice>, Self::Error>;
 
     /// Whether an existing thread has been explicitly stopped.
@@ -235,7 +247,7 @@ pub trait StateStore: Send + Sync + Clone {
     /// Implementations that track stopped state per conversation may resolve
     /// the root themselves. Stores without stopped-thread policy inherit the
     /// default `false` response.
-    async fn is_thread_stopped(&self, _thread_id: &str) -> Result<bool, Self::Error> {
+    async fn is_thread_stopped(&self, _thread_id: &ThreadId) -> Result<bool, Self::Error> {
         Ok(false)
     }
 }

--- a/crates/infinity-agent-core/src/traits.rs
+++ b/crates/infinity-agent-core/src/traits.rs
@@ -11,17 +11,17 @@ use crate::system::UserChoice;
 pub trait ConversationStore: Send + Sync + Clone {
     type Error: std::error::Error + Send + Sync + 'static;
 
-    async fn ensure_root_thread(&self, thread_id: &ThreadId) -> Result<(), Self::Error>;
+    async fn ensure_root_thread(&self, thread_id: &ThreadId<str>) -> Result<(), Self::Error>;
 
     /// Return whether an exact root or child thread record exists without
     /// creating it.
-    async fn thread_exists(&self, thread_id: &ThreadId) -> Result<bool, Self::Error>;
+    async fn thread_exists(&self, thread_id: &ThreadId<str>) -> Result<bool, Self::Error>;
 
     /// Load history for a session. `start_from` (exclusive) and `up_to`
     /// (inclusive) are optional bounds on message order. `None` means unbounded.
     async fn load_history_up_to(
         &self,
-        session_id: &ThreadId,
+        session_id: &ThreadId<str>,
         start_from: Option<i64>,
         up_to: Option<i64>,
     ) -> Result<Vec<InfinityMessage>, Self::Error>;
@@ -35,7 +35,7 @@ pub trait ConversationStore: Send + Sync + Clone {
     /// history come from ancestors (not this thread's own store).
     async fn load_history_with_ancestors(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<(Vec<InfinityMessage>, Option<i64>, usize), Self::Error> {
         // Check the thread itself first
         if let Ok(Some((summary, compacted_up_to))) = self
@@ -107,49 +107,52 @@ pub trait ConversationStore: Send + Sync + Clone {
 
     async fn append_messages(
         &self,
-        session_id: &ThreadId,
+        session_id: &ThreadId<str>,
         messages: Vec<(InfinityMessage, String)>,
     ) -> Result<(), Self::Error>;
 
     async fn spawn_thread(
         &self,
-        parent_thread_id: &ThreadId,
+        parent_thread_id: &ThreadId<str>,
         spawn_tool_call_id: &str,
         is_for_subscription_event: bool,
         spawn_order_override: Option<usize>,
     ) -> Result<ThreadId, Self::Error>;
 
-    async fn is_thread_closed(&self, thread_id: &ThreadId) -> Result<bool, Self::Error>;
+    async fn is_thread_closed(&self, thread_id: &ThreadId<str>) -> Result<bool, Self::Error>;
 
-    async fn close_thread(&self, thread_id: &ThreadId) -> Result<(), Self::Error>;
+    async fn close_thread(&self, thread_id: &ThreadId<str>) -> Result<(), Self::Error>;
 
-    async fn is_subscription_event_thread(&self, thread_id: &ThreadId)
-    -> Result<bool, Self::Error>;
+    async fn is_subscription_event_thread(
+        &self,
+        thread_id: &ThreadId<str>,
+    ) -> Result<bool, Self::Error>;
 
     async fn get_thread_parent_info(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Option<(ThreadId, String)>, Self::Error>;
 
     async fn get_ancestor_chain(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<(ThreadId, i64)>, Self::Error>;
 
     // ── Compaction support ──
 
-    async fn mark_thread_as_compaction(&self, thread_id: &ThreadId) -> Result<(), Self::Error>;
+    async fn mark_thread_as_compaction(&self, thread_id: &ThreadId<str>)
+    -> Result<(), Self::Error>;
 
-    async fn is_compaction_thread(&self, thread_id: &ThreadId) -> Result<bool, Self::Error>;
+    async fn is_compaction_thread(&self, thread_id: &ThreadId<str>) -> Result<bool, Self::Error>;
 
     async fn get_thread_spawn_order(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Option<i64>, Self::Error>;
 
     async fn save_compaction_summary(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         summary: &str,
         up_to_order: i64,
     ) -> Result<(), Self::Error>;
@@ -158,7 +161,7 @@ pub trait ConversationStore: Send + Sync + Clone {
     /// only return summaries whose `up_to_order` is <= n.
     async fn load_latest_compaction_summary_up_to(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         up_to_order: Option<i64>,
     ) -> Result<Option<(String, i64)>, Self::Error>;
 }
@@ -174,64 +177,64 @@ pub trait StateStore: Send + Sync + Clone {
     /// events); tool results are deduplicated against history itself.
     async fn get_processed_ids(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<std::collections::HashSet<String>, Self::Error>;
 
     async fn add_processed_message_ids(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         message_ids: Vec<String>,
     ) -> Result<(), Self::Error>;
 
     async fn get_metadata(
         &self,
-        root_thread_id: &ThreadId,
+        root_thread_id: &ThreadId<str>,
     ) -> Result<Option<serde_json::Value>, Self::Error>;
 
     async fn set_metadata(
         &self,
-        root_thread_id: &ThreadId,
+        root_thread_id: &ThreadId<str>,
         metadata: serde_json::Value,
     ) -> Result<(), Self::Error>;
 
     /// Return the list of active subscription tool_call_ids for a specific thread.
     async fn get_active_subscriptions(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<String>, Self::Error>;
 
     /// Record a new active subscription (tool_call_id) for a specific thread.
     async fn add_active_subscription(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         tool_call_id: &str,
     ) -> Result<(), Self::Error>;
 
     /// Remove an active subscription (tool_call_id) from a specific thread.
     async fn remove_active_subscription(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         tool_call_id: &str,
     ) -> Result<(), Self::Error>;
 
     /// Add or replace a pending user choice for one thread.
     async fn add_pending_user_choice(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         choice: UserChoice,
     ) -> Result<(), Self::Error>;
 
     /// Remove a pending user choice after it is answered or interrupted.
     async fn remove_pending_user_choice(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         choice_id: &str,
     ) -> Result<(), Self::Error>;
 
     /// List choices awaiting a response for one thread.
     async fn get_pending_user_choices(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<UserChoice>, Self::Error>;
 
     /// Whether an existing thread has been explicitly stopped.
@@ -247,7 +250,7 @@ pub trait StateStore: Send + Sync + Clone {
     /// Implementations that track stopped state per conversation may resolve
     /// the root themselves. Stores without stopped-thread policy inherit the
     /// default `false` response.
-    async fn is_thread_stopped(&self, _thread_id: &ThreadId) -> Result<bool, Self::Error> {
+    async fn is_thread_stopped(&self, _thread_id: &ThreadId<str>) -> Result<bool, Self::Error> {
         Ok(false)
     }
 }

--- a/crates/infinity-agent-lambda/src/bin/rap-receiver.rs
+++ b/crates/infinity-agent-lambda/src/bin/rap-receiver.rs
@@ -68,7 +68,7 @@ async fn handle(
         .send_message()
         .queue_url(input_queue_url)
         .message_body(enqueue.message_body)
-        .message_group_id(enqueue.group_id)
+        .message_group_id(enqueue.group_id.into_inner())
         .message_deduplication_id(enqueue.dedup_id)
         .send()
         .await
@@ -84,7 +84,7 @@ async fn handle(
 /// group (the target thread), and the deduplication ID.
 struct PreparedEnqueue {
     message_body: String,
-    group_id: String,
+    group_id: infinity_agent_core::ThreadId,
     dedup_id: String,
 }
 

--- a/crates/infinity-agent-lambda/src/conversation_history.rs
+++ b/crates/infinity-agent-lambda/src/conversation_history.rs
@@ -5,6 +5,7 @@ use aws_sdk_dsql::{
     auth_token::{AuthTokenGenerator, Config},
 };
 use aws_types::region::Region;
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::message::InfinityMessage;
 use infinity_agent_core::traits::ConversationStore;
 use infinity_provider_protocol::message::Message;
@@ -149,24 +150,24 @@ impl DsqlConversationStore {
 impl ConversationStore for DsqlConversationStore {
     type Error = DsqlError;
 
-    async fn ensure_root_thread(&self, thread_id: &str) -> Result<(), DsqlError> {
+    async fn ensure_root_thread(&self, thread_id: &ThreadId) -> Result<(), DsqlError> {
         sqlx::query(
             r#"INSERT INTO thread_hierarchy (thread_id, parent_thread_id, root_thread_id)
             VALUES ($1, NULL, $1)
             ON CONFLICT (thread_id) DO NOTHING"#,
         )
-        .bind(thread_id)
+        .bind(thread_id.as_str())
         .execute(&self.pool)
         .await
         .map_err(|e| DsqlError(format!("Failed to ensure root thread: {}", e)))?;
         Ok(())
     }
 
-    async fn thread_exists(&self, thread_id: &str) -> Result<bool, DsqlError> {
+    async fn thread_exists(&self, thread_id: &ThreadId) -> Result<bool, DsqlError> {
         sqlx::query_scalar::<_, bool>(
             "SELECT EXISTS (SELECT 1 FROM thread_hierarchy WHERE thread_id = $1)",
         )
-        .bind(thread_id)
+        .bind(thread_id.as_str())
         .fetch_one(&self.pool)
         .await
         .map_err(|e| DsqlError(format!("Failed to check thread existence: {e}")))
@@ -174,7 +175,7 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn load_history_up_to(
         &self,
-        session_id: &str,
+        session_id: &ThreadId,
         start_from: Option<i64>,
         up_to: Option<i64>,
     ) -> Result<Vec<InfinityMessage>, DsqlError> {
@@ -191,7 +192,7 @@ impl ConversationStore for DsqlConversationStore {
         }
         query.push_str(" ORDER BY message_order ASC");
 
-        let mut q = sqlx::query(&query).bind(session_id);
+        let mut q = sqlx::query(&query).bind(session_id.as_str());
         if let Some(n) = start_from {
             q = q.bind(n);
         }
@@ -219,7 +220,7 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn append_messages(
         &self,
-        session_id: &str,
+        session_id: &ThreadId,
         messages: Vec<(InfinityMessage, String)>,
     ) -> Result<(), DsqlError> {
         if messages.is_empty() {
@@ -230,7 +231,7 @@ impl ConversationStore for DsqlConversationStore {
             r#"SELECT COALESCE(MAX(message_order), 0)
             FROM conversation_history WHERE session_id = $1"#,
         )
-        .bind(session_id)
+        .bind(session_id.as_str())
         .fetch_one(&self.pool)
         .await
         .map_err(|e| DsqlError(format!("Failed to get max order: {}", e)))?;
@@ -245,7 +246,7 @@ impl ConversationStore for DsqlConversationStore {
             current_order += 1;
             let json_str = serde_json::to_string(&message)
                 .map_err(|e| DsqlError(format!("Failed to serialize message: {}", e)))?;
-            session_ids.push(session_id.to_owned());
+            session_ids.push(session_id.as_str().to_owned());
             message_orders.push(current_order);
             message_ids_vec.push(message_id);
             message_data.push(json_str);
@@ -278,12 +279,12 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn spawn_thread(
         &self,
-        parent_thread_id: &str,
+        parent_thread_id: &ThreadId,
         spawn_tool_call_id: &str,
         is_for_subscription_event: bool,
         spawn_order_override: Option<usize>,
-    ) -> Result<String, DsqlError> {
-        let new_thread_id = uuid::Uuid::new_v4().to_string();
+    ) -> Result<ThreadId, DsqlError> {
+        let new_thread_id = ThreadId::from(uuid::Uuid::new_v4().to_string());
 
         let spawn_message_order = if let Some(order) = spawn_order_override {
             order as i64
@@ -292,7 +293,7 @@ impl ConversationStore for DsqlConversationStore {
                 r#"SELECT COALESCE(MAX(message_order), 0)
                 FROM conversation_history WHERE session_id = $1"#,
             )
-            .bind(parent_thread_id)
+            .bind(parent_thread_id.as_str())
             .fetch_one(&self.pool)
             .await
             .map_err(|e| DsqlError(format!("Failed to get current message order: {}", e)))?;
@@ -302,7 +303,7 @@ impl ConversationStore for DsqlConversationStore {
         let root_thread_id: String = sqlx::query_scalar(
             r#"SELECT root_thread_id FROM thread_hierarchy WHERE thread_id = $1"#,
         )
-        .bind(parent_thread_id)
+        .bind(parent_thread_id.as_str())
         .fetch_one(&self.pool)
         .await
         .map_err(|e| DsqlError(format!("Failed to find parent thread: {}", e)))?;
@@ -311,8 +312,8 @@ impl ConversationStore for DsqlConversationStore {
             r#"INSERT INTO thread_hierarchy (thread_id, parent_thread_id, root_thread_id, spawn_message_order, spawn_tool_call_id, is_subscription_event)
             VALUES ($1, $2, $3, $4, $5, $6)"#,
         )
-        .bind(&new_thread_id)
-        .bind(parent_thread_id)
+        .bind(new_thread_id.as_str())
+        .bind(parent_thread_id.as_str())
         .bind(&root_thread_id)
         .bind(spawn_message_order)
         .bind(spawn_tool_call_id)
@@ -324,30 +325,30 @@ impl ConversationStore for DsqlConversationStore {
         Ok(new_thread_id)
     }
 
-    async fn is_thread_closed(&self, thread_id: &str) -> Result<bool, DsqlError> {
+    async fn is_thread_closed(&self, thread_id: &ThreadId) -> Result<bool, DsqlError> {
         let row: Option<(bool,)> =
             sqlx::query_as(r#"SELECT closed FROM thread_hierarchy WHERE thread_id = $1"#)
-                .bind(thread_id)
+                .bind(thread_id.as_str())
                 .fetch_optional(&self.pool)
                 .await
                 .map_err(|e| DsqlError(format!("Failed to check thread closed: {}", e)))?;
         Ok(row.map(|(c,)| c).unwrap_or(false))
     }
 
-    async fn close_thread(&self, thread_id: &str) -> Result<(), DsqlError> {
+    async fn close_thread(&self, thread_id: &ThreadId) -> Result<(), DsqlError> {
         sqlx::query(r#"UPDATE thread_hierarchy SET closed = TRUE WHERE thread_id = $1"#)
-            .bind(thread_id)
+            .bind(thread_id.as_str())
             .execute(&self.pool)
             .await
             .map_err(|e| DsqlError(format!("Failed to close thread: {}", e)))?;
         Ok(())
     }
 
-    async fn is_subscription_event_thread(&self, thread_id: &str) -> Result<bool, DsqlError> {
+    async fn is_subscription_event_thread(&self, thread_id: &ThreadId) -> Result<bool, DsqlError> {
         let row: Option<(bool,)> = sqlx::query_as(
             r#"SELECT is_subscription_event FROM thread_hierarchy WHERE thread_id = $1"#,
         )
-        .bind(thread_id)
+        .bind(thread_id.as_str())
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| DsqlError(format!("Failed to check subscription event: {}", e)))?;
@@ -356,12 +357,12 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn get_thread_parent_info(
         &self,
-        thread_id: &str,
-    ) -> Result<Option<(String, String)>, DsqlError> {
+        thread_id: &ThreadId,
+    ) -> Result<Option<(ThreadId, String)>, DsqlError> {
         let row = sqlx::query(
             r#"SELECT parent_thread_id, spawn_tool_call_id FROM thread_hierarchy WHERE thread_id = $1"#,
         )
-        .bind(thread_id)
+        .bind(thread_id.as_str())
         .fetch_one(&self.pool)
         .await
         .map_err(|e| DsqlError(format!("Failed to get thread info: {}", e)))?;
@@ -369,14 +370,17 @@ impl ConversationStore for DsqlConversationStore {
         let parent: Option<String> = row.get("parent_thread_id");
         let tool_call_id: Option<String> = row.get("spawn_tool_call_id");
         match (parent, tool_call_id) {
-            (Some(p), Some(t)) => Ok(Some((p, t))),
+            (Some(p), Some(t)) => Ok(Some((ThreadId::from(p), t))),
             _ => Ok(None),
         }
     }
 
-    async fn get_ancestor_chain(&self, thread_id: &str) -> Result<Vec<(String, i64)>, DsqlError> {
-        let mut result: Vec<(String, i64)> = Vec::new();
-        let mut current = thread_id.to_owned();
+    async fn get_ancestor_chain(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Vec<(ThreadId, i64)>, DsqlError> {
+        let mut result: Vec<(ThreadId, i64)> = Vec::new();
+        let mut current = thread_id.as_str().to_owned();
 
         loop {
             let row = sqlx::query(
@@ -392,7 +396,7 @@ impl ConversationStore for DsqlConversationStore {
 
             match parent {
                 Some(p) => {
-                    result.push((p.clone(), spawn_order.unwrap_or(0)));
+                    result.push((ThreadId::from(p.clone()), spawn_order.unwrap_or(0)));
                     current = p;
                 }
                 None => break,
@@ -405,7 +409,7 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn save_compaction_summary(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         summary: &str,
         up_to_order: i64,
     ) -> Result<(), DsqlError> {
@@ -414,7 +418,7 @@ impl ConversationStore for DsqlConversationStore {
             VALUES ($1, $2, $3)
             ON CONFLICT (thread_id, up_to_order) DO UPDATE SET summary = $3"#,
         )
-        .bind(thread_id)
+        .bind(thread_id.as_str())
         .bind(up_to_order)
         .bind(summary)
         .execute(&self.pool)
@@ -425,7 +429,7 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn load_latest_compaction_summary_up_to(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         up_to_order: Option<i64>,
     ) -> Result<Option<(String, i64)>, DsqlError> {
         let row = match up_to_order {
@@ -435,7 +439,7 @@ impl ConversationStore for DsqlConversationStore {
                     WHERE thread_id = $1 AND up_to_order <= $2
                     ORDER BY up_to_order DESC LIMIT 1"#,
                 )
-                .bind(thread_id)
+                .bind(thread_id.as_str())
                 .bind(n)
                 .fetch_optional(&self.pool)
                 .await
@@ -445,7 +449,7 @@ impl ConversationStore for DsqlConversationStore {
                     r#"SELECT summary, up_to_order FROM compaction_summaries
                     WHERE thread_id = $1 ORDER BY up_to_order DESC LIMIT 1"#,
                 )
-                .bind(thread_id)
+                .bind(thread_id.as_str())
                 .fetch_optional(&self.pool)
                 .await
             }
@@ -459,30 +463,30 @@ impl ConversationStore for DsqlConversationStore {
         }))
     }
 
-    async fn is_compaction_thread(&self, thread_id: &str) -> Result<bool, DsqlError> {
+    async fn is_compaction_thread(&self, thread_id: &ThreadId) -> Result<bool, DsqlError> {
         let row: Option<(bool,)> =
             sqlx::query_as(r#"SELECT is_compaction FROM thread_hierarchy WHERE thread_id = $1"#)
-                .bind(thread_id)
+                .bind(thread_id.as_str())
                 .fetch_optional(&self.pool)
                 .await
                 .map_err(|e| DsqlError(format!("Failed to check compaction thread: {}", e)))?;
         Ok(row.map(|(v,)| v).unwrap_or(false))
     }
 
-    async fn mark_thread_as_compaction(&self, thread_id: &str) -> Result<(), DsqlError> {
+    async fn mark_thread_as_compaction(&self, thread_id: &ThreadId) -> Result<(), DsqlError> {
         sqlx::query(r#"UPDATE thread_hierarchy SET is_compaction = TRUE WHERE thread_id = $1"#)
-            .bind(thread_id)
+            .bind(thread_id.as_str())
             .execute(&self.pool)
             .await
             .map_err(|e| DsqlError(format!("Failed to mark compaction thread: {}", e)))?;
         Ok(())
     }
 
-    async fn get_thread_spawn_order(&self, thread_id: &str) -> Result<Option<i64>, DsqlError> {
+    async fn get_thread_spawn_order(&self, thread_id: &ThreadId) -> Result<Option<i64>, DsqlError> {
         let row: Option<(Option<i64>,)> = sqlx::query_as(
             r#"SELECT spawn_message_order FROM thread_hierarchy WHERE thread_id = $1"#,
         )
-        .bind(thread_id)
+        .bind(thread_id.as_str())
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| DsqlError(format!("Failed to get spawn order: {}", e)))?;

--- a/crates/infinity-agent-lambda/src/conversation_history.rs
+++ b/crates/infinity-agent-lambda/src/conversation_history.rs
@@ -150,7 +150,7 @@ impl DsqlConversationStore {
 impl ConversationStore for DsqlConversationStore {
     type Error = DsqlError;
 
-    async fn ensure_root_thread(&self, thread_id: &ThreadId) -> Result<(), DsqlError> {
+    async fn ensure_root_thread(&self, thread_id: &ThreadId<str>) -> Result<(), DsqlError> {
         sqlx::query(
             r#"INSERT INTO thread_hierarchy (thread_id, parent_thread_id, root_thread_id)
             VALUES ($1, NULL, $1)
@@ -163,7 +163,7 @@ impl ConversationStore for DsqlConversationStore {
         Ok(())
     }
 
-    async fn thread_exists(&self, thread_id: &ThreadId) -> Result<bool, DsqlError> {
+    async fn thread_exists(&self, thread_id: &ThreadId<str>) -> Result<bool, DsqlError> {
         sqlx::query_scalar::<_, bool>(
             "SELECT EXISTS (SELECT 1 FROM thread_hierarchy WHERE thread_id = $1)",
         )
@@ -175,7 +175,7 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn load_history_up_to(
         &self,
-        session_id: &ThreadId,
+        session_id: &ThreadId<str>,
         start_from: Option<i64>,
         up_to: Option<i64>,
     ) -> Result<Vec<InfinityMessage>, DsqlError> {
@@ -220,7 +220,7 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn append_messages(
         &self,
-        session_id: &ThreadId,
+        session_id: &ThreadId<str>,
         messages: Vec<(InfinityMessage, String)>,
     ) -> Result<(), DsqlError> {
         if messages.is_empty() {
@@ -279,7 +279,7 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn spawn_thread(
         &self,
-        parent_thread_id: &ThreadId,
+        parent_thread_id: &ThreadId<str>,
         spawn_tool_call_id: &str,
         is_for_subscription_event: bool,
         spawn_order_override: Option<usize>,
@@ -325,7 +325,7 @@ impl ConversationStore for DsqlConversationStore {
         Ok(new_thread_id)
     }
 
-    async fn is_thread_closed(&self, thread_id: &ThreadId) -> Result<bool, DsqlError> {
+    async fn is_thread_closed(&self, thread_id: &ThreadId<str>) -> Result<bool, DsqlError> {
         let row: Option<(bool,)> =
             sqlx::query_as(r#"SELECT closed FROM thread_hierarchy WHERE thread_id = $1"#)
                 .bind(thread_id.as_str())
@@ -335,7 +335,7 @@ impl ConversationStore for DsqlConversationStore {
         Ok(row.map(|(c,)| c).unwrap_or(false))
     }
 
-    async fn close_thread(&self, thread_id: &ThreadId) -> Result<(), DsqlError> {
+    async fn close_thread(&self, thread_id: &ThreadId<str>) -> Result<(), DsqlError> {
         sqlx::query(r#"UPDATE thread_hierarchy SET closed = TRUE WHERE thread_id = $1"#)
             .bind(thread_id.as_str())
             .execute(&self.pool)
@@ -344,7 +344,10 @@ impl ConversationStore for DsqlConversationStore {
         Ok(())
     }
 
-    async fn is_subscription_event_thread(&self, thread_id: &ThreadId) -> Result<bool, DsqlError> {
+    async fn is_subscription_event_thread(
+        &self,
+        thread_id: &ThreadId<str>,
+    ) -> Result<bool, DsqlError> {
         let row: Option<(bool,)> = sqlx::query_as(
             r#"SELECT is_subscription_event FROM thread_hierarchy WHERE thread_id = $1"#,
         )
@@ -357,7 +360,7 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn get_thread_parent_info(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Option<(ThreadId, String)>, DsqlError> {
         let row = sqlx::query(
             r#"SELECT parent_thread_id, spawn_tool_call_id FROM thread_hierarchy WHERE thread_id = $1"#,
@@ -377,7 +380,7 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn get_ancestor_chain(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<(ThreadId, i64)>, DsqlError> {
         let mut result: Vec<(ThreadId, i64)> = Vec::new();
         let mut current = thread_id.as_str().to_owned();
@@ -409,7 +412,7 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn save_compaction_summary(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         summary: &str,
         up_to_order: i64,
     ) -> Result<(), DsqlError> {
@@ -429,7 +432,7 @@ impl ConversationStore for DsqlConversationStore {
 
     async fn load_latest_compaction_summary_up_to(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         up_to_order: Option<i64>,
     ) -> Result<Option<(String, i64)>, DsqlError> {
         let row = match up_to_order {
@@ -463,7 +466,7 @@ impl ConversationStore for DsqlConversationStore {
         }))
     }
 
-    async fn is_compaction_thread(&self, thread_id: &ThreadId) -> Result<bool, DsqlError> {
+    async fn is_compaction_thread(&self, thread_id: &ThreadId<str>) -> Result<bool, DsqlError> {
         let row: Option<(bool,)> =
             sqlx::query_as(r#"SELECT is_compaction FROM thread_hierarchy WHERE thread_id = $1"#)
                 .bind(thread_id.as_str())
@@ -473,7 +476,7 @@ impl ConversationStore for DsqlConversationStore {
         Ok(row.map(|(v,)| v).unwrap_or(false))
     }
 
-    async fn mark_thread_as_compaction(&self, thread_id: &ThreadId) -> Result<(), DsqlError> {
+    async fn mark_thread_as_compaction(&self, thread_id: &ThreadId<str>) -> Result<(), DsqlError> {
         sqlx::query(r#"UPDATE thread_hierarchy SET is_compaction = TRUE WHERE thread_id = $1"#)
             .bind(thread_id.as_str())
             .execute(&self.pool)
@@ -482,7 +485,10 @@ impl ConversationStore for DsqlConversationStore {
         Ok(())
     }
 
-    async fn get_thread_spawn_order(&self, thread_id: &ThreadId) -> Result<Option<i64>, DsqlError> {
+    async fn get_thread_spawn_order(
+        &self,
+        thread_id: &ThreadId<str>,
+    ) -> Result<Option<i64>, DsqlError> {
         let row: Option<(Option<i64>,)> = sqlx::query_as(
             r#"SELECT spawn_message_order FROM thread_hierarchy WHERE thread_id = $1"#,
         )

--- a/crates/infinity-agent-lambda/src/event_handler.rs
+++ b/crates/infinity-agent-lambda/src/event_handler.rs
@@ -320,7 +320,7 @@ impl LambdaThreadConfig {
 impl ThreadConfigSource<SqsMessageSender, RapHttpClient> for LambdaThreadConfig {
     async fn resolve(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<
         ThreadConfig<SqsMessageSender, RapHttpClient>,
         Box<dyn std::error::Error + Send + Sync>,

--- a/crates/infinity-agent-lambda/src/event_handler.rs
+++ b/crates/infinity-agent-lambda/src/event_handler.rs
@@ -10,6 +10,7 @@ use aws_sdk_sqs::Client as SqsClient;
 use infinity_provider_bedrock::BedrockProvider;
 use lambda_runtime::{Error, LambdaEvent, tracing};
 
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::event_processor;
 use infinity_agent_core::message::InputMessage;
 use infinity_agent_core::system::{
@@ -184,7 +185,7 @@ pub(crate) async fn function_handler(event: LambdaEvent<SqsEvent>) -> Result<(),
         required_choices: Vec<infinity_agent_core::system::UserChoice>,
         completed_choices: Vec<String>,
     }
-    let mut per_thread: BTreeMap<String, ThreadOutput> = BTreeMap::new();
+    let mut per_thread: BTreeMap<ThreadId, ThreadOutput> = BTreeMap::new();
     for (thread_id, event) in collector.take() {
         let entry = per_thread.entry(thread_id).or_default();
         match event {
@@ -319,7 +320,7 @@ impl LambdaThreadConfig {
 impl ThreadConfigSource<SqsMessageSender, RapHttpClient> for LambdaThreadConfig {
     async fn resolve(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
     ) -> Result<
         ThreadConfig<SqsMessageSender, RapHttpClient>,
         Box<dyn std::error::Error + Send + Sync>,
@@ -330,7 +331,7 @@ impl ThreadConfigSource<SqsMessageSender, RapHttpClient> for LambdaThreadConfig 
         if !self.toolset_server_urls.is_empty() {
             match self
                 .toolset_loader
-                .load_toolsets(&self.toolset_server_urls, thread_id)
+                .load_toolsets(&self.toolset_server_urls, thread_id.as_str())
                 .await
             {
                 Ok(loaded) => {

--- a/crates/infinity-agent-lambda/src/state_store.rs
+++ b/crates/infinity-agent-lambda/src/state_store.rs
@@ -32,7 +32,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn get_processed_ids(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<HashSet<String>, DynamoError> {
         let result = self
             .client
@@ -58,7 +58,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn add_processed_message_ids(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         message_ids: Vec<String>,
     ) -> Result<(), DynamoError> {
         if message_ids.is_empty() {
@@ -78,7 +78,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn get_metadata(
         &self,
-        root_thread_id: &ThreadId,
+        root_thread_id: &ThreadId<str>,
     ) -> Result<Option<serde_json::Value>, DynamoError> {
         let result = self
             .client
@@ -105,7 +105,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn set_metadata(
         &self,
-        root_thread_id: &ThreadId,
+        root_thread_id: &ThreadId<str>,
         metadata: serde_json::Value,
     ) -> Result<(), DynamoError> {
         let json = serde_json::to_string(&metadata)
@@ -127,7 +127,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn get_active_subscriptions(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<String>, DynamoError> {
         let result = self
             .client
@@ -152,7 +152,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn add_active_subscription(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         tool_call_id: &str,
     ) -> Result<(), DynamoError> {
         self.client
@@ -169,7 +169,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn add_pending_user_choice(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         choice: UserChoice,
     ) -> Result<(), DynamoError> {
         let json = serde_json::to_string(&choice)
@@ -207,7 +207,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn remove_pending_user_choice(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         choice_id: &str,
     ) -> Result<(), DynamoError> {
         let Some(choice) = self
@@ -234,7 +234,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn get_pending_user_choices(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<UserChoice>, DynamoError> {
         let result = self
             .client
@@ -265,7 +265,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn remove_active_subscription(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         tool_call_id: &str,
     ) -> Result<(), DynamoError> {
         self.client

--- a/crates/infinity-agent-lambda/src/state_store.rs
+++ b/crates/infinity-agent-lambda/src/state_store.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use aws_sdk_dynamodb::{Client as DynamoDbClient, types::AttributeValue};
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::system::UserChoice;
 use infinity_agent_core::traits::StateStore;
 use std::collections::HashSet;
@@ -29,12 +30,15 @@ impl DynamoDbStateStore {
 impl StateStore for DynamoDbStateStore {
     type Error = DynamoError;
 
-    async fn get_processed_ids(&self, thread_id: &str) -> Result<HashSet<String>, DynamoError> {
+    async fn get_processed_ids(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<HashSet<String>, DynamoError> {
         let result = self
             .client
             .get_item()
             .table_name(&self.table_name)
-            .key("session", AttributeValue::S(thread_id.to_owned()))
+            .key("session", AttributeValue::S(thread_id.as_str().to_owned()))
             .send()
             .await
             .map_err(|e| DynamoError(format!("Failed to get processed IDs: {}", e)))?;
@@ -54,7 +58,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn add_processed_message_ids(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         message_ids: Vec<String>,
     ) -> Result<(), DynamoError> {
         if message_ids.is_empty() {
@@ -63,7 +67,7 @@ impl StateStore for DynamoDbStateStore {
         self.client
             .update_item()
             .table_name(&self.table_name)
-            .key("session", AttributeValue::S(thread_id.to_owned()))
+            .key("session", AttributeValue::S(thread_id.as_str().to_owned()))
             .update_expression("ADD processed_message_ids :ids")
             .expression_attribute_values(":ids", AttributeValue::Ss(message_ids))
             .send()
@@ -74,13 +78,16 @@ impl StateStore for DynamoDbStateStore {
 
     async fn get_metadata(
         &self,
-        root_thread_id: &str,
+        root_thread_id: &ThreadId,
     ) -> Result<Option<serde_json::Value>, DynamoError> {
         let result = self
             .client
             .get_item()
             .table_name(&self.table_name)
-            .key("session", AttributeValue::S(root_thread_id.to_owned()))
+            .key(
+                "session",
+                AttributeValue::S(root_thread_id.as_str().to_owned()),
+            )
             .send()
             .await
             .map_err(|e| DynamoError(format!("Failed to get metadata: {}", e)))?;
@@ -98,7 +105,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn set_metadata(
         &self,
-        root_thread_id: &str,
+        root_thread_id: &ThreadId,
         metadata: serde_json::Value,
     ) -> Result<(), DynamoError> {
         let json = serde_json::to_string(&metadata)
@@ -106,7 +113,10 @@ impl StateStore for DynamoDbStateStore {
         self.client
             .update_item()
             .table_name(&self.table_name)
-            .key("session", AttributeValue::S(root_thread_id.to_owned()))
+            .key(
+                "session",
+                AttributeValue::S(root_thread_id.as_str().to_owned()),
+            )
             .update_expression("SET metadata = :metadata")
             .expression_attribute_values(":metadata", AttributeValue::S(json))
             .send()
@@ -115,12 +125,15 @@ impl StateStore for DynamoDbStateStore {
         Ok(())
     }
 
-    async fn get_active_subscriptions(&self, thread_id: &str) -> Result<Vec<String>, DynamoError> {
+    async fn get_active_subscriptions(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Vec<String>, DynamoError> {
         let result = self
             .client
             .get_item()
             .table_name(&self.table_name)
-            .key("session", AttributeValue::S(thread_id.to_owned()))
+            .key("session", AttributeValue::S(thread_id.as_str().to_owned()))
             .send()
             .await
             .map_err(|e| DynamoError(format!("Failed to get active subscriptions: {}", e)))?;
@@ -139,13 +152,13 @@ impl StateStore for DynamoDbStateStore {
 
     async fn add_active_subscription(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         tool_call_id: &str,
     ) -> Result<(), DynamoError> {
         self.client
             .update_item()
             .table_name(&self.table_name)
-            .key("session", AttributeValue::S(thread_id.to_owned()))
+            .key("session", AttributeValue::S(thread_id.as_str().to_owned()))
             .update_expression("ADD active_subscriptions :id")
             .expression_attribute_values(":id", AttributeValue::Ss(vec![tool_call_id.to_owned()]))
             .send()
@@ -156,7 +169,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn add_pending_user_choice(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         choice: UserChoice,
     ) -> Result<(), DynamoError> {
         let json = serde_json::to_string(&choice)
@@ -173,7 +186,7 @@ impl StateStore for DynamoDbStateStore {
             self.client
                 .update_item()
                 .table_name(&self.table_name)
-                .key("session", AttributeValue::S(thread_id.to_owned()))
+                .key("session", AttributeValue::S(thread_id.as_str().to_owned()))
                 .update_expression("DELETE pending_user_choices :old")
                 .expression_attribute_values(":old", AttributeValue::Ss(vec![existing]))
                 .send()
@@ -183,7 +196,7 @@ impl StateStore for DynamoDbStateStore {
         self.client
             .update_item()
             .table_name(&self.table_name)
-            .key("session", AttributeValue::S(thread_id.to_owned()))
+            .key("session", AttributeValue::S(thread_id.as_str().to_owned()))
             .update_expression("ADD pending_user_choices :new")
             .expression_attribute_values(":new", AttributeValue::Ss(vec![json]))
             .send()
@@ -194,7 +207,7 @@ impl StateStore for DynamoDbStateStore {
 
     async fn remove_pending_user_choice(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         choice_id: &str,
     ) -> Result<(), DynamoError> {
         let Some(choice) = self
@@ -210,7 +223,7 @@ impl StateStore for DynamoDbStateStore {
         self.client
             .update_item()
             .table_name(&self.table_name)
-            .key("session", AttributeValue::S(thread_id.to_owned()))
+            .key("session", AttributeValue::S(thread_id.as_str().to_owned()))
             .update_expression("DELETE pending_user_choices :choice")
             .expression_attribute_values(":choice", AttributeValue::Ss(vec![json]))
             .send()
@@ -221,13 +234,13 @@ impl StateStore for DynamoDbStateStore {
 
     async fn get_pending_user_choices(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
     ) -> Result<Vec<UserChoice>, DynamoError> {
         let result = self
             .client
             .get_item()
             .table_name(&self.table_name)
-            .key("session", AttributeValue::S(thread_id.to_owned()))
+            .key("session", AttributeValue::S(thread_id.as_str().to_owned()))
             .send()
             .await
             .map_err(|e| DynamoError(format!("Failed to get pending user choices: {e}")))?;
@@ -252,13 +265,13 @@ impl StateStore for DynamoDbStateStore {
 
     async fn remove_active_subscription(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         tool_call_id: &str,
     ) -> Result<(), DynamoError> {
         self.client
             .update_item()
             .table_name(&self.table_name)
-            .key("session", AttributeValue::S(thread_id.to_owned()))
+            .key("session", AttributeValue::S(thread_id.as_str().to_owned()))
             .update_expression("DELETE active_subscriptions :id")
             .expression_attribute_values(":id", AttributeValue::Ss(vec![tool_call_id.to_owned()]))
             .send()

--- a/crates/infinity-agent-lambda/src/tools/sleep.rs
+++ b/crates/infinity-agent-lambda/src/tools/sleep.rs
@@ -5,6 +5,7 @@ use aws_sdk_scheduler::{
 };
 use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use chrono_tz::Tz;
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::tools::{Tool, ToolContext};
 use infinity_agent_core::{
     message::{InputMessage, InputMessageContent},
@@ -18,14 +19,19 @@ use super::sqs_sender::SqsMessageSender;
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 /// Build the tool-result message a sleep delivers when it wakes.
-fn wakeup_message(id: &str, call_id: Option<String>, text: String, group_id: &str) -> InputMessage {
+fn wakeup_message(
+    id: &str,
+    call_id: Option<String>,
+    text: String,
+    group_id: &ThreadId,
+) -> InputMessage {
     InputMessage {
         content: InputMessageContent::User(UserContent::ToolResult(ToolResult {
             id: id.to_owned(),
             call_id,
             content: vec![ToolResultContent::Text(Text { text })],
         })),
-        group_id: group_id.to_owned(),
+        group_id: group_id.clone(),
         metadata: None,
         synthetic: None,
         display_as: None,
@@ -94,7 +100,7 @@ impl WakeupScheduler {
                         .input(serde_json::to_string(msg)?)
                         .sqs_parameters(
                             SqsParameters::builder()
-                                .message_group_id(context.group_id.clone())
+                                .message_group_id(context.group_id.clone().into_inner())
                                 .build(),
                         )
                         .build()?,

--- a/crates/infinity-agent-lambda/src/tools/sleep.rs
+++ b/crates/infinity-agent-lambda/src/tools/sleep.rs
@@ -23,7 +23,7 @@ fn wakeup_message(
     id: &str,
     call_id: Option<String>,
     text: String,
-    group_id: &ThreadId,
+    group_id: &ThreadId<str>,
 ) -> InputMessage {
     InputMessage {
         content: InputMessageContent::User(UserContent::ToolResult(ToolResult {
@@ -31,7 +31,7 @@ fn wakeup_message(
             call_id,
             content: vec![ToolResultContent::Text(Text { text })],
         })),
-        group_id: group_id.clone(),
+        group_id: group_id.to_owned(),
         metadata: None,
         synthetic: None,
         display_as: None,

--- a/crates/infinity-agent-lambda/src/tools/sqs_sender.rs
+++ b/crates/infinity-agent-lambda/src/tools/sqs_sender.rs
@@ -55,7 +55,7 @@ impl InputSender for SqsMessageSender {
             .send_message()
             .queue_url(&self.input_queue_url)
             .message_body(body)
-            .message_group_id(group_id)
+            .message_group_id(group_id.into_inner())
             .message_deduplication_id(format!("{}-{}", dedup_id, now))
             .send()
             .await

--- a/crates/infinity-daemon/src/client_handler.rs
+++ b/crates/infinity-daemon/src/client_handler.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::message::{
     InputMessage, InputMessageContent, SyntheticKind, TaggedSyntheticKind,
 };
@@ -301,8 +302,8 @@ pub async fn handle_client_channels(
     session_manager: SharedSessionManager,
 ) {
     let (mut client_tx, mut client_tx_rx) = mpsc::unbounded_channel::<DaemonMessage>();
-    let mut attached_session_id: Option<String> = None;
-    let mut attached_thread_id: Option<String> = None;
+    let mut attached_session_id: Option<ThreadId> = None;
+    let mut attached_thread_id: Option<ThreadId> = None;
     let mut remote_proxy_tx: Option<mpsc::UnboundedSender<ClientMessage>> = None;
     let mut remote_proxy_rx: Option<mpsc::UnboundedReceiver<DaemonMessage>> = None;
     let mut active_remote_name: Option<String> = None;
@@ -472,7 +473,7 @@ pub async fn handle_client_channels(
                                         remote_proxy_tx = Some(tx);
                                         remote_proxy_rx = Some(rx);
                                         active_remote_name = Some(rname);
-                                        attached_session_id = Some(session_id);
+                                        attached_session_id = Some(ThreadId::from(session_id));
                                     }
                                     Err(e) => {
                                         let _ = daemon_tx.send(DaemonMessage::Error {
@@ -492,12 +493,13 @@ pub async fn handle_client_channels(
                             let mut emit = async |msg: DaemonMessage| {
                                 let _ = daemon_tx.send(msg);
                             };
-                            let target = thread_id.as_deref().unwrap_or(&session_id);
-                            match mgr.resume_session(&session_id, target, &mut emit).await {
+                            let session_tid = ThreadId::from(session_id.as_str());
+                            let target = thread_id.as_deref().map(ThreadId::from).unwrap_or_else(|| session_tid.clone());
+                            match mgr.resume_session(&session_tid, &target, &mut emit).await {
                                 Ok(()) => {
-                                    mgr.attach_client(target, client_tx.clone(), true, keeps_session_alive).await;
-                                    attached_thread_id = Some(target.to_owned());
-                                    attached_session_id = Some(session_id);
+                                    mgr.attach_client(&target, client_tx.clone(), true, keeps_session_alive).await;
+                                    attached_thread_id = Some(target);
+                                    attached_session_id = Some(session_tid);
                                 }
                                 Err(e) => { let _ = daemon_tx.send(DaemonMessage::Error { thread_id: Some(session_id), text: format!("failed to resume session: {e}") }); }
                             }
@@ -513,7 +515,7 @@ pub async fn handle_client_channels(
                             .send_input((
                                 InputMessage {
                                     content: InputMessageContent::User(UserContent::text(&text)),
-                                    group_id: thread_id.clone(),
+                                    group_id: thread_id.clone().into(),
                                     metadata: None,
                                     synthetic: None,
                                     display_as: None,
@@ -541,6 +543,7 @@ pub async fn handle_client_channels(
                         attached_thread_id = None;
                     }
                     ClientMessage::SoftDetach { session_id } => {
+                        let session_id = ThreadId::from(session_id);
                         let mgr = session_manager.lock().await;
                         let do_cleanup = mgr.is_session_idle(&session_id);
                         tracing::debug!(do_cleanup, "Handling SoftDetach");
@@ -557,12 +560,14 @@ pub async fn handle_client_channels(
                         }
                     }
                     ClientMessage::ShutdownSession { session_id } => {
+                        let session_id = ThreadId::from(session_id);
                         let mgr = session_manager.lock().await;
                         mgr.cleanup_session(&session_id).await;
                         attached_session_id = None;
                         attached_thread_id = None;
                     }
                     ClientMessage::ArchiveSession { session_id } => {
+                        let session_id = ThreadId::from(session_id);
                         let mgr = session_manager.lock().await;
                         mgr.cleanup_session(&session_id).await;
                         let mut store = mgr.session_store.lock().await;
@@ -578,7 +583,7 @@ pub async fn handle_client_channels(
                         mgr.send_input((
                             InputMessage {
                                 content: InputMessageContent::User(UserContent::text("")),
-                                group_id: session_id.clone(),
+                                group_id: session_id.clone().into(),
                                 metadata: None,
                                 synthetic: Some(SyntheticKind::Tagged(
                                     TaggedSyntheticKind::Compaction,
@@ -595,7 +600,7 @@ pub async fn handle_client_channels(
                         // `switch_model` delivers the confirmation to this
                         // client exactly once: via its subscription when
                         // attached, directly otherwise.
-                        if let Err(e) = mgr.switch_model(&thread_id, model, Some(&client_tx)) {
+                        if let Err(e) = mgr.switch_model(&ThreadId::from(thread_id.as_str()), model, Some(&client_tx)) {
                             let _ = daemon_tx.send(DaemonMessage::Error {
                                 thread_id: Some(thread_id),
                                 text: format!("failed to switch model: {e}"),
@@ -632,7 +637,7 @@ pub async fn handle_client_channels(
                     ClientMessage::Emigrate { session_id, dest_rap_urls } => {
                         // Daemon-to-daemon: shut down session, migrate RAP servers, serialize, return data
                         let mgr = session_manager.clone();
-                        match crate::migrate::handle_emigrate(&session_id, dest_rap_urls, &mgr).await {
+                        match crate::migrate::handle_emigrate(&ThreadId::from(session_id.as_str()), dest_rap_urls, &mgr).await {
                             Ok(data) => {
                                 let _ = daemon_tx.send(DaemonMessage::EmigrateResult {
                                     session_id,
@@ -649,6 +654,7 @@ pub async fn handle_client_channels(
                     }
                     ClientMessage::EmigrateDone { session_id } => {
                         // Daemon-to-daemon: immigration complete, archive local session
+                        let session_id = ThreadId::from(session_id);
                         let mgr = session_manager.lock().await;
                         let mut store = mgr.session_store.lock().await;
                         store.mark_archived(&session_id);
@@ -660,8 +666,9 @@ pub async fn handle_client_channels(
                         match mgr.conversation_store().import_session(&session_data) {
                             Ok(()) => {
                                 let mut store = mgr.session_store.lock().await;
-                                store.create(&session_id, cwd);
-                                store.mark_shut_down(&session_id);
+                                let session_tid = ThreadId::from(session_id.as_str());
+                                store.create(&session_tid, cwd);
+                                store.mark_shut_down(&session_tid);
                                 let _ = store.save();
                                 let _ = daemon_tx.send(DaemonMessage::ImportComplete { session_id });
                             }

--- a/crates/infinity-daemon/src/memory_store.rs
+++ b/crates/infinity-daemon/src/memory_store.rs
@@ -270,7 +270,7 @@ impl PersistentConversationStore {
 
     /// Migration: if a thread's last_updated / total_tokens_used is empty, try to
     /// restore them from the legacy `sessions.json` (parent of the threads dir).
-    fn migrate_from_session_store(&self, thread_id: &ThreadId, threads_dir: &Path) {
+    fn migrate_from_session_store(&self, thread_id: &ThreadId<str>, threads_dir: &Path) {
         {
             let extras = self.extras.lock().expect("bug: mutex poisoned");
             match extras.get(thread_id) {
@@ -315,7 +315,7 @@ impl PersistentConversationStore {
     }
 
     /// Notify that a session's thread tree changed.
-    fn notify_session(&self, thread_id: &ThreadId) {
+    fn notify_session(&self, thread_id: &ThreadId<str>) {
         if let Some(ref tx) = self.change_tx {
             let root = self.get_root_thread_id(thread_id);
             let _ = tx.send(root);
@@ -324,7 +324,7 @@ impl PersistentConversationStore {
 
     /// Combine the core store's info and the daemon extras into the
     /// serialization shape, if the thread exists in both.
-    fn thread_meta(&self, thread_id: &ThreadId) -> Option<ThreadMeta> {
+    fn thread_meta(&self, thread_id: &ThreadId<str>) -> Option<ThreadMeta> {
         let info = self.core.thread_info(thread_id)?;
         let extras = self
             .extras
@@ -337,17 +337,17 @@ impl PersistentConversationStore {
 
     /// Restore a thread's metadata from its serialization shape (splitting
     /// it between the core store and the daemon extras).
-    fn restore_thread_meta(&self, thread_id: &ThreadId, mut meta: ThreadMeta) {
+    fn restore_thread_meta(&self, thread_id: &ThreadId<str>, mut meta: ThreadMeta) {
         self.backfill_selected_model(&mut meta.extras);
         self.core.set_thread_info(thread_id, meta.info);
         self.extras
             .lock()
             .expect("bug: mutex poisoned")
-            .insert(thread_id.clone(), meta.extras);
+            .insert(thread_id.to_owned(), meta.extras);
     }
 
     /// Write a single thread's metadata to `{dir}/{thread_id}.meta.json`.
-    fn save_thread_metadata(&self, thread_id: &ThreadId) {
+    fn save_thread_metadata(&self, thread_id: &ThreadId<str>) {
         let Some(ref dir) = self.dir else { return };
         if let Some(meta) = self.thread_meta(thread_id) {
             let path = dir.join(format!("{}.meta.json", thread_id));
@@ -359,7 +359,7 @@ impl PersistentConversationStore {
 
     /// Write a single thread's data to `{dir}/{thread_id}.json` and metadata to `.meta.json`.
     /// No-op when persistence is disabled.
-    fn save_thread(&self, thread_id: &ThreadId) {
+    fn save_thread(&self, thread_id: &ThreadId<str>) {
         let Some(ref dir) = self.dir else { return };
         let snapshot = ThreadSnapshot {
             messages: self.core.thread_messages(thread_id).unwrap_or_default(),
@@ -376,7 +376,7 @@ impl PersistentConversationStore {
     /// Ensure a thread's metadata (core info + extras) is loaded from disk.
     /// Tries `.meta.json` first; falls back to extracting from the full `.json` snapshot
     /// and writes the `.meta.json` for future fast loads.
-    fn ensure_thread_metadata_loaded(&self, thread_id: &ThreadId) {
+    fn ensure_thread_metadata_loaded(&self, thread_id: &ThreadId<str>) {
         let Some(ref dir) = self.dir else { return };
 
         let mut meta_loaded = self.metadata_loaded.lock().expect("bug: mutex poisoned");
@@ -414,12 +414,12 @@ impl PersistentConversationStore {
         // Migration: restore title/last_updated from legacy sessions.json
         self.migrate_from_session_store(thread_id, dir);
 
-        meta_loaded.insert(thread_id.clone());
+        meta_loaded.insert(thread_id.to_owned());
     }
 
     /// Ensure a thread's full data (messages, compaction summaries) is loaded.
     /// Calls `ensure_thread_metadata_loaded` first.
-    fn ensure_thread_loaded(&self, thread_id: &ThreadId) {
+    fn ensure_thread_loaded(&self, thread_id: &ThreadId<str>) {
         self.ensure_thread_metadata_loaded(thread_id);
 
         let Some(ref dir) = self.dir else { return };
@@ -445,28 +445,28 @@ impl PersistentConversationStore {
             );
         }
 
-        loaded.insert(thread_id.clone());
+        loaded.insert(thread_id.to_owned());
 
         self.load_views(thread_id);
     }
 
     /// Whether metadata exists for this thread (in memory or on disk).
-    pub fn has_thread(&self, thread_id: &ThreadId) -> bool {
+    pub fn has_thread(&self, thread_id: &ThreadId<str>) -> bool {
         self.ensure_thread_metadata_loaded(thread_id);
         self.core.thread_info(thread_id).is_some()
     }
 
     /// Resolve a thread ID to its root thread ID (i.e. the session ID).
-    pub fn get_root_thread_id(&self, thread_id: &ThreadId) -> ThreadId {
+    pub fn get_root_thread_id(&self, thread_id: &ThreadId<str>) -> ThreadId {
         self.ensure_thread_metadata_loaded(thread_id);
         self.core
             .thread_info(thread_id)
             .map(|t| t.root_thread_id)
-            .unwrap_or_else(|| thread_id.clone())
+            .unwrap_or_else(|| thread_id.to_owned())
     }
 
     /// Get the parent thread ID, if any.
-    pub fn get_thread_parent_id(&self, thread_id: &ThreadId) -> Option<ThreadId> {
+    pub fn get_thread_parent_id(&self, thread_id: &ThreadId<str>) -> Option<ThreadId> {
         self.ensure_thread_metadata_loaded(thread_id);
         self.core
             .thread_info(thread_id)
@@ -474,7 +474,7 @@ impl PersistentConversationStore {
     }
 
     /// Set the title for a thread.
-    pub fn set_thread_title(&self, thread_id: &ThreadId, title: &str) {
+    pub fn set_thread_title(&self, thread_id: &ThreadId<str>, title: &str) {
         self.ensure_thread_metadata_loaded(thread_id);
         {
             let mut extras = self.extras.lock().expect("bug: mutex poisoned");
@@ -488,7 +488,7 @@ impl PersistentConversationStore {
 
     /// Get the model selected for this specific thread. Does NOT fall back to
     /// the parent thread — every thread is assigned a model at creation time.
-    pub fn get_thread_model(&self, thread_id: &ThreadId) -> ModelRef {
+    pub fn get_thread_model(&self, thread_id: &ThreadId<str>) -> ModelRef {
         self.ensure_thread_metadata_loaded(thread_id);
         let extras = self.extras.lock().expect("bug: mutex poisoned");
         extras
@@ -498,7 +498,7 @@ impl PersistentConversationStore {
     }
 
     /// Set the model selected for a thread.
-    pub fn set_thread_model(&self, thread_id: &ThreadId, model: ModelRef) {
+    pub fn set_thread_model(&self, thread_id: &ThreadId<str>, model: ModelRef) {
         self.ensure_thread_metadata_loaded(thread_id);
         {
             let mut extras = self.extras.lock().expect("bug: mutex poisoned");
@@ -513,13 +513,13 @@ impl PersistentConversationStore {
     /// are closed or used for compaction. Session-level state must still account
     /// for those threads even though they are omitted from the visible thread
     /// list.
-    pub fn get_session_thread_ids(&self, root_id: &ThreadId) -> Vec<ThreadId> {
+    pub fn get_session_thread_ids(&self, root_id: &ThreadId<str>) -> Vec<ThreadId> {
         let mut result = Vec::new();
-        let mut queue = vec![root_id.clone()];
+        let mut queue = vec![root_id.to_owned()];
         let mut visited = HashSet::new();
 
         while let Some(thread_id) = queue.pop() {
-            if !visited.insert(thread_id.clone()) {
+            if !visited.insert(thread_id.to_owned()) {
                 continue;
             }
             self.ensure_thread_metadata_loaded(&thread_id);
@@ -541,11 +541,11 @@ impl PersistentConversationStore {
     /// within the given session. Walks the children tree via metadata.
     pub fn get_open_subthreads(
         &self,
-        parent_id: &ThreadId,
+        parent_id: &ThreadId<str>,
     ) -> Vec<infinity_protocol::SubthreadInfo> {
         self.ensure_thread_metadata_loaded(parent_id);
         let mut result = Vec::new();
-        let mut queue = vec![parent_id.clone()];
+        let mut queue = vec![parent_id.to_owned()];
         while let Some(pid) = queue.pop() {
             let children = {
                 let extras = self.extras.lock().expect("bug: mutex poisoned");
@@ -576,7 +576,7 @@ impl PersistentConversationStore {
         result
     }
 
-    pub fn get_total_tokens_used(&self, thread_id: &ThreadId) -> usize {
+    pub fn get_total_tokens_used(&self, thread_id: &ThreadId<str>) -> usize {
         self.ensure_thread_metadata_loaded(thread_id);
         self.extras
             .lock()
@@ -586,7 +586,7 @@ impl PersistentConversationStore {
             .unwrap_or(0)
     }
 
-    pub fn set_total_tokens_used(&self, thread_id: &ThreadId, tokens: usize) {
+    pub fn set_total_tokens_used(&self, thread_id: &ThreadId<str>, tokens: usize) {
         self.ensure_thread_metadata_loaded(thread_id);
         if let Some(e) = self
             .extras
@@ -600,7 +600,7 @@ impl PersistentConversationStore {
         self.notify_session(thread_id);
     }
 
-    pub fn get_last_updated(&self, thread_id: &ThreadId) -> String {
+    pub fn get_last_updated(&self, thread_id: &ThreadId<str>) -> String {
         self.ensure_thread_metadata_loaded(thread_id);
         self.extras
             .lock()
@@ -610,7 +610,7 @@ impl PersistentConversationStore {
             .unwrap_or_default()
     }
 
-    pub fn set_last_updated(&self, thread_id: &ThreadId, ts: &str) {
+    pub fn set_last_updated(&self, thread_id: &ThreadId<str>, ts: &str) {
         self.ensure_thread_metadata_loaded(thread_id);
         if let Some(e) = self
             .extras
@@ -624,7 +624,7 @@ impl PersistentConversationStore {
     }
 
     /// Write views to `{dir}/{thread_id}.views.json`.
-    fn save_views(&self, thread_id: &ThreadId) {
+    fn save_views(&self, thread_id: &ThreadId<str>) {
         let Some(ref dir) = self.dir else { return };
         let views = self.views.lock().expect("bug: mutex poisoned");
         let path = dir.join(format!("{}.views.json", thread_id));
@@ -641,7 +641,7 @@ impl PersistentConversationStore {
     }
 
     /// Load views from `{dir}/{thread_id}.views.json`.
-    fn load_views(&self, thread_id: &ThreadId) {
+    fn load_views(&self, thread_id: &ThreadId<str>) {
         tracing::info!("Loading views for thread {thread_id}");
         let Some(ref dir) = self.dir else { return };
         let path = dir.join(format!("{}.views.json", thread_id));
@@ -651,7 +651,7 @@ impl PersistentConversationStore {
                     self.views
                         .lock()
                         .expect("bug: mutex poisoned")
-                        .insert(thread_id.clone(), v);
+                        .insert(thread_id.to_owned(), v);
                 }
                 Err(e) => {
                     tracing::error!("Failed to deserialize views: {e}");
@@ -665,11 +665,11 @@ impl PersistentConversationStore {
     }
 
     /// Update a view for a thread and persist.
-    pub fn set_view(&self, thread_id: &ThreadId, view_type: &str, content: serde_json::Value) {
+    pub fn set_view(&self, thread_id: &ThreadId<str>, view_type: &str, content: serde_json::Value) {
         {
             let mut views = self.views.lock().expect("bug: mutex poisoned");
             views
-                .entry(thread_id.clone())
+                .entry(thread_id.to_owned())
                 .or_default()
                 .insert(view_type.to_owned(), content);
         }
@@ -677,7 +677,7 @@ impl PersistentConversationStore {
     }
 
     /// Get all views for a thread.
-    pub fn get_views(&self, thread_id: &ThreadId) -> HashMap<String, serde_json::Value> {
+    pub fn get_views(&self, thread_id: &ThreadId<str>) -> HashMap<String, serde_json::Value> {
         self.ensure_thread_loaded(thread_id);
         self.views
             .lock()
@@ -687,7 +687,7 @@ impl PersistentConversationStore {
             .unwrap_or_default()
     }
 
-    pub fn get_thread_title(&self, thread_id: &ThreadId) -> Option<String> {
+    pub fn get_thread_title(&self, thread_id: &ThreadId<str>) -> Option<String> {
         self.ensure_thread_metadata_loaded(thread_id);
         self.extras
             .lock()
@@ -697,9 +697,9 @@ impl PersistentConversationStore {
     }
 
     /// Serialize all threads in a session tree to a JSON string.
-    pub fn serialize_session(&self, root_thread_id: &ThreadId) -> String {
+    pub fn serialize_session(&self, root_thread_id: &ThreadId<str>) -> String {
         let mut threads: HashMap<ThreadId, SerializedThread> = HashMap::new();
-        let mut queue = vec![root_thread_id.clone()];
+        let mut queue = vec![root_thread_id.to_owned()];
         while let Some(tid) = queue.pop() {
             self.ensure_thread_loaded(&tid);
             let Some(metadata) = self.thread_meta(&tid) else {
@@ -763,13 +763,13 @@ impl PersistentConversationStore {
 impl ConversationStore for PersistentConversationStore {
     type Error = MemoryError;
 
-    async fn ensure_root_thread(&self, thread_id: &ThreadId) -> Result<(), MemoryError> {
+    async fn ensure_root_thread(&self, thread_id: &ThreadId<str>) -> Result<(), MemoryError> {
         self.ensure_thread_loaded(thread_id);
         let inserted = self.core.thread_info(thread_id).is_none();
         if inserted {
             self.core.ensure_root_thread(thread_id).await?;
             self.extras.lock().expect("bug: mutex poisoned").insert(
-                thread_id.clone(),
+                thread_id.to_owned(),
                 ThreadExtras::new(self.default_model.clone()),
             );
             self.save_thread(thread_id);
@@ -777,13 +777,13 @@ impl ConversationStore for PersistentConversationStore {
         Ok(())
     }
 
-    async fn thread_exists(&self, thread_id: &ThreadId) -> Result<bool, MemoryError> {
+    async fn thread_exists(&self, thread_id: &ThreadId<str>) -> Result<bool, MemoryError> {
         Ok(self.has_thread(thread_id))
     }
 
     async fn load_history_up_to(
         &self,
-        session_id: &ThreadId,
+        session_id: &ThreadId<str>,
         start_from: Option<i64>,
         up_to: Option<i64>,
     ) -> Result<Vec<InfinityMessage>, MemoryError> {
@@ -796,7 +796,7 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn append_messages(
         &self,
-        session_id: &ThreadId,
+        session_id: &ThreadId<str>,
         messages: Vec<(InfinityMessage, String)>,
     ) -> Result<(), MemoryError> {
         self.ensure_thread_loaded(session_id);
@@ -808,7 +808,7 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn spawn_thread(
         &self,
-        parent_thread_id: &ThreadId,
+        parent_thread_id: &ThreadId<str>,
         spawn_tool_call_id: &str,
         is_for_subscription_event: bool,
         spawn_order_override: Option<usize>,
@@ -855,12 +855,12 @@ impl ConversationStore for PersistentConversationStore {
         Ok(new_id)
     }
 
-    async fn is_thread_closed(&self, thread_id: &ThreadId) -> Result<bool, MemoryError> {
+    async fn is_thread_closed(&self, thread_id: &ThreadId<str>) -> Result<bool, MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         Ok(self.core.is_thread_closed(thread_id).await?)
     }
 
-    async fn close_thread(&self, thread_id: &ThreadId) -> Result<(), MemoryError> {
+    async fn close_thread(&self, thread_id: &ThreadId<str>) -> Result<(), MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         self.core.close_thread(thread_id).await?;
         self.save_thread_metadata(thread_id);
@@ -870,7 +870,7 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn is_subscription_event_thread(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<bool, MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         Ok(self.core.is_subscription_event_thread(thread_id).await?)
@@ -878,7 +878,7 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn get_thread_parent_info(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Option<(ThreadId, String)>, MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         Ok(self.core.get_thread_parent_info(thread_id).await?)
@@ -886,11 +886,11 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn get_ancestor_chain(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<(ThreadId, i64)>, MemoryError> {
         // Lazily load the metadata of every ancestor, then delegate the walk
         // (and its ordering semantics) to the core store.
-        let mut current = thread_id.clone();
+        let mut current = thread_id.to_owned();
         loop {
             self.ensure_thread_metadata_loaded(&current);
             match self
@@ -907,7 +907,7 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn save_compaction_summary(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         summary: &str,
         up_to_order: i64,
     ) -> Result<(), MemoryError> {
@@ -921,7 +921,7 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn load_latest_compaction_summary_up_to(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         up_to_order: Option<i64>,
     ) -> Result<Option<(String, i64)>, MemoryError> {
         self.ensure_thread_loaded(thread_id);
@@ -931,12 +931,15 @@ impl ConversationStore for PersistentConversationStore {
             .await?)
     }
 
-    async fn is_compaction_thread(&self, thread_id: &ThreadId) -> Result<bool, MemoryError> {
+    async fn is_compaction_thread(&self, thread_id: &ThreadId<str>) -> Result<bool, MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         Ok(self.core.is_compaction_thread(thread_id).await?)
     }
 
-    async fn mark_thread_as_compaction(&self, thread_id: &ThreadId) -> Result<(), MemoryError> {
+    async fn mark_thread_as_compaction(
+        &self,
+        thread_id: &ThreadId<str>,
+    ) -> Result<(), MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         self.core.mark_thread_as_compaction(thread_id).await?;
         self.save_thread_metadata(thread_id);
@@ -945,7 +948,7 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn get_thread_spawn_order(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Option<i64>, MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         Ok(self.core.get_thread_spawn_order(thread_id).await?)
@@ -984,7 +987,7 @@ impl PersistentStateStore {
         }
     }
 
-    pub fn has_pending_choices(&self, thread_id: &ThreadId) -> bool {
+    pub fn has_pending_choices(&self, thread_id: &ThreadId<str>) -> bool {
         self.ensure_loaded(thread_id);
         !self
             .core
@@ -996,14 +999,14 @@ impl PersistentStateStore {
     /// Whether any thread in the session rooted at `session_id` has a pending
     /// user choice. The exact-thread query above remains available for routing
     /// choice responses to the thread that requested them.
-    pub fn has_pending_choices_for_session(&self, session_id: &ThreadId) -> bool {
+    pub fn has_pending_choices_for_session(&self, session_id: &ThreadId<str>) -> bool {
         self.conversation_store
             .get_session_thread_ids(session_id)
             .iter()
             .any(|thread_id| self.has_pending_choices(thread_id))
     }
 
-    pub fn pending_choice(&self, thread_id: &ThreadId, choice_id: &str) -> Option<UserChoice> {
+    pub fn pending_choice(&self, thread_id: &ThreadId<str>, choice_id: &str) -> Option<UserChoice> {
         self.ensure_loaded(thread_id);
         self.core
             .thread_state(thread_id)
@@ -1012,7 +1015,10 @@ impl PersistentStateStore {
             .find(|choice| choice.id == choice_id)
     }
 
-    pub async fn clear_pending_choices(&self, thread_id: &ThreadId) -> Result<(), MemoryError> {
+    pub async fn clear_pending_choices(
+        &self,
+        thread_id: &ThreadId<str>,
+    ) -> Result<(), MemoryError> {
         let choices = self.get_pending_user_choices(thread_id).await?;
         for choice in choices {
             self.remove_pending_user_choice(thread_id, &choice.id)
@@ -1025,7 +1031,7 @@ impl PersistentStateStore {
     /// closed and compaction threads that are not shown in the session UI.
     pub async fn clear_pending_choices_for_session(
         &self,
-        session_id: &ThreadId,
+        session_id: &ThreadId<str>,
     ) -> Result<(), MemoryError> {
         for thread_id in self.conversation_store.get_session_thread_ids(session_id) {
             self.clear_pending_choices(&thread_id).await?;
@@ -1035,7 +1041,7 @@ impl PersistentStateStore {
 
     /// Write a single key's state data to `{dir}/{key}.state.json`. The file
     /// is the serialized core [`ThreadState`] snapshot.
-    fn save_key(&self, key: &ThreadId) {
+    fn save_key(&self, key: &ThreadId<str>) {
         let snapshot = self.core.thread_state(key);
         let path = self.dir.join(format!("{}.state.json", key));
         if let Ok(json) = serde_json::to_string_pretty(&snapshot) {
@@ -1044,7 +1050,7 @@ impl PersistentStateStore {
     }
 
     /// Ensure a key's data is loaded from disk into the core store.
-    fn ensure_loaded(&self, key: &ThreadId) {
+    fn ensure_loaded(&self, key: &ThreadId<str>) {
         let mut loaded = self.loaded.lock().expect("bug: mutex poisoned");
         if loaded.contains(key) {
             return;
@@ -1057,7 +1063,7 @@ impl PersistentStateStore {
             self.core.set_thread_state(key, snapshot);
         }
 
-        loaded.insert(key.clone());
+        loaded.insert(key.to_owned());
     }
 }
 
@@ -1067,7 +1073,7 @@ impl StateStore for PersistentStateStore {
 
     async fn get_processed_ids(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<HashSet<String>, MemoryError> {
         self.ensure_loaded(thread_id);
         Ok(self.core.get_processed_ids(thread_id).await?)
@@ -1075,7 +1081,7 @@ impl StateStore for PersistentStateStore {
 
     async fn add_processed_message_ids(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         message_ids: Vec<String>,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(thread_id);
@@ -1088,7 +1094,7 @@ impl StateStore for PersistentStateStore {
 
     async fn get_metadata(
         &self,
-        root_thread_id: &ThreadId,
+        root_thread_id: &ThreadId<str>,
     ) -> Result<Option<serde_json::Value>, MemoryError> {
         self.ensure_loaded(root_thread_id);
         Ok(self.core.get_metadata(root_thread_id).await?)
@@ -1096,7 +1102,7 @@ impl StateStore for PersistentStateStore {
 
     async fn set_metadata(
         &self,
-        root_thread_id: &ThreadId,
+        root_thread_id: &ThreadId<str>,
         metadata: serde_json::Value,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(root_thread_id);
@@ -1107,7 +1113,7 @@ impl StateStore for PersistentStateStore {
 
     async fn get_active_subscriptions(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<String>, MemoryError> {
         self.ensure_loaded(thread_id);
         Ok(self.core.get_active_subscriptions(thread_id).await?)
@@ -1115,7 +1121,7 @@ impl StateStore for PersistentStateStore {
 
     async fn add_active_subscription(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         tool_call_id: &str,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(thread_id);
@@ -1128,7 +1134,7 @@ impl StateStore for PersistentStateStore {
 
     async fn remove_active_subscription(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         tool_call_id: &str,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(thread_id);
@@ -1141,7 +1147,7 @@ impl StateStore for PersistentStateStore {
 
     async fn add_pending_user_choice(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         choice: UserChoice,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(thread_id);
@@ -1153,7 +1159,7 @@ impl StateStore for PersistentStateStore {
 
     async fn remove_pending_user_choice(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         choice_id: &str,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(thread_id);
@@ -1167,13 +1173,13 @@ impl StateStore for PersistentStateStore {
 
     async fn get_pending_user_choices(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<Vec<UserChoice>, MemoryError> {
         self.ensure_loaded(thread_id);
         Ok(self.core.get_pending_user_choices(thread_id).await?)
     }
 
-    async fn is_thread_stopped(&self, thread_id: &ThreadId) -> Result<bool, MemoryError> {
+    async fn is_thread_stopped(&self, thread_id: &ThreadId<str>) -> Result<bool, MemoryError> {
         let session_id = self.conversation_store.get_root_thread_id(thread_id);
         Ok(self.session_store.lock().await.is_shut_down(&session_id))
     }
@@ -1246,25 +1252,25 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread(&"root".into())
+            .ensure_root_thread(ThreadId::from_ref("root"))
             .await
             .expect("ensure root thread");
         store
             .append_messages(
-                &"root".into(),
+                ThreadId::from_ref("root"),
                 vec![(user_msg("p1"), "m1".into()), (asst_msg("p2"), "m2".into())],
             )
             .await
             .expect("append root messages");
 
         let child = store
-            .spawn_thread(&"root".into(), "tc-1", false, None)
+            .spawn_thread(ThreadId::from_ref("root"), "tc-1", false, None)
             .await
             .expect("spawn child thread");
 
         store
             .append_messages(
-                &"root".into(),
+                ThreadId::from_ref("root"),
                 vec![(user_msg("p3"), "m3".into()), (asst_msg("p4"), "m4".into())],
             )
             .await
@@ -1304,16 +1310,19 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread(&"root".into())
+            .ensure_root_thread(ThreadId::from_ref("root"))
             .await
             .expect("ensure root thread");
         store
-            .append_messages(&"root".into(), vec![(user_msg("r1"), "m1".into())])
+            .append_messages(
+                ThreadId::from_ref("root"),
+                vec![(user_msg("r1"), "m1".into())],
+            )
             .await
             .expect("append root messages");
 
         let child = store
-            .spawn_thread(&"root".into(), "tc-1", false, None)
+            .spawn_thread(ThreadId::from_ref("root"), "tc-1", false, None)
             .await
             .expect("spawn child thread");
         store
@@ -1350,12 +1359,12 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread(&"root".into())
+            .ensure_root_thread(ThreadId::from_ref("root"))
             .await
             .expect("ensure root thread");
         store
             .append_messages(
-                &"root".into(),
+                ThreadId::from_ref("root"),
                 vec![
                     (user_msg("old1"), "m1".into()),
                     (asst_msg("old2"), "m2".into()),
@@ -1367,12 +1376,12 @@ mod tests {
             .expect("append root messages");
 
         store
-            .save_compaction_summary(&"root".into(), "summary of old stuff", 2)
+            .save_compaction_summary(ThreadId::from_ref("root"), "summary of old stuff", 2)
             .await
             .expect("save compaction summary");
 
         let (history, compacted_up_to, _) = store
-            .load_history_with_ancestors(&"root".into())
+            .load_history_with_ancestors(ThreadId::from_ref("root"))
             .await
             .expect("load history with ancestors");
         assert_eq!(history.len(), 3);
@@ -1395,12 +1404,12 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread(&"root".into())
+            .ensure_root_thread(ThreadId::from_ref("root"))
             .await
             .expect("ensure root thread");
         store
             .append_messages(
-                &"root".into(),
+                ThreadId::from_ref("root"),
                 vec![
                     (user_msg("old1"), "m1".into()),
                     (asst_msg("old2"), "m2".into()),
@@ -1411,12 +1420,12 @@ mod tests {
             .expect("append root messages");
 
         store
-            .save_compaction_summary(&"root".into(), "compacted root", 2)
+            .save_compaction_summary(ThreadId::from_ref("root"), "compacted root", 2)
             .await
             .expect("save compaction summary");
 
         let child = store
-            .spawn_thread(&"root".into(), "tc-1", false, None)
+            .spawn_thread(ThreadId::from_ref("root"), "tc-1", false, None)
             .await
             .expect("spawn child thread");
         store
@@ -1447,12 +1456,12 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread(&"root".into())
+            .ensure_root_thread(ThreadId::from_ref("root"))
             .await
             .expect("ensure root thread");
         store
             .append_messages(
-                &"root".into(),
+                ThreadId::from_ref("root"),
                 vec![
                     (user_msg("a"), "m1".into()),
                     (asst_msg("b"), "m2".into()),
@@ -1465,16 +1474,16 @@ mod tests {
             .expect("append root messages");
 
         store
-            .save_compaction_summary(&"root".into(), "early summary", 2)
+            .save_compaction_summary(ThreadId::from_ref("root"), "early summary", 2)
             .await
             .expect("save early compaction summary");
         store
-            .save_compaction_summary(&"root".into(), "later summary", 4)
+            .save_compaction_summary(ThreadId::from_ref("root"), "later summary", 4)
             .await
             .expect("save later compaction summary");
 
         let child = store
-            .spawn_thread(&"root".into(), "tc-1", false, None)
+            .spawn_thread(ThreadId::from_ref("root"), "tc-1", false, None)
             .await
             .expect("spawn child thread");
         store
@@ -1506,23 +1515,23 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread(&"root".into())
+            .ensure_root_thread(ThreadId::from_ref("root"))
             .await
             .expect("ensure root thread");
         store
             .append_messages(
-                &"root".into(),
+                ThreadId::from_ref("root"),
                 vec![(user_msg("r1"), "m1".into()), (asst_msg("r2"), "m2".into())],
             )
             .await
             .expect("append root messages");
         store
-            .save_compaction_summary(&"root".into(), "root compaction", 2)
+            .save_compaction_summary(ThreadId::from_ref("root"), "root compaction", 2)
             .await
             .expect("save root compaction summary");
 
         let child = store
-            .spawn_thread(&"root".into(), "tc-1", false, None)
+            .spawn_thread(ThreadId::from_ref("root"), "tc-1", false, None)
             .await
             .expect("spawn child thread");
         store

--- a/crates/infinity-daemon/src/memory_store.rs
+++ b/crates/infinity-daemon/src/memory_store.rs
@@ -13,6 +13,7 @@
 //! - session serialization for migration.
 
 use async_trait::async_trait;
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::message::InfinityMessage;
 use infinity_agent_core::stores::{
     self as core_stores, CompactionSummary, ThreadInfo, ThreadState,
@@ -52,18 +53,18 @@ pub struct PersistentConversationStore {
     /// Daemon-only per-thread bookkeeping. Invariant: a thread has an entry
     /// here iff it has one in `core` (both are created together by the
     /// spawn/load/import paths of this wrapper).
-    extras: Arc<Mutex<HashMap<String, ThreadExtras>>>,
+    extras: Arc<Mutex<HashMap<ThreadId, ThreadExtras>>>,
     /// Directory where per-thread JSON files are stored. `None` disables persistence.
     dir: Option<PathBuf>,
     /// Tracks which thread IDs have had their full data loaded from disk.
-    loaded: Arc<Mutex<HashSet<String>>>,
+    loaded: Arc<Mutex<HashSet<ThreadId>>>,
     /// Tracks which thread IDs have had their metadata loaded from disk.
-    metadata_loaded: Arc<Mutex<HashSet<String>>>,
+    metadata_loaded: Arc<Mutex<HashSet<ThreadId>>>,
     /// Optional sender to notify session store of changes (for SessionsUpdated broadcasts).
-    change_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+    change_tx: Option<tokio::sync::mpsc::UnboundedSender<ThreadId>>,
     /// Per-thread active views, keyed by thread_id → (view_type → content).
     /// Persisted separately to `{thread_id}.views.json`.
-    views: Arc<Mutex<HashMap<String, HashMap<String, serde_json::Value>>>>,
+    views: Arc<Mutex<HashMap<ThreadId, HashMap<String, serde_json::Value>>>>,
     /// The global default model, used for new threads and backfilled into
     /// metadata serialized before models were tracked per-thread.
     default_model: ModelRef,
@@ -78,7 +79,7 @@ pub(crate) struct ThreadExtras {
     #[serde(default)]
     title: Option<String>,
     #[serde(default)]
-    children: Vec<String>,
+    children: Vec<ThreadId>,
     #[serde(default)]
     total_tokens_used: usize,
     #[serde(default)]
@@ -263,13 +264,13 @@ impl PersistentConversationStore {
     }
 
     /// Set the change notification sender. Called after construction.
-    pub fn set_change_tx(&mut self, tx: tokio::sync::mpsc::UnboundedSender<String>) {
+    pub fn set_change_tx(&mut self, tx: tokio::sync::mpsc::UnboundedSender<ThreadId>) {
         self.change_tx = Some(tx);
     }
 
     /// Migration: if a thread's last_updated / total_tokens_used is empty, try to
     /// restore them from the legacy `sessions.json` (parent of the threads dir).
-    fn migrate_from_session_store(&self, thread_id: &str, threads_dir: &Path) {
+    fn migrate_from_session_store(&self, thread_id: &ThreadId, threads_dir: &Path) {
         {
             let extras = self.extras.lock().expect("bug: mutex poisoned");
             match extras.get(thread_id) {
@@ -285,7 +286,7 @@ impl PersistentConversationStore {
         let Ok(val) = serde_json::from_str::<serde_json::Value>(&json) else {
             return;
         };
-        let Some(entry) = val.get("sessions").and_then(|s| s.get(thread_id)) else {
+        let Some(entry) = val.get("sessions").and_then(|s| s.get(thread_id.as_str())) else {
             return;
         };
 
@@ -314,7 +315,7 @@ impl PersistentConversationStore {
     }
 
     /// Notify that a session's thread tree changed.
-    fn notify_session(&self, thread_id: &str) {
+    fn notify_session(&self, thread_id: &ThreadId) {
         if let Some(ref tx) = self.change_tx {
             let root = self.get_root_thread_id(thread_id);
             let _ = tx.send(root);
@@ -323,7 +324,7 @@ impl PersistentConversationStore {
 
     /// Combine the core store's info and the daemon extras into the
     /// serialization shape, if the thread exists in both.
-    fn thread_meta(&self, thread_id: &str) -> Option<ThreadMeta> {
+    fn thread_meta(&self, thread_id: &ThreadId) -> Option<ThreadMeta> {
         let info = self.core.thread_info(thread_id)?;
         let extras = self
             .extras
@@ -336,17 +337,17 @@ impl PersistentConversationStore {
 
     /// Restore a thread's metadata from its serialization shape (splitting
     /// it between the core store and the daemon extras).
-    fn restore_thread_meta(&self, thread_id: &str, mut meta: ThreadMeta) {
+    fn restore_thread_meta(&self, thread_id: &ThreadId, mut meta: ThreadMeta) {
         self.backfill_selected_model(&mut meta.extras);
         self.core.set_thread_info(thread_id, meta.info);
         self.extras
             .lock()
             .expect("bug: mutex poisoned")
-            .insert(thread_id.to_owned(), meta.extras);
+            .insert(thread_id.clone(), meta.extras);
     }
 
     /// Write a single thread's metadata to `{dir}/{thread_id}.meta.json`.
-    fn save_thread_metadata(&self, thread_id: &str) {
+    fn save_thread_metadata(&self, thread_id: &ThreadId) {
         let Some(ref dir) = self.dir else { return };
         if let Some(meta) = self.thread_meta(thread_id) {
             let path = dir.join(format!("{}.meta.json", thread_id));
@@ -358,7 +359,7 @@ impl PersistentConversationStore {
 
     /// Write a single thread's data to `{dir}/{thread_id}.json` and metadata to `.meta.json`.
     /// No-op when persistence is disabled.
-    fn save_thread(&self, thread_id: &str) {
+    fn save_thread(&self, thread_id: &ThreadId) {
         let Some(ref dir) = self.dir else { return };
         let snapshot = ThreadSnapshot {
             messages: self.core.thread_messages(thread_id).unwrap_or_default(),
@@ -375,7 +376,7 @@ impl PersistentConversationStore {
     /// Ensure a thread's metadata (core info + extras) is loaded from disk.
     /// Tries `.meta.json` first; falls back to extracting from the full `.json` snapshot
     /// and writes the `.meta.json` for future fast loads.
-    fn ensure_thread_metadata_loaded(&self, thread_id: &str) {
+    fn ensure_thread_metadata_loaded(&self, thread_id: &ThreadId) {
         let Some(ref dir) = self.dir else { return };
 
         let mut meta_loaded = self.metadata_loaded.lock().expect("bug: mutex poisoned");
@@ -413,12 +414,12 @@ impl PersistentConversationStore {
         // Migration: restore title/last_updated from legacy sessions.json
         self.migrate_from_session_store(thread_id, dir);
 
-        meta_loaded.insert(thread_id.to_owned());
+        meta_loaded.insert(thread_id.clone());
     }
 
     /// Ensure a thread's full data (messages, compaction summaries) is loaded.
     /// Calls `ensure_thread_metadata_loaded` first.
-    fn ensure_thread_loaded(&self, thread_id: &str) {
+    fn ensure_thread_loaded(&self, thread_id: &ThreadId) {
         self.ensure_thread_metadata_loaded(thread_id);
 
         let Some(ref dir) = self.dir else { return };
@@ -444,28 +445,28 @@ impl PersistentConversationStore {
             );
         }
 
-        loaded.insert(thread_id.to_owned());
+        loaded.insert(thread_id.clone());
 
         self.load_views(thread_id);
     }
 
     /// Whether metadata exists for this thread (in memory or on disk).
-    pub fn has_thread(&self, thread_id: &str) -> bool {
+    pub fn has_thread(&self, thread_id: &ThreadId) -> bool {
         self.ensure_thread_metadata_loaded(thread_id);
         self.core.thread_info(thread_id).is_some()
     }
 
     /// Resolve a thread ID to its root thread ID (i.e. the session ID).
-    pub fn get_root_thread_id(&self, thread_id: &str) -> String {
+    pub fn get_root_thread_id(&self, thread_id: &ThreadId) -> ThreadId {
         self.ensure_thread_metadata_loaded(thread_id);
         self.core
             .thread_info(thread_id)
             .map(|t| t.root_thread_id)
-            .unwrap_or_else(|| thread_id.to_owned())
+            .unwrap_or_else(|| thread_id.clone())
     }
 
     /// Get the parent thread ID, if any.
-    pub fn get_thread_parent_id(&self, thread_id: &str) -> Option<String> {
+    pub fn get_thread_parent_id(&self, thread_id: &ThreadId) -> Option<ThreadId> {
         self.ensure_thread_metadata_loaded(thread_id);
         self.core
             .thread_info(thread_id)
@@ -473,7 +474,7 @@ impl PersistentConversationStore {
     }
 
     /// Set the title for a thread.
-    pub fn set_thread_title(&self, thread_id: &str, title: &str) {
+    pub fn set_thread_title(&self, thread_id: &ThreadId, title: &str) {
         self.ensure_thread_metadata_loaded(thread_id);
         {
             let mut extras = self.extras.lock().expect("bug: mutex poisoned");
@@ -487,7 +488,7 @@ impl PersistentConversationStore {
 
     /// Get the model selected for this specific thread. Does NOT fall back to
     /// the parent thread — every thread is assigned a model at creation time.
-    pub fn get_thread_model(&self, thread_id: &str) -> ModelRef {
+    pub fn get_thread_model(&self, thread_id: &ThreadId) -> ModelRef {
         self.ensure_thread_metadata_loaded(thread_id);
         let extras = self.extras.lock().expect("bug: mutex poisoned");
         extras
@@ -497,7 +498,7 @@ impl PersistentConversationStore {
     }
 
     /// Set the model selected for a thread.
-    pub fn set_thread_model(&self, thread_id: &str, model: ModelRef) {
+    pub fn set_thread_model(&self, thread_id: &ThreadId, model: ModelRef) {
         self.ensure_thread_metadata_loaded(thread_id);
         {
             let mut extras = self.extras.lock().expect("bug: mutex poisoned");
@@ -512,9 +513,9 @@ impl PersistentConversationStore {
     /// are closed or used for compaction. Session-level state must still account
     /// for those threads even though they are omitted from the visible thread
     /// list.
-    pub fn get_session_thread_ids(&self, root_id: &str) -> Vec<String> {
+    pub fn get_session_thread_ids(&self, root_id: &ThreadId) -> Vec<ThreadId> {
         let mut result = Vec::new();
-        let mut queue = vec![root_id.to_owned()];
+        let mut queue = vec![root_id.clone()];
         let mut visited = HashSet::new();
 
         while let Some(thread_id) = queue.pop() {
@@ -538,10 +539,13 @@ impl PersistentConversationStore {
 
     /// List open (non-closed) subthreads that are descendants of `parent_id`
     /// within the given session. Walks the children tree via metadata.
-    pub fn get_open_subthreads(&self, parent_id: &str) -> Vec<infinity_protocol::SubthreadInfo> {
+    pub fn get_open_subthreads(
+        &self,
+        parent_id: &ThreadId,
+    ) -> Vec<infinity_protocol::SubthreadInfo> {
         self.ensure_thread_metadata_loaded(parent_id);
         let mut result = Vec::new();
-        let mut queue = vec![parent_id.to_owned()];
+        let mut queue = vec![parent_id.clone()];
         while let Some(pid) = queue.pop() {
             let children = {
                 let extras = self.extras.lock().expect("bug: mutex poisoned");
@@ -561,8 +565,8 @@ impl PersistentConversationStore {
                         extras.get(&child_id).and_then(|e| e.title.clone())
                     };
                     result.push(infinity_protocol::SubthreadInfo {
-                        thread_id: child_id.clone(),
-                        parent_thread_id: pid.clone(),
+                        thread_id: child_id.to_string(),
+                        parent_thread_id: pid.to_string(),
                         title,
                     });
                     queue.push(child_id);
@@ -572,7 +576,7 @@ impl PersistentConversationStore {
         result
     }
 
-    pub fn get_total_tokens_used(&self, thread_id: &str) -> usize {
+    pub fn get_total_tokens_used(&self, thread_id: &ThreadId) -> usize {
         self.ensure_thread_metadata_loaded(thread_id);
         self.extras
             .lock()
@@ -582,7 +586,7 @@ impl PersistentConversationStore {
             .unwrap_or(0)
     }
 
-    pub fn set_total_tokens_used(&self, thread_id: &str, tokens: usize) {
+    pub fn set_total_tokens_used(&self, thread_id: &ThreadId, tokens: usize) {
         self.ensure_thread_metadata_loaded(thread_id);
         if let Some(e) = self
             .extras
@@ -596,7 +600,7 @@ impl PersistentConversationStore {
         self.notify_session(thread_id);
     }
 
-    pub fn get_last_updated(&self, thread_id: &str) -> String {
+    pub fn get_last_updated(&self, thread_id: &ThreadId) -> String {
         self.ensure_thread_metadata_loaded(thread_id);
         self.extras
             .lock()
@@ -606,7 +610,7 @@ impl PersistentConversationStore {
             .unwrap_or_default()
     }
 
-    pub fn set_last_updated(&self, thread_id: &str, ts: &str) {
+    pub fn set_last_updated(&self, thread_id: &ThreadId, ts: &str) {
         self.ensure_thread_metadata_loaded(thread_id);
         if let Some(e) = self
             .extras
@@ -620,7 +624,7 @@ impl PersistentConversationStore {
     }
 
     /// Write views to `{dir}/{thread_id}.views.json`.
-    fn save_views(&self, thread_id: &str) {
+    fn save_views(&self, thread_id: &ThreadId) {
         let Some(ref dir) = self.dir else { return };
         let views = self.views.lock().expect("bug: mutex poisoned");
         let path = dir.join(format!("{}.views.json", thread_id));
@@ -637,7 +641,7 @@ impl PersistentConversationStore {
     }
 
     /// Load views from `{dir}/{thread_id}.views.json`.
-    fn load_views(&self, thread_id: &str) {
+    fn load_views(&self, thread_id: &ThreadId) {
         tracing::info!("Loading views for thread {thread_id}");
         let Some(ref dir) = self.dir else { return };
         let path = dir.join(format!("{}.views.json", thread_id));
@@ -647,7 +651,7 @@ impl PersistentConversationStore {
                     self.views
                         .lock()
                         .expect("bug: mutex poisoned")
-                        .insert(thread_id.to_owned(), v);
+                        .insert(thread_id.clone(), v);
                 }
                 Err(e) => {
                     tracing::error!("Failed to deserialize views: {e}");
@@ -661,11 +665,11 @@ impl PersistentConversationStore {
     }
 
     /// Update a view for a thread and persist.
-    pub fn set_view(&self, thread_id: &str, view_type: &str, content: serde_json::Value) {
+    pub fn set_view(&self, thread_id: &ThreadId, view_type: &str, content: serde_json::Value) {
         {
             let mut views = self.views.lock().expect("bug: mutex poisoned");
             views
-                .entry(thread_id.to_owned())
+                .entry(thread_id.clone())
                 .or_default()
                 .insert(view_type.to_owned(), content);
         }
@@ -673,7 +677,7 @@ impl PersistentConversationStore {
     }
 
     /// Get all views for a thread.
-    pub fn get_views(&self, thread_id: &str) -> HashMap<String, serde_json::Value> {
+    pub fn get_views(&self, thread_id: &ThreadId) -> HashMap<String, serde_json::Value> {
         self.ensure_thread_loaded(thread_id);
         self.views
             .lock()
@@ -683,7 +687,7 @@ impl PersistentConversationStore {
             .unwrap_or_default()
     }
 
-    pub fn get_thread_title(&self, thread_id: &str) -> Option<String> {
+    pub fn get_thread_title(&self, thread_id: &ThreadId) -> Option<String> {
         self.ensure_thread_metadata_loaded(thread_id);
         self.extras
             .lock()
@@ -693,9 +697,9 @@ impl PersistentConversationStore {
     }
 
     /// Serialize all threads in a session tree to a JSON string.
-    pub fn serialize_session(&self, root_thread_id: &str) -> String {
-        let mut threads: HashMap<String, SerializedThread> = HashMap::new();
-        let mut queue = vec![root_thread_id.to_owned()];
+    pub fn serialize_session(&self, root_thread_id: &ThreadId) -> String {
+        let mut threads: HashMap<ThreadId, SerializedThread> = HashMap::new();
+        let mut queue = vec![root_thread_id.clone()];
         while let Some(tid) = queue.pop() {
             self.ensure_thread_loaded(&tid);
             let Some(metadata) = self.thread_meta(&tid) else {
@@ -727,7 +731,7 @@ impl PersistentConversationStore {
 
     /// Import a serialized session into the store.
     pub fn import_session(&self, data: &str) -> Result<(), MemoryError> {
-        let threads: HashMap<String, SerializedThread> = serde_json::from_str(data)
+        let threads: HashMap<ThreadId, SerializedThread> = serde_json::from_str(data)
             .map_err(|e| MemoryError(format!("failed to deserialize session: {e}")))?;
         for (tid, st) in threads {
             self.restore_thread_meta(&tid, st.metadata);
@@ -759,13 +763,13 @@ impl PersistentConversationStore {
 impl ConversationStore for PersistentConversationStore {
     type Error = MemoryError;
 
-    async fn ensure_root_thread(&self, thread_id: &str) -> Result<(), MemoryError> {
+    async fn ensure_root_thread(&self, thread_id: &ThreadId) -> Result<(), MemoryError> {
         self.ensure_thread_loaded(thread_id);
         let inserted = self.core.thread_info(thread_id).is_none();
         if inserted {
             self.core.ensure_root_thread(thread_id).await?;
             self.extras.lock().expect("bug: mutex poisoned").insert(
-                thread_id.to_owned(),
+                thread_id.clone(),
                 ThreadExtras::new(self.default_model.clone()),
             );
             self.save_thread(thread_id);
@@ -773,13 +777,13 @@ impl ConversationStore for PersistentConversationStore {
         Ok(())
     }
 
-    async fn thread_exists(&self, thread_id: &str) -> Result<bool, MemoryError> {
+    async fn thread_exists(&self, thread_id: &ThreadId) -> Result<bool, MemoryError> {
         Ok(self.has_thread(thread_id))
     }
 
     async fn load_history_up_to(
         &self,
-        session_id: &str,
+        session_id: &ThreadId,
         start_from: Option<i64>,
         up_to: Option<i64>,
     ) -> Result<Vec<InfinityMessage>, MemoryError> {
@@ -792,7 +796,7 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn append_messages(
         &self,
-        session_id: &str,
+        session_id: &ThreadId,
         messages: Vec<(InfinityMessage, String)>,
     ) -> Result<(), MemoryError> {
         self.ensure_thread_loaded(session_id);
@@ -804,13 +808,13 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn spawn_thread(
         &self,
-        parent_thread_id: &str,
+        parent_thread_id: &ThreadId,
         spawn_tool_call_id: &str,
         is_for_subscription_event: bool,
         spawn_order_override: Option<usize>,
-    ) -> Result<String, MemoryError> {
+    ) -> Result<ThreadId, MemoryError> {
         self.ensure_thread_loaded(parent_thread_id);
-        let new_id = self.id_source.generate();
+        let new_id = ThreadId::from(self.id_source.generate());
         {
             // Hold the load-tracking locks while creating the thread so a
             // concurrent load cannot interleave with the creation.
@@ -851,12 +855,12 @@ impl ConversationStore for PersistentConversationStore {
         Ok(new_id)
     }
 
-    async fn is_thread_closed(&self, thread_id: &str) -> Result<bool, MemoryError> {
+    async fn is_thread_closed(&self, thread_id: &ThreadId) -> Result<bool, MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         Ok(self.core.is_thread_closed(thread_id).await?)
     }
 
-    async fn close_thread(&self, thread_id: &str) -> Result<(), MemoryError> {
+    async fn close_thread(&self, thread_id: &ThreadId) -> Result<(), MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         self.core.close_thread(thread_id).await?;
         self.save_thread_metadata(thread_id);
@@ -864,23 +868,29 @@ impl ConversationStore for PersistentConversationStore {
         Ok(())
     }
 
-    async fn is_subscription_event_thread(&self, thread_id: &str) -> Result<bool, MemoryError> {
+    async fn is_subscription_event_thread(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<bool, MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         Ok(self.core.is_subscription_event_thread(thread_id).await?)
     }
 
     async fn get_thread_parent_info(
         &self,
-        thread_id: &str,
-    ) -> Result<Option<(String, String)>, MemoryError> {
+        thread_id: &ThreadId,
+    ) -> Result<Option<(ThreadId, String)>, MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         Ok(self.core.get_thread_parent_info(thread_id).await?)
     }
 
-    async fn get_ancestor_chain(&self, thread_id: &str) -> Result<Vec<(String, i64)>, MemoryError> {
+    async fn get_ancestor_chain(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Vec<(ThreadId, i64)>, MemoryError> {
         // Lazily load the metadata of every ancestor, then delegate the walk
         // (and its ordering semantics) to the core store.
-        let mut current = thread_id.to_owned();
+        let mut current = thread_id.clone();
         loop {
             self.ensure_thread_metadata_loaded(&current);
             match self
@@ -897,7 +907,7 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn save_compaction_summary(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         summary: &str,
         up_to_order: i64,
     ) -> Result<(), MemoryError> {
@@ -911,7 +921,7 @@ impl ConversationStore for PersistentConversationStore {
 
     async fn load_latest_compaction_summary_up_to(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         up_to_order: Option<i64>,
     ) -> Result<Option<(String, i64)>, MemoryError> {
         self.ensure_thread_loaded(thread_id);
@@ -921,19 +931,22 @@ impl ConversationStore for PersistentConversationStore {
             .await?)
     }
 
-    async fn is_compaction_thread(&self, thread_id: &str) -> Result<bool, MemoryError> {
+    async fn is_compaction_thread(&self, thread_id: &ThreadId) -> Result<bool, MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         Ok(self.core.is_compaction_thread(thread_id).await?)
     }
 
-    async fn mark_thread_as_compaction(&self, thread_id: &str) -> Result<(), MemoryError> {
+    async fn mark_thread_as_compaction(&self, thread_id: &ThreadId) -> Result<(), MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         self.core.mark_thread_as_compaction(thread_id).await?;
         self.save_thread_metadata(thread_id);
         Ok(())
     }
 
-    async fn get_thread_spawn_order(&self, thread_id: &str) -> Result<Option<i64>, MemoryError> {
+    async fn get_thread_spawn_order(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Option<i64>, MemoryError> {
         self.ensure_thread_metadata_loaded(thread_id);
         Ok(self.core.get_thread_spawn_order(thread_id).await?)
     }
@@ -948,7 +961,7 @@ pub struct PersistentStateStore {
     /// Directory where per-thread state JSON files are stored.
     dir: PathBuf,
     /// Tracks which keys have already been loaded (or attempted) from disk.
-    loaded: Arc<Mutex<HashSet<String>>>,
+    loaded: Arc<Mutex<HashSet<ThreadId>>>,
     // Used to resolve child threads for stopped-session policy.
     conversation_store: PersistentConversationStore,
     session_store: Arc<tokio::sync::Mutex<crate::session_store::SessionStore>>,
@@ -971,7 +984,7 @@ impl PersistentStateStore {
         }
     }
 
-    pub fn has_pending_choices(&self, thread_id: &str) -> bool {
+    pub fn has_pending_choices(&self, thread_id: &ThreadId) -> bool {
         self.ensure_loaded(thread_id);
         !self
             .core
@@ -983,14 +996,14 @@ impl PersistentStateStore {
     /// Whether any thread in the session rooted at `session_id` has a pending
     /// user choice. The exact-thread query above remains available for routing
     /// choice responses to the thread that requested them.
-    pub fn has_pending_choices_for_session(&self, session_id: &str) -> bool {
+    pub fn has_pending_choices_for_session(&self, session_id: &ThreadId) -> bool {
         self.conversation_store
             .get_session_thread_ids(session_id)
             .iter()
             .any(|thread_id| self.has_pending_choices(thread_id))
     }
 
-    pub fn pending_choice(&self, thread_id: &str, choice_id: &str) -> Option<UserChoice> {
+    pub fn pending_choice(&self, thread_id: &ThreadId, choice_id: &str) -> Option<UserChoice> {
         self.ensure_loaded(thread_id);
         self.core
             .thread_state(thread_id)
@@ -999,7 +1012,7 @@ impl PersistentStateStore {
             .find(|choice| choice.id == choice_id)
     }
 
-    pub async fn clear_pending_choices(&self, thread_id: &str) -> Result<(), MemoryError> {
+    pub async fn clear_pending_choices(&self, thread_id: &ThreadId) -> Result<(), MemoryError> {
         let choices = self.get_pending_user_choices(thread_id).await?;
         for choice in choices {
             self.remove_pending_user_choice(thread_id, &choice.id)
@@ -1012,7 +1025,7 @@ impl PersistentStateStore {
     /// closed and compaction threads that are not shown in the session UI.
     pub async fn clear_pending_choices_for_session(
         &self,
-        session_id: &str,
+        session_id: &ThreadId,
     ) -> Result<(), MemoryError> {
         for thread_id in self.conversation_store.get_session_thread_ids(session_id) {
             self.clear_pending_choices(&thread_id).await?;
@@ -1022,7 +1035,7 @@ impl PersistentStateStore {
 
     /// Write a single key's state data to `{dir}/{key}.state.json`. The file
     /// is the serialized core [`ThreadState`] snapshot.
-    fn save_key(&self, key: &str) {
+    fn save_key(&self, key: &ThreadId) {
         let snapshot = self.core.thread_state(key);
         let path = self.dir.join(format!("{}.state.json", key));
         if let Ok(json) = serde_json::to_string_pretty(&snapshot) {
@@ -1031,7 +1044,7 @@ impl PersistentStateStore {
     }
 
     /// Ensure a key's data is loaded from disk into the core store.
-    fn ensure_loaded(&self, key: &str) {
+    fn ensure_loaded(&self, key: &ThreadId) {
         let mut loaded = self.loaded.lock().expect("bug: mutex poisoned");
         if loaded.contains(key) {
             return;
@@ -1044,7 +1057,7 @@ impl PersistentStateStore {
             self.core.set_thread_state(key, snapshot);
         }
 
-        loaded.insert(key.to_owned());
+        loaded.insert(key.clone());
     }
 }
 
@@ -1052,14 +1065,17 @@ impl PersistentStateStore {
 impl StateStore for PersistentStateStore {
     type Error = MemoryError;
 
-    async fn get_processed_ids(&self, thread_id: &str) -> Result<HashSet<String>, MemoryError> {
+    async fn get_processed_ids(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<HashSet<String>, MemoryError> {
         self.ensure_loaded(thread_id);
         Ok(self.core.get_processed_ids(thread_id).await?)
     }
 
     async fn add_processed_message_ids(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         message_ids: Vec<String>,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(thread_id);
@@ -1072,7 +1088,7 @@ impl StateStore for PersistentStateStore {
 
     async fn get_metadata(
         &self,
-        root_thread_id: &str,
+        root_thread_id: &ThreadId,
     ) -> Result<Option<serde_json::Value>, MemoryError> {
         self.ensure_loaded(root_thread_id);
         Ok(self.core.get_metadata(root_thread_id).await?)
@@ -1080,7 +1096,7 @@ impl StateStore for PersistentStateStore {
 
     async fn set_metadata(
         &self,
-        root_thread_id: &str,
+        root_thread_id: &ThreadId,
         metadata: serde_json::Value,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(root_thread_id);
@@ -1089,14 +1105,17 @@ impl StateStore for PersistentStateStore {
         Ok(())
     }
 
-    async fn get_active_subscriptions(&self, thread_id: &str) -> Result<Vec<String>, MemoryError> {
+    async fn get_active_subscriptions(
+        &self,
+        thread_id: &ThreadId,
+    ) -> Result<Vec<String>, MemoryError> {
         self.ensure_loaded(thread_id);
         Ok(self.core.get_active_subscriptions(thread_id).await?)
     }
 
     async fn add_active_subscription(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         tool_call_id: &str,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(thread_id);
@@ -1109,7 +1128,7 @@ impl StateStore for PersistentStateStore {
 
     async fn remove_active_subscription(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         tool_call_id: &str,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(thread_id);
@@ -1122,7 +1141,7 @@ impl StateStore for PersistentStateStore {
 
     async fn add_pending_user_choice(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         choice: UserChoice,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(thread_id);
@@ -1134,7 +1153,7 @@ impl StateStore for PersistentStateStore {
 
     async fn remove_pending_user_choice(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         choice_id: &str,
     ) -> Result<(), MemoryError> {
         self.ensure_loaded(thread_id);
@@ -1148,13 +1167,13 @@ impl StateStore for PersistentStateStore {
 
     async fn get_pending_user_choices(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
     ) -> Result<Vec<UserChoice>, MemoryError> {
         self.ensure_loaded(thread_id);
         Ok(self.core.get_pending_user_choices(thread_id).await?)
     }
 
-    async fn is_thread_stopped(&self, thread_id: &str) -> Result<bool, MemoryError> {
+    async fn is_thread_stopped(&self, thread_id: &ThreadId) -> Result<bool, MemoryError> {
         let session_id = self.conversation_store.get_root_thread_id(thread_id);
         Ok(self.session_store.lock().await.is_shut_down(&session_id))
     }
@@ -1200,7 +1219,7 @@ mod tests {
         });
         let meta: ThreadMeta =
             serde_json::from_value(old_json.clone()).expect("old flat format parses");
-        assert_eq!(meta.info.root_thread_id, "r");
+        assert_eq!(meta.info.root_thread_id.as_str(), "r");
         assert_eq!(meta.info.spawn_message_order, Some(3));
         assert_eq!(meta.extras.total_tokens_used, 42);
         assert_eq!(meta.extras.selected_model.provider_id, "prov");
@@ -1227,25 +1246,25 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread("root")
+            .ensure_root_thread(&"root".into())
             .await
             .expect("ensure root thread");
         store
             .append_messages(
-                "root",
+                &"root".into(),
                 vec![(user_msg("p1"), "m1".into()), (asst_msg("p2"), "m2".into())],
             )
             .await
             .expect("append root messages");
 
         let child = store
-            .spawn_thread("root", "tc-1", false, None)
+            .spawn_thread(&"root".into(), "tc-1", false, None)
             .await
             .expect("spawn child thread");
 
         store
             .append_messages(
-                "root",
+                &"root".into(),
                 vec![(user_msg("p3"), "m3".into()), (asst_msg("p4"), "m4".into())],
             )
             .await
@@ -1285,16 +1304,16 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread("root")
+            .ensure_root_thread(&"root".into())
             .await
             .expect("ensure root thread");
         store
-            .append_messages("root", vec![(user_msg("r1"), "m1".into())])
+            .append_messages(&"root".into(), vec![(user_msg("r1"), "m1".into())])
             .await
             .expect("append root messages");
 
         let child = store
-            .spawn_thread("root", "tc-1", false, None)
+            .spawn_thread(&"root".into(), "tc-1", false, None)
             .await
             .expect("spawn child thread");
         store
@@ -1331,12 +1350,12 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread("root")
+            .ensure_root_thread(&"root".into())
             .await
             .expect("ensure root thread");
         store
             .append_messages(
-                "root",
+                &"root".into(),
                 vec![
                     (user_msg("old1"), "m1".into()),
                     (asst_msg("old2"), "m2".into()),
@@ -1348,12 +1367,12 @@ mod tests {
             .expect("append root messages");
 
         store
-            .save_compaction_summary("root", "summary of old stuff", 2)
+            .save_compaction_summary(&"root".into(), "summary of old stuff", 2)
             .await
             .expect("save compaction summary");
 
         let (history, compacted_up_to, _) = store
-            .load_history_with_ancestors("root")
+            .load_history_with_ancestors(&"root".into())
             .await
             .expect("load history with ancestors");
         assert_eq!(history.len(), 3);
@@ -1376,12 +1395,12 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread("root")
+            .ensure_root_thread(&"root".into())
             .await
             .expect("ensure root thread");
         store
             .append_messages(
-                "root",
+                &"root".into(),
                 vec![
                     (user_msg("old1"), "m1".into()),
                     (asst_msg("old2"), "m2".into()),
@@ -1392,12 +1411,12 @@ mod tests {
             .expect("append root messages");
 
         store
-            .save_compaction_summary("root", "compacted root", 2)
+            .save_compaction_summary(&"root".into(), "compacted root", 2)
             .await
             .expect("save compaction summary");
 
         let child = store
-            .spawn_thread("root", "tc-1", false, None)
+            .spawn_thread(&"root".into(), "tc-1", false, None)
             .await
             .expect("spawn child thread");
         store
@@ -1428,12 +1447,12 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread("root")
+            .ensure_root_thread(&"root".into())
             .await
             .expect("ensure root thread");
         store
             .append_messages(
-                "root",
+                &"root".into(),
                 vec![
                     (user_msg("a"), "m1".into()),
                     (asst_msg("b"), "m2".into()),
@@ -1446,16 +1465,16 @@ mod tests {
             .expect("append root messages");
 
         store
-            .save_compaction_summary("root", "early summary", 2)
+            .save_compaction_summary(&"root".into(), "early summary", 2)
             .await
             .expect("save early compaction summary");
         store
-            .save_compaction_summary("root", "later summary", 4)
+            .save_compaction_summary(&"root".into(), "later summary", 4)
             .await
             .expect("save later compaction summary");
 
         let child = store
-            .spawn_thread("root", "tc-1", false, None)
+            .spawn_thread(&"root".into(), "tc-1", false, None)
             .await
             .expect("spawn child thread");
         store
@@ -1487,23 +1506,23 @@ mod tests {
             Arc::new(crate::ids::UuidIdSource),
         );
         store
-            .ensure_root_thread("root")
+            .ensure_root_thread(&"root".into())
             .await
             .expect("ensure root thread");
         store
             .append_messages(
-                "root",
+                &"root".into(),
                 vec![(user_msg("r1"), "m1".into()), (asst_msg("r2"), "m2".into())],
             )
             .await
             .expect("append root messages");
         store
-            .save_compaction_summary("root", "root compaction", 2)
+            .save_compaction_summary(&"root".into(), "root compaction", 2)
             .await
             .expect("save root compaction summary");
 
         let child = store
-            .spawn_thread("root", "tc-1", false, None)
+            .spawn_thread(&"root".into(), "tc-1", false, None)
             .await
             .expect("spawn child thread");
         store

--- a/crates/infinity-daemon/src/migrate.rs
+++ b/crates/infinity-daemon/src/migrate.rs
@@ -217,7 +217,7 @@ async fn boot_source_rap_servers(
 /// Handle an Emigrate request: shut down session, boot fresh RAP servers,
 /// migrate state, serialize, and return the session data.
 pub async fn handle_emigrate(
-    session_id: &ThreadId,
+    session_id: &ThreadId<str>,
     dest_rap_urls: HashMap<String, String>,
     session_manager: &SharedSessionManager,
 ) -> Result<String, BoxError> {

--- a/crates/infinity-daemon/src/migrate.rs
+++ b/crates/infinity-daemon/src/migrate.rs
@@ -3,6 +3,7 @@
 //! Handles migrating a session between local and remote daemons.
 //! The local daemon always acts as the orchestrator.
 
+use infinity_agent_core::ThreadId;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -28,11 +29,13 @@ pub async fn orchestrate_migration(
         session_id: session_id.clone(),
     });
 
-    let real_session_id = session_id
-        .split_once('/')
-        .map_or(session_id.as_str(), |(_, s)| s);
+    let real_session_id = ThreadId::from(
+        session_id
+            .split_once('/')
+            .map_or(session_id.as_str(), |(_, s)| s),
+    );
     let new_session_id = match &to {
-        None => real_session_id.to_owned(),
+        None => real_session_id.to_string(),
         Some(remote) => format!("{remote}/{real_session_id}"),
     };
 
@@ -60,12 +63,12 @@ async fn run_migration(
 ) -> Result<(), BoxError> {
     let source_is_local = !session_id.contains('/');
     let (source_remote, real_session_id) = if source_is_local {
-        (None, session_id.to_owned())
+        (None, ThreadId::from(session_id))
     } else {
         let (r, s) = session_id
             .split_once('/')
             .ok_or("invalid remote session id")?;
-        (Some(r.to_owned()), s.to_owned())
+        (Some(r.to_owned()), ThreadId::from(s))
     };
     let dest_is_local = to.is_none();
 
@@ -104,7 +107,7 @@ async fn run_migration(
             rap_client::http::SimpleHttpClient::new(),
         );
         if let Err(errors) = notifier
-            .request_migration(&real_session_id, &migration_servers, &dest_rap_urls)
+            .request_migration(real_session_id.as_str(), &migration_servers, &dest_rap_urls)
             .await
         {
             return Err(format!("RAP migration failed: {}", errors.join("; ")).into());
@@ -127,7 +130,7 @@ async fn run_migration(
             source_remote
                 .as_deref()
                 .expect("bug: source remote but no name"),
-            &real_session_id,
+            real_session_id.as_str(),
             dest_rap_urls,
         )
         .await?
@@ -155,7 +158,7 @@ async fn run_migration(
         immigrate_to_remote(
             &rd,
             to.expect("bug: dest is remote"),
-            &real_session_id,
+            real_session_id.as_str(),
             dest_cwd,
             &session_data,
         )
@@ -180,7 +183,7 @@ async fn run_migration(
                 source_remote
                     .as_deref()
                     .expect("bug: source remote but no name"),
-                &real_session_id,
+                real_session_id.as_str(),
             )
             .await?;
         }
@@ -214,7 +217,7 @@ async fn boot_source_rap_servers(
 /// Handle an Emigrate request: shut down session, boot fresh RAP servers,
 /// migrate state, serialize, and return the session data.
 pub async fn handle_emigrate(
-    session_id: &str,
+    session_id: &ThreadId,
     dest_rap_urls: HashMap<String, String>,
     session_manager: &SharedSessionManager,
 ) -> Result<String, BoxError> {
@@ -239,7 +242,7 @@ pub async fn handle_emigrate(
             rap_client::http::SimpleHttpClient::new(),
         );
         if let Err(errors) = notifier
-            .request_migration(session_id, &migration_servers, &dest_rap_urls)
+            .request_migration(session_id.as_str(), &migration_servers, &dest_rap_urls)
             .await
         {
             return Err(format!("RAP migration failed: {}", errors.join("; ")).into());

--- a/crates/infinity-daemon/src/models.rs
+++ b/crates/infinity-daemon/src/models.rs
@@ -386,7 +386,7 @@ pub struct CatalogModelSource {
 impl infinity_agent_core::system::ModelSource for CatalogModelSource {
     async fn resolve(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<infinity_agent_core::system::ResolvedModel, BoxError> {
         let selected = self.conversation_store.get_thread_model(thread_id);
         let (model_ref, entry, fell_back) = self.catalog.resolve(&selected);

--- a/crates/infinity-daemon/src/models.rs
+++ b/crates/infinity-daemon/src/models.rs
@@ -11,6 +11,7 @@
 //! on stdout, and talks to it through a
 //! [`RemoteModelProvider`](infinity_provider_protocol::remote::RemoteModelProvider).
 
+use infinity_agent_core::ThreadId;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
@@ -385,7 +386,7 @@ pub struct CatalogModelSource {
 impl infinity_agent_core::system::ModelSource for CatalogModelSource {
     async fn resolve(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
     ) -> Result<infinity_agent_core::system::ResolvedModel, BoxError> {
         let selected = self.conversation_store.get_thread_model(thread_id);
         let (model_ref, entry, fell_back) = self.catalog.resolve(&selected);

--- a/crates/infinity-daemon/src/rap_callback.rs
+++ b/crates/infinity-daemon/src/rap_callback.rs
@@ -34,7 +34,7 @@ pub fn serve_callbacks(
                 update.group_id
             );
             let manager = sm.lock().await;
-            manager.handle_view_update(&update.group_id, &update.view_type, update.content);
+            manager.handle_view_update(update.group_id.as_str(), &update.view_type, update.content);
         }
     });
 

--- a/crates/infinity-daemon/src/rap_callback.rs
+++ b/crates/infinity-daemon/src/rap_callback.rs
@@ -34,7 +34,7 @@ pub fn serve_callbacks(
                 update.group_id
             );
             let manager = sm.lock().await;
-            manager.handle_view_update(update.group_id.as_str(), &update.view_type, update.content);
+            manager.handle_view_update(&update.group_id, &update.view_type, update.content);
         }
     });
 

--- a/crates/infinity-daemon/src/rap_servers.rs
+++ b/crates/infinity-daemon/src/rap_servers.rs
@@ -21,6 +21,7 @@
 //! servers by config id and consulting each manifest's `needsMigration`
 //! flag.
 
+use infinity_agent_core::ThreadId;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -104,13 +105,13 @@ enum ServerState {
 pub struct ManagedRapServer {
     /// Config id (for migration bookkeeping), when present.
     pub config_id: Option<String>,
-    session_id: String,
+    session_id: ThreadId,
     spec: ServerSpec,
     state: tokio::sync::Mutex<ServerState>,
 }
 
 impl ManagedRapServer {
-    fn new(session_id: String, config_id: Option<String>, spec: ServerSpec) -> Self {
+    fn new(session_id: ThreadId, config_id: Option<String>, spec: ServerSpec) -> Self {
         Self {
             config_id,
             session_id,
@@ -272,7 +273,8 @@ pub async fn boot_migration_servers(
     cwd: &Path,
     user_config_path: Option<&Path>,
 ) -> Result<Vec<MigrationServer>, BoxError> {
-    let (_source_info, specs) = collect_server_specs("migration", cwd, user_config_path)?;
+    let (_source_info, specs) =
+        collect_server_specs(&ThreadId::from("migration"), cwd, user_config_path)?;
     let mut servers = Vec::new();
     for server in specs {
         let manifest = match server.ensure_up().await {
@@ -428,7 +430,7 @@ struct SessionToolset {
 /// session's toolset.
 #[derive(Clone)]
 pub struct SessionRapManager {
-    toolsets: Rc<tokio::sync::Mutex<HashMap<String, Rc<SessionToolset>>>>,
+    toolsets: Rc<tokio::sync::Mutex<HashMap<ThreadId, Rc<SessionToolset>>>>,
     conversation_store: PersistentConversationStore,
     session_store: SessionStoreHandle,
     user_rap_config: Option<PathBuf>,
@@ -436,7 +438,7 @@ pub struct SessionRapManager {
     subscriber_map: SubscriberMap,
     /// Sessions whose servers have been shut down at least once (observable
     /// for tests and diagnostics).
-    shutdown_log: Rc<std::cell::RefCell<Vec<String>>>,
+    shutdown_log: Rc<std::cell::RefCell<Vec<ThreadId>>>,
 }
 
 impl SessionRapManager {
@@ -457,9 +459,9 @@ impl SessionRapManager {
     }
 
     /// Send an informational message to the session's subscribers.
-    fn info(&self, session_id: &str, text: String) {
+    fn info(&self, session_id: &ThreadId, text: String) {
         let msg = DaemonMessage::Info {
-            thread_id: Some(session_id.to_owned()),
+            thread_id: Some(session_id.to_string()),
             text,
         };
         crate::session::observer::broadcast_to_thread(&self.subscriber_map, session_id, &msg, None);
@@ -468,7 +470,7 @@ impl SessionRapManager {
     /// Get (or lazily build) the toolset for a session: read the RAP config
     /// for the session's cwd, boot the servers, fetch their manifests, and
     /// build the tool instances.
-    async fn get_or_init(&self, session_id: &str) -> Result<Rc<SessionToolset>, BoxError> {
+    async fn get_or_init(&self, session_id: &ThreadId) -> Result<Rc<SessionToolset>, BoxError> {
         let mut toolsets = self.toolsets.lock().await;
         if let Some(ts) = toolsets.get(session_id) {
             return Ok(ts.clone());
@@ -540,13 +542,13 @@ impl SessionRapManager {
             servers,
             extra_system_prompt,
         });
-        toolsets.insert(session_id.to_owned(), toolset.clone());
+        toolsets.insert(session_id.clone(), toolset.clone());
         Ok(toolset)
     }
 
     /// Stop the session's RAP servers (keeping the cached toolset, so a later
     /// tool invocation reboots them transparently). Safe to call at any time.
-    pub async fn shutdown_session(&self, session_id: &str) {
+    pub async fn shutdown_session(&self, session_id: &ThreadId) {
         let toolset = {
             let toolsets = self.toolsets.lock().await;
             toolsets.get(session_id).cloned()
@@ -556,20 +558,20 @@ impl SessionRapManager {
                 server.shutdown().await;
             }
         }
-        self.shutdown_log.borrow_mut().push(session_id.to_owned());
+        self.shutdown_log.borrow_mut().push(session_id.clone());
     }
 
     /// Stop the session's servers and drop its cached toolset entirely, so
     /// the next use re-reads the RAP config and re-fetches manifests. Used
     /// when a session is explicitly shut down.
-    pub async fn evict_session(&self, session_id: &str) {
+    pub async fn evict_session(&self, session_id: &ThreadId) {
         self.shutdown_session(session_id).await;
         self.toolsets.lock().await.remove(session_id);
     }
 
     /// Stop every managed server (daemon exit).
     pub async fn shutdown_all(&self) {
-        let session_ids: Vec<String> = self.toolsets.lock().await.keys().cloned().collect();
+        let session_ids: Vec<ThreadId> = self.toolsets.lock().await.keys().cloned().collect();
         for session_id in session_ids {
             self.shutdown_session(&session_id).await;
         }
@@ -577,11 +579,11 @@ impl SessionRapManager {
 
     /// How many times [`shutdown_session`](Self::shutdown_session) has been
     /// invoked for `session_id` (diagnostics / tests).
-    pub fn times_shut_down(&self, session_id: &str) -> usize {
+    pub fn times_shut_down(&self, session_id: &ThreadId) -> usize {
         self.shutdown_log
             .borrow()
             .iter()
-            .filter(|s| s.as_str() == session_id)
+            .filter(|s| *s == session_id)
             .count()
     }
 }
@@ -590,7 +592,7 @@ impl SessionRapManager {
 impl ThreadConfigSource<ChannelSender, SimpleHttpClient> for SessionRapManager {
     async fn resolve(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
     ) -> Result<ThreadConfig<ChannelSender, SimpleHttpClient>, BoxError> {
         let session_id = self.conversation_store.get_root_thread_id(thread_id);
         let toolset = self.get_or_init(&session_id).await?;
@@ -615,7 +617,7 @@ impl ThreadConfigSource<ChannelSender, SimpleHttpClient> for SessionRapManager {
 /// handles. Also returns a human-readable line describing which config
 /// source(s) were used, for display to the session's subscribers.
 fn collect_server_specs(
-    session_id: &str,
+    session_id: &ThreadId,
     cwd: &Path,
     user_config_path: Option<&Path>,
 ) -> Result<(String, Vec<ManagedRapServer>), BoxError> {
@@ -650,7 +652,7 @@ fn collect_server_specs(
                 id,
             } => (id, ServerSpec::HttpMcp { name, url, headers }),
         };
-        servers.push(ManagedRapServer::new(session_id.to_owned(), id, spec));
+        servers.push(ManagedRapServer::new(session_id.clone(), id, spec));
     }
     Ok((source_info, servers))
 }

--- a/crates/infinity-daemon/src/rap_servers.rs
+++ b/crates/infinity-daemon/src/rap_servers.rs
@@ -459,7 +459,7 @@ impl SessionRapManager {
     }
 
     /// Send an informational message to the session's subscribers.
-    fn info(&self, session_id: &ThreadId, text: String) {
+    fn info(&self, session_id: &ThreadId<str>, text: String) {
         let msg = DaemonMessage::Info {
             thread_id: Some(session_id.to_string()),
             text,
@@ -470,7 +470,10 @@ impl SessionRapManager {
     /// Get (or lazily build) the toolset for a session: read the RAP config
     /// for the session's cwd, boot the servers, fetch their manifests, and
     /// build the tool instances.
-    async fn get_or_init(&self, session_id: &ThreadId) -> Result<Rc<SessionToolset>, BoxError> {
+    async fn get_or_init(
+        &self,
+        session_id: &ThreadId<str>,
+    ) -> Result<Rc<SessionToolset>, BoxError> {
         let mut toolsets = self.toolsets.lock().await;
         if let Some(ts) = toolsets.get(session_id) {
             return Ok(ts.clone());
@@ -542,13 +545,13 @@ impl SessionRapManager {
             servers,
             extra_system_prompt,
         });
-        toolsets.insert(session_id.clone(), toolset.clone());
+        toolsets.insert(session_id.to_owned(), toolset.clone());
         Ok(toolset)
     }
 
     /// Stop the session's RAP servers (keeping the cached toolset, so a later
     /// tool invocation reboots them transparently). Safe to call at any time.
-    pub async fn shutdown_session(&self, session_id: &ThreadId) {
+    pub async fn shutdown_session(&self, session_id: &ThreadId<str>) {
         let toolset = {
             let toolsets = self.toolsets.lock().await;
             toolsets.get(session_id).cloned()
@@ -558,13 +561,13 @@ impl SessionRapManager {
                 server.shutdown().await;
             }
         }
-        self.shutdown_log.borrow_mut().push(session_id.clone());
+        self.shutdown_log.borrow_mut().push(session_id.to_owned());
     }
 
     /// Stop the session's servers and drop its cached toolset entirely, so
     /// the next use re-reads the RAP config and re-fetches manifests. Used
     /// when a session is explicitly shut down.
-    pub async fn evict_session(&self, session_id: &ThreadId) {
+    pub async fn evict_session(&self, session_id: &ThreadId<str>) {
         self.shutdown_session(session_id).await;
         self.toolsets.lock().await.remove(session_id);
     }
@@ -579,7 +582,7 @@ impl SessionRapManager {
 
     /// How many times [`shutdown_session`](Self::shutdown_session) has been
     /// invoked for `session_id` (diagnostics / tests).
-    pub fn times_shut_down(&self, session_id: &ThreadId) -> usize {
+    pub fn times_shut_down(&self, session_id: &ThreadId<str>) -> usize {
         self.shutdown_log
             .borrow()
             .iter()
@@ -592,7 +595,7 @@ impl SessionRapManager {
 impl ThreadConfigSource<ChannelSender, SimpleHttpClient> for SessionRapManager {
     async fn resolve(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
     ) -> Result<ThreadConfig<ChannelSender, SimpleHttpClient>, BoxError> {
         let session_id = self.conversation_store.get_root_thread_id(thread_id);
         let toolset = self.get_or_init(&session_id).await?;
@@ -617,7 +620,7 @@ impl ThreadConfigSource<ChannelSender, SimpleHttpClient> for SessionRapManager {
 /// handles. Also returns a human-readable line describing which config
 /// source(s) were used, for display to the session's subscribers.
 fn collect_server_specs(
-    session_id: &ThreadId,
+    session_id: &ThreadId<str>,
     cwd: &Path,
     user_config_path: Option<&Path>,
 ) -> Result<(String, Vec<ManagedRapServer>), BoxError> {
@@ -652,7 +655,7 @@ fn collect_server_specs(
                 id,
             } => (id, ServerSpec::HttpMcp { name, url, headers }),
         };
-        servers.push(ManagedRapServer::new(session_id.clone(), id, spec));
+        servers.push(ManagedRapServer::new(session_id.to_owned(), id, spec));
     }
     Ok((source_info, servers))
 }

--- a/crates/infinity-daemon/src/session/display.rs
+++ b/crates/infinity-daemon/src/session/display.rs
@@ -4,7 +4,7 @@ use infinity_agent_core::system::AgentEvent;
 use infinity_protocol::{DaemonMessage, TokenUsage};
 use infinity_provider_protocol::message::{AssistantContent, ToolResultContent, UserContent};
 
-pub(crate) fn agent_event_to_daemon(thread_id: &ThreadId, evt: &AgentEvent) -> DaemonMessage {
+pub(crate) fn agent_event_to_daemon(thread_id: &ThreadId<str>, evt: &AgentEvent) -> DaemonMessage {
     let tid = Some(thread_id.to_string());
     match evt {
         AgentEvent::CompletionStarted => DaemonMessage::StartOutput { thread_id: tid },
@@ -76,7 +76,7 @@ pub(crate) fn agent_event_to_daemon(thread_id: &ThreadId, evt: &AgentEvent) -> D
 
 pub(crate) fn history_message_to_daemon(
     msg: &InfinityMessage,
-    tid: &ThreadId,
+    tid: &ThreadId<str>,
     history: &[InfinityMessage],
 ) -> Option<DaemonMessage> {
     let thread_id = Some(tid.to_string());

--- a/crates/infinity-daemon/src/session/display.rs
+++ b/crates/infinity-daemon/src/session/display.rs
@@ -1,10 +1,11 @@
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::message::InfinityMessage;
 use infinity_agent_core::system::AgentEvent;
 use infinity_protocol::{DaemonMessage, TokenUsage};
 use infinity_provider_protocol::message::{AssistantContent, ToolResultContent, UserContent};
 
-pub(crate) fn agent_event_to_daemon(thread_id: &str, evt: &AgentEvent) -> DaemonMessage {
-    let tid = Some(thread_id.to_owned());
+pub(crate) fn agent_event_to_daemon(thread_id: &ThreadId, evt: &AgentEvent) -> DaemonMessage {
+    let tid = Some(thread_id.to_string());
     match evt {
         AgentEvent::CompletionStarted => DaemonMessage::StartOutput { thread_id: tid },
         AgentEvent::TextChunk { text } => DaemonMessage::TextChunk {
@@ -75,10 +76,10 @@ pub(crate) fn agent_event_to_daemon(thread_id: &str, evt: &AgentEvent) -> Daemon
 
 pub(crate) fn history_message_to_daemon(
     msg: &InfinityMessage,
-    tid: &str,
+    tid: &ThreadId,
     history: &[InfinityMessage],
 ) -> Option<DaemonMessage> {
-    let thread_id = Some(tid.to_owned());
+    let thread_id = Some(tid.to_string());
     match msg {
         InfinityMessage::SubscriptionEvent {
             result,

--- a/crates/infinity-daemon/src/session/mod.rs
+++ b/crates/infinity-daemon/src/session/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::message::InputMessage;
 use infinity_agent_core::system::AgentSystemBuilder;
 use infinity_agent_core::system::local::{
@@ -33,7 +34,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 /// is live, and stays active after the driver idles for as long as it holds
 /// active subscriptions (its RAP servers must stay up to deliver the
 /// events). Maintained by the session activity watcher.
-pub type ActiveThreadSet = Arc<std::sync::Mutex<std::collections::HashSet<String>>>;
+pub type ActiveThreadSet = Arc<std::sync::Mutex<std::collections::HashSet<ThreadId>>>;
 
 pub type SessionStoreHandle = Arc<tokio::sync::Mutex<session_store::SessionStore>>;
 
@@ -105,7 +106,7 @@ pub struct SessionManager {
     /// Requests an idle re-evaluation for a session (e.g. after a client
     /// disconnect). Consumed by the session activity watcher alongside the
     /// core thread lifecycle events.
-    idle_eval_tx: mpsc::UnboundedSender<String>,
+    idle_eval_tx: mpsc::UnboundedSender<ThreadId>,
 }
 
 impl SessionManager {
@@ -153,7 +154,7 @@ impl SessionManager {
 
         std::fs::create_dir_all(&state_dir).ok();
         let sessions_path = state_dir.join("sessions.json");
-        let (change_tx, mut change_rx) = mpsc::unbounded_channel::<String>();
+        let (change_tx, mut change_rx) = mpsc::unbounded_channel::<ThreadId>();
         let change_tx_for_conv = change_tx.clone();
         let session_store = Arc::new(tokio::sync::Mutex::new(session_store::SessionStore::load(
             &sessions_path.to_string_lossy(),
@@ -206,7 +207,7 @@ impl SessionManager {
                     };
                     drop(store);
                     let mut sessions = HashMap::new();
-                    sessions.insert(session_id, info);
+                    sessions.insert(session_id.to_string(), info);
                     let msg = DaemonMessage::SessionsUpdated { sessions };
                     bc.lock()
                         .expect("bug: mutex poisoned")
@@ -244,7 +245,7 @@ impl SessionManager {
         let make_observer = {
             let subscriber_map = subscriber_map.clone();
             let conversation_store = conversation_store.clone();
-            move |thread_id: &str| {
+            move |thread_id: &ThreadId| {
                 let parent_subs = {
                     let parent_id = conversation_store.get_thread_parent_id(thread_id);
                     let smap = subscriber_map.lock().expect("bug: mutex poisoned");
@@ -256,7 +257,7 @@ impl SessionManager {
                 let subscribers = subscriber_map
                     .lock()
                     .expect("bug: mutex poisoned")
-                    .entry(thread_id.to_owned())
+                    .entry(thread_id.clone())
                     .or_insert_with(|| Arc::new(std::sync::Mutex::new(parent_subs)))
                     .clone();
                 DaemonObserver {
@@ -283,7 +284,7 @@ impl SessionManager {
         // on the next tool invocation, so there is no teardown/wakeup race
         // to coordinate.
         let active_threads: ActiveThreadSet = Default::default();
-        let (idle_eval_tx, mut idle_eval_rx) = mpsc::unbounded_channel::<String>();
+        let (idle_eval_tx, mut idle_eval_rx) = mpsc::unbounded_channel::<ThreadId>();
         {
             let conversation_store = conversation_store.clone();
             let session_store = session_store.clone();
@@ -296,7 +297,7 @@ impl SessionManager {
                     loop {
                         enum Activity {
                             Lifecycle(ThreadLifecycleEvent),
-                            Reevaluate(String),
+                            Reevaluate(ThreadId),
                         }
                         let event = tokio::select! {
                             event = running.next_lifecycle_event() => match event {
@@ -422,12 +423,17 @@ impl SessionManager {
     }
 
     /// Handle a view_update RAP callback: persist the view and broadcast to subscribers.
-    pub fn handle_view_update(&self, group_id: &str, view_type: &str, content: serde_json::Value) {
+    pub fn handle_view_update(
+        &self,
+        group_id: &ThreadId,
+        view_type: &str,
+        content: serde_json::Value,
+    ) {
         self.conversation_store
             .set_view(group_id, view_type, content.clone());
 
         let msg = DaemonMessage::ViewUpdate {
-            thread_id: Some(group_id.to_owned()),
+            thread_id: Some(group_id.to_string()),
             view_type: view_type.to_owned(),
             content,
         };
@@ -442,8 +448,8 @@ impl SessionManager {
         cwd: &Path,
         model: ModelRef,
         emit: &mut impl AsyncFnMut(DaemonMessage),
-    ) -> Result<String, BoxError> {
-        let session_id = self.id_source.generate();
+    ) -> Result<ThreadId, BoxError> {
+        let session_id = ThreadId::from(self.id_source.generate());
         {
             let mut store = self.session_store.lock().await;
             store.create(&session_id, cwd.to_path_buf());
@@ -471,22 +477,22 @@ impl SessionManager {
     /// via `send_input`. This just emits `Connected` so the client can attach.
     pub async fn resume_session(
         &self,
-        session_id: &str,
-        thread_id: &str,
+        session_id: &ThreadId,
+        thread_id: &ThreadId,
         emit: &mut impl AsyncFnMut(DaemonMessage),
     ) -> Result<(), BoxError> {
         emit(self.build_connected(session_id, thread_id)).await;
         Ok(())
     }
 
-    fn build_connected(&self, session_id: &str, thread_id: &str) -> DaemonMessage {
+    fn build_connected(&self, session_id: &ThreadId, thread_id: &ThreadId) -> DaemonMessage {
         // Resolve the thread's own selected model (falling back to the global
         // default if it is no longer available).
         let selected = self.conversation_store.get_thread_model(thread_id);
         let (model_ref, entry, _) = self.catalog.resolve(&selected);
         DaemonMessage::Connected {
-            session_id: session_id.to_owned(),
-            thread_id: thread_id.to_owned(),
+            session_id: session_id.to_string(),
+            thread_id: thread_id.to_string(),
             model_name: entry.display_name.clone(),
             context_window: entry.context_window,
             title: self.conversation_store.get_thread_title(session_id),
@@ -505,7 +511,7 @@ impl SessionManager {
     /// the session from going idle (and its RAP servers being stopped).
     pub async fn attach_client(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         tx: mpsc::UnboundedSender<DaemonMessage>,
         wants_replay: bool,
         keeps_session_alive: bool,
@@ -566,7 +572,7 @@ impl SessionManager {
     /// attached.
     pub fn switch_model(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId,
         model: ModelRef,
         requester: Option<&mpsc::UnboundedSender<DaemonMessage>>,
     ) -> Result<(), String> {
@@ -586,7 +592,7 @@ impl SessionManager {
             .set_thread_model(thread_id, model.clone());
 
         let msg = DaemonMessage::ModelSwitched {
-            thread_id: thread_id.to_owned(),
+            thread_id: thread_id.to_string(),
             model_name: entry.display_name.clone(),
             context_window: entry.context_window,
             provider_id: model.provider_id.clone(),
@@ -621,7 +627,7 @@ impl SessionManager {
         for (id, entry) in &store.sessions {
             let threads = self.conversation_store.get_open_subthreads(id);
             result.insert(
-                id.clone(),
+                id.to_string(),
                 SessionInfo {
                     title: self.conversation_store.get_thread_title(id),
                     last_updated: self.conversation_store.get_last_updated(id),
@@ -650,7 +656,7 @@ impl SessionManager {
     /// clears the flag and picks the session back up (its servers reboot
     /// lazily); RAP callbacks arriving while shut down are ignored.
     #[tracing::instrument(skip(self))]
-    pub async fn cleanup_session(&self, session_id: &str) {
+    pub async fn cleanup_session(&self, session_id: &ThreadId) {
         if let Err(error) = self
             .state_store
             .clear_pending_choices_for_session(session_id)
@@ -671,15 +677,15 @@ impl SessionManager {
 
     /// Returns true if the session has no active threads: none with a live
     /// driver and none waiting on subscription events.
-    pub fn is_session_idle(&self, session_id: &str) -> bool {
+    pub fn is_session_idle(&self, session_id: &ThreadId) -> bool {
         !session_has_active_threads(&self.active_threads, &self.conversation_store, session_id)
     }
 
     /// Request an idle re-evaluation for a session (e.g. after a client
     /// disconnect): if none of its threads are live and no keep-alive client
     /// remains, its RAP servers are stopped.
-    pub fn send_idle_ping(&self, session_id: &str) {
-        let _ = self.idle_eval_tx.send(session_id.to_owned());
+    pub fn send_idle_ping(&self, session_id: &ThreadId) {
+        let _ = self.idle_eval_tx.send(session_id.clone());
     }
 }
 
@@ -690,13 +696,13 @@ impl SessionManager {
 fn session_has_active_threads(
     active_threads: &ActiveThreadSet,
     conversation_store: &PersistentConversationStore,
-    session_id: &str,
+    session_id: &ThreadId,
 ) -> bool {
     active_threads
         .lock()
         .expect("bug: mutex poisoned")
         .iter()
-        .any(|thread_id| conversation_store.get_root_thread_id(thread_id) == session_id)
+        .any(|thread_id| conversation_store.get_root_thread_id(thread_id) == *session_id)
 }
 
 /// Decide whether `session_id` has gone idle and release its resources.
@@ -709,7 +715,7 @@ fn session_has_active_threads(
 /// moment later simply respawns a driver, and the first tool interaction
 /// boots the servers back up.
 async fn evaluate_session_idle(
-    session_id: &str,
+    session_id: &ThreadId,
     conversation_store: &PersistentConversationStore,
     session_store: &SessionStoreHandle,
     subscriber_map: &SubscriberMap,
@@ -735,7 +741,9 @@ async fn evaluate_session_idle(
     let has_clients = {
         let smap = subscriber_map.lock().expect("bug: mutex poisoned");
         smap.iter()
-            .filter(|(thread_id, _)| conversation_store.get_root_thread_id(thread_id) == session_id)
+            .filter(|(thread_id, _)| {
+                conversation_store.get_root_thread_id(thread_id) == *session_id
+            })
             .any(|(_, subs)| {
                 subs.lock()
                     .expect("bug: mutex poisoned")

--- a/crates/infinity-daemon/src/session/mod.rs
+++ b/crates/infinity-daemon/src/session/mod.rs
@@ -245,7 +245,7 @@ impl SessionManager {
         let make_observer = {
             let subscriber_map = subscriber_map.clone();
             let conversation_store = conversation_store.clone();
-            move |thread_id: &ThreadId| {
+            move |thread_id: &ThreadId<str>| {
                 let parent_subs = {
                     let parent_id = conversation_store.get_thread_parent_id(thread_id);
                     let smap = subscriber_map.lock().expect("bug: mutex poisoned");
@@ -257,7 +257,7 @@ impl SessionManager {
                 let subscribers = subscriber_map
                     .lock()
                     .expect("bug: mutex poisoned")
-                    .entry(thread_id.clone())
+                    .entry(thread_id.to_owned())
                     .or_insert_with(|| Arc::new(std::sync::Mutex::new(parent_subs)))
                     .clone();
                 DaemonObserver {
@@ -425,7 +425,7 @@ impl SessionManager {
     /// Handle a view_update RAP callback: persist the view and broadcast to subscribers.
     pub fn handle_view_update(
         &self,
-        group_id: &ThreadId,
+        group_id: &ThreadId<str>,
         view_type: &str,
         content: serde_json::Value,
     ) {
@@ -477,15 +477,19 @@ impl SessionManager {
     /// via `send_input`. This just emits `Connected` so the client can attach.
     pub async fn resume_session(
         &self,
-        session_id: &ThreadId,
-        thread_id: &ThreadId,
+        session_id: &ThreadId<str>,
+        thread_id: &ThreadId<str>,
         emit: &mut impl AsyncFnMut(DaemonMessage),
     ) -> Result<(), BoxError> {
         emit(self.build_connected(session_id, thread_id)).await;
         Ok(())
     }
 
-    fn build_connected(&self, session_id: &ThreadId, thread_id: &ThreadId) -> DaemonMessage {
+    fn build_connected(
+        &self,
+        session_id: &ThreadId<str>,
+        thread_id: &ThreadId<str>,
+    ) -> DaemonMessage {
         // Resolve the thread's own selected model (falling back to the global
         // default if it is no longer available).
         let selected = self.conversation_store.get_thread_model(thread_id);
@@ -511,7 +515,7 @@ impl SessionManager {
     /// the session from going idle (and its RAP servers being stopped).
     pub async fn attach_client(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         tx: mpsc::UnboundedSender<DaemonMessage>,
         wants_replay: bool,
         keeps_session_alive: bool,
@@ -572,7 +576,7 @@ impl SessionManager {
     /// attached.
     pub fn switch_model(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         model: ModelRef,
         requester: Option<&mpsc::UnboundedSender<DaemonMessage>>,
     ) -> Result<(), String> {
@@ -656,7 +660,7 @@ impl SessionManager {
     /// clears the flag and picks the session back up (its servers reboot
     /// lazily); RAP callbacks arriving while shut down are ignored.
     #[tracing::instrument(skip(self))]
-    pub async fn cleanup_session(&self, session_id: &ThreadId) {
+    pub async fn cleanup_session(&self, session_id: &ThreadId<str>) {
         if let Err(error) = self
             .state_store
             .clear_pending_choices_for_session(session_id)
@@ -677,15 +681,15 @@ impl SessionManager {
 
     /// Returns true if the session has no active threads: none with a live
     /// driver and none waiting on subscription events.
-    pub fn is_session_idle(&self, session_id: &ThreadId) -> bool {
+    pub fn is_session_idle(&self, session_id: &ThreadId<str>) -> bool {
         !session_has_active_threads(&self.active_threads, &self.conversation_store, session_id)
     }
 
     /// Request an idle re-evaluation for a session (e.g. after a client
     /// disconnect): if none of its threads are live and no keep-alive client
     /// remains, its RAP servers are stopped.
-    pub fn send_idle_ping(&self, session_id: &ThreadId) {
-        let _ = self.idle_eval_tx.send(session_id.clone());
+    pub fn send_idle_ping(&self, session_id: &ThreadId<str>) {
+        let _ = self.idle_eval_tx.send(session_id.to_owned());
     }
 }
 
@@ -696,7 +700,7 @@ impl SessionManager {
 fn session_has_active_threads(
     active_threads: &ActiveThreadSet,
     conversation_store: &PersistentConversationStore,
-    session_id: &ThreadId,
+    session_id: &ThreadId<str>,
 ) -> bool {
     active_threads
         .lock()
@@ -715,7 +719,7 @@ fn session_has_active_threads(
 /// moment later simply respawns a driver, and the first tool interaction
 /// boots the servers back up.
 async fn evaluate_session_idle(
-    session_id: &ThreadId,
+    session_id: &ThreadId<str>,
     conversation_store: &PersistentConversationStore,
     session_store: &SessionStoreHandle,
     subscriber_map: &SubscriberMap,

--- a/crates/infinity-daemon/src/session/observer.rs
+++ b/crates/infinity-daemon/src/session/observer.rs
@@ -66,7 +66,7 @@ pub fn broadcast_pruning(
 /// both locks at once.
 pub fn broadcast_to_thread(
     map: &SubscriberMap,
-    thread_id: &ThreadId,
+    thread_id: &ThreadId<str>,
     msg: &DaemonMessage,
     requester: Option<&mpsc::UnboundedSender<DaemonMessage>>,
 ) -> bool {
@@ -103,7 +103,7 @@ impl DaemonObserver {
 impl ThreadObserver for DaemonObserver {
     type SubscribeRequest = SubscribeRequest;
 
-    fn on_event(&self, thread_id: &ThreadId, event: &AgentEvent) {
+    fn on_event(&self, thread_id: &ThreadId<str>, event: &AgentEvent) {
         // Persist state derived from the event before broadcasting it, so a
         // client can never observe a message whose session state is missing.
         match event {
@@ -133,7 +133,7 @@ impl ThreadObserver for DaemonObserver {
 
     fn on_subscribe(
         &self,
-        thread_id: &ThreadId,
+        thread_id: &ThreadId<str>,
         request: SubscribeRequest,
         snapshot: ReplaySnapshot,
     ) {

--- a/crates/infinity-daemon/src/session/observer.rs
+++ b/crates/infinity-daemon/src/session/observer.rs
@@ -1,6 +1,7 @@
 //! The daemon's [`ThreadObserver`]: fans agent events out to attached
 //! clients as [`DaemonMessage`]s and persists derived presentation state.
 
+use infinity_agent_core::ThreadId;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -32,7 +33,7 @@ pub type ThreadSubscribers = Arc<std::sync::Mutex<Vec<Subscriber>>>;
 
 /// Maps thread_id → subscriber list (for inheriting to children and idle
 /// detection).
-pub type SubscriberMap = Arc<std::sync::Mutex<HashMap<String, ThreadSubscribers>>>;
+pub type SubscriberMap = Arc<std::sync::Mutex<HashMap<ThreadId, ThreadSubscribers>>>;
 
 /// Deliver `msg` to every subscriber in the list, pruning subscribers whose
 /// client has disconnected (their channel is closed). This is the single
@@ -65,7 +66,7 @@ pub fn broadcast_pruning(
 /// both locks at once.
 pub fn broadcast_to_thread(
     map: &SubscriberMap,
-    thread_id: &str,
+    thread_id: &ThreadId,
     msg: &DaemonMessage,
     requester: Option<&mpsc::UnboundedSender<DaemonMessage>>,
 ) -> bool {
@@ -102,7 +103,7 @@ impl DaemonObserver {
 impl ThreadObserver for DaemonObserver {
     type SubscribeRequest = SubscribeRequest;
 
-    fn on_event(&self, thread_id: &str, event: &AgentEvent) {
+    fn on_event(&self, thread_id: &ThreadId, event: &AgentEvent) {
         // Persist state derived from the event before broadcasting it, so a
         // client can never observe a message whose session state is missing.
         match event {
@@ -130,7 +131,12 @@ impl ThreadObserver for DaemonObserver {
         self.broadcast(agent_event_to_daemon(thread_id, event));
     }
 
-    fn on_subscribe(&self, thread_id: &str, request: SubscribeRequest, snapshot: ReplaySnapshot) {
+    fn on_subscribe(
+        &self,
+        thread_id: &ThreadId,
+        request: SubscribeRequest,
+        snapshot: ReplaySnapshot,
+    ) {
         if request.wants_replay {
             let mut history: Vec<DaemonMessage> = snapshot
                 .history
@@ -143,10 +149,10 @@ impl ThreadObserver for DaemonObserver {
             // the replay instead of appearing idle.
             if let Some(thinking) = snapshot.current_thinking {
                 history.push(DaemonMessage::ThinkingStart {
-                    thread_id: Some(thread_id.to_owned()),
+                    thread_id: Some(thread_id.to_string()),
                 });
                 history.push(DaemonMessage::ThinkingChunk {
-                    thread_id: Some(thread_id.to_owned()),
+                    thread_id: Some(thread_id.to_string()),
                     chunk: thinking,
                 });
             }
@@ -154,7 +160,7 @@ impl ThreadObserver for DaemonObserver {
                 .pending_choices
                 .iter()
                 .map(|choice| DaemonMessage::UserChoiceRequired {
-                    thread_id: Some(thread_id.to_owned()),
+                    thread_id: Some(thread_id.to_string()),
                     id: choice.id.clone(),
                     prompt: choice.prompt.clone(),
                     choices: choice.choices.clone(),

--- a/crates/infinity-daemon/src/session/tests.rs
+++ b/crates/infinity-daemon/src/session/tests.rs
@@ -5,6 +5,7 @@
 //! The generic driver behaviors (batching, interruption, deferral, idling,
 //! compaction) are tested in `infinity_agent_core::system::tests`.
 
+use infinity_agent_core::ThreadId;
 use std::sync::Arc;
 
 use infinity_agent_core::message::{InputMessage, InputMessageContent, UserChoiceRequired};
@@ -87,7 +88,7 @@ fn tmp_stores(
 /// [`DaemonObserver`] per thread. Returns the running handle and a subscriber
 /// channel receiving the root thread's `DaemonMessage`s.
 fn start_daemon_system(
-    root: &str,
+    root: &ThreadId,
     conv: PersistentConversationStore,
     state: impl StateStore + 'static,
     catalog: Arc<ModelCatalog>,
@@ -111,7 +112,7 @@ fn start_daemon_system(
     let (client_tx, client_rx) = mpsc::unbounded_channel();
     let subscriber_map: SubscriberMap = Default::default();
     subscriber_map.lock().expect("bug: mutex poisoned").insert(
-        root.to_owned(),
+        root.clone(),
         Arc::new(std::sync::Mutex::new(vec![Subscriber {
             tx: client_tx,
             keeps_session_alive: true,
@@ -120,11 +121,11 @@ fn start_daemon_system(
 
     let make_observer = {
         let subscriber_map = subscriber_map.clone();
-        move |thread_id: &str| {
+        move |thread_id: &ThreadId| {
             let parent_subs = {
                 let parent_id = conv.get_thread_parent_id(thread_id);
                 let smap = subscriber_map.lock().expect("bug: mutex poisoned");
-                let source = parent_id.as_deref().unwrap_or(thread_id);
+                let source = parent_id.as_ref().unwrap_or(thread_id);
                 smap.get(source)
                     .map(|arc| arc.lock().expect("bug: mutex poisoned").clone())
                     .unwrap_or_default()
@@ -159,7 +160,7 @@ async fn collect_until_done(rx: &mut mpsc::UnboundedReceiver<DaemonMessage>) -> 
     texts
 }
 
-fn tool_result_input(group_id: &str, id: &str, text: &str) -> InputMessage {
+fn tool_result_input(group_id: &ThreadId, id: &str, text: &str) -> InputMessage {
     InputMessage {
         content: InputMessageContent::User(UserContent::ToolResult(
             infinity_provider_protocol::message::ToolResult {
@@ -172,7 +173,7 @@ fn tool_result_input(group_id: &str, id: &str, text: &str) -> InputMessage {
                 ],
             },
         )),
-        group_id: group_id.into(),
+        group_id: group_id.clone(),
         metadata: None,
         synthetic: None,
         display_as: None,
@@ -217,10 +218,12 @@ async fn model_switch_applies_to_next_completion() {
             let (model1, mut ctrl1) = mock_model();
             let (model2, mut ctrl2) = mock_model();
             let catalog = two_model_catalog(model1, model2).await;
-            conv.ensure_root_thread("t1").await.expect("ensure root");
+            conv.ensure_root_thread(&"t1".into())
+                .await
+                .expect("ensure root");
 
             let (running, mut display_rx, _smap) = start_daemon_system(
-                "t1",
+                &"t1".into(),
                 conv.clone(),
                 state,
                 catalog,
@@ -229,7 +232,7 @@ async fn model_switch_applies_to_next_completion() {
 
             // First round runs on model1 and leaves an async tool call
             // pending (so the driver stays alive).
-            running.send_user_text("t1", "use the tool").await;
+            running.send_user_text(&"t1".into(), "use the tool").await;
             let _req = ctrl1.next_request().await;
             ctrl1.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
             ctrl1.finish();
@@ -237,11 +240,14 @@ async fn model_switch_applies_to_next_completion() {
 
             // Switch while the driver waits for the tool result. (The session
             // manager persists the selection; each round resolves it fresh.)
-            conv.set_thread_model("t1", model2_ref());
+            conv.set_thread_model(&"t1".into(), model2_ref());
 
             // The tool result triggers the next round — on model2.
             running
-                .send(tool_result_input("t1", "tc-1", "tool done"), "res-1")
+                .send(
+                    tool_result_input(&"t1".into(), "tc-1", "tool done"),
+                    "res-1",
+                )
                 .await;
             let _req2 = ctrl2.next_request().await;
             ctrl2.send_text("hello from model2");
@@ -267,10 +273,12 @@ async fn model_switch_during_completion_applies_to_next_round() {
             let (model1, mut ctrl1) = mock_model();
             let (model2, mut ctrl2) = mock_model();
             let catalog = two_model_catalog(model1, model2).await;
-            conv.ensure_root_thread("t1").await.expect("ensure root");
+            conv.ensure_root_thread(&"t1".into())
+                .await
+                .expect("ensure root");
 
             let (running, mut display_rx, _smap) = start_daemon_system(
-                "t1",
+                &"t1".into(),
                 conv.clone(),
                 state,
                 catalog,
@@ -278,7 +286,7 @@ async fn model_switch_during_completion_applies_to_next_round() {
             );
 
             // Start a completion on model1 and leave it in flight.
-            running.send_user_text("t1", "start").await;
+            running.send_user_text(&"t1".into(), "start").await;
             let _req = ctrl1.next_request().await;
             ctrl1.send_text("streaming on model1...");
             loop {
@@ -293,7 +301,7 @@ async fn model_switch_during_completion_applies_to_next_round() {
 
             // Switch mid-completion: the in-flight round keeps streaming on
             // model1 (it resolved its model at round start).
-            conv.set_thread_model("t1", model2_ref());
+            conv.set_thread_model(&"t1".into(), model2_ref());
 
             // The in-flight completion finishes undisturbed on model1
             // (ending with an async tool call so the driver stays alive).
@@ -303,7 +311,10 @@ async fn model_switch_during_completion_applies_to_next_round() {
 
             // The next round (tool result) goes to model2.
             running
-                .send(tool_result_input("t1", "tc-1", "tool done"), "res-1")
+                .send(
+                    tool_result_input(&"t1".into(), "tc-1", "tool done"),
+                    "res-1",
+                )
                 .await;
             let _req2 = ctrl2.next_request().await;
             ctrl2.send_text("hello from model2");
@@ -329,16 +340,20 @@ async fn spawned_thread_inherits_parent_model() {
             let (model2, mut ctrl2) = mock_model();
             let catalog = two_model_catalog(model1, model2).await;
 
-            conv.ensure_root_thread("root").await.expect("ensure root");
+            conv.ensure_root_thread(&"root".into())
+                .await
+                .expect("ensure root");
             // Set root thread to use the non-default model (provider2/model2).
-            conv.set_thread_model("root", model2_ref());
+            conv.set_thread_model(&"root".into(), model2_ref());
 
             // The built-in spawn_thread tool comes from the system builder.
             let (running, mut display_rx, _smap) =
-                start_daemon_system("root", conv.clone(), state, catalog, vec![]);
+                start_daemon_system(&"root".into(), conv.clone(), state, catalog, vec![]);
 
             // Send user input to root thread (which uses model2).
-            running.send_user_text("root", "spawn a child").await;
+            running
+                .send_user_text(&"root".into(), "spawn a child")
+                .await;
 
             // Root thread uses model2, so ctrl2 gets the request.
             let _req = ctrl2.next_request().await;
@@ -411,14 +426,16 @@ async fn observer_persists_usage_and_resets_on_compaction() {
     use infinity_agent_core::system::{AgentEvent, ThreadObserver};
 
     let (conv, _state, _dir) = tmp_stores(model1_ref());
-    conv.ensure_root_thread("t1").await.expect("ensure root");
+    conv.ensure_root_thread(&"t1".into())
+        .await
+        .expect("ensure root");
     let observer = DaemonObserver {
         subscribers: Default::default(),
         conversation_store: conv.clone(),
     };
 
     observer.on_event(
-        "t1",
+        &"t1".into(),
         &AgentEvent::CompletionFinished {
             usage: Some(infinity_provider_protocol::Usage {
                 input_tokens: 40,
@@ -428,15 +445,18 @@ async fn observer_persists_usage_and_resets_on_compaction() {
             }),
         },
     );
-    assert_eq!(conv.get_total_tokens_used("t1"), 42);
+    assert_eq!(conv.get_total_tokens_used(&"t1".into()), 42);
 
     // A usage-less response must not reset the stored total.
-    observer.on_event("t1", &AgentEvent::CompletionFinished { usage: None });
-    assert_eq!(conv.get_total_tokens_used("t1"), 42);
+    observer.on_event(
+        &"t1".into(),
+        &AgentEvent::CompletionFinished { usage: None },
+    );
+    assert_eq!(conv.get_total_tokens_used(&"t1".into()), 42);
 
     // Compaction resets the stale pre-compaction total.
-    observer.on_event("t1", &AgentEvent::CompactionApplied);
-    assert_eq!(conv.get_total_tokens_used("t1"), 0);
+    observer.on_event(&"t1".into(), &AgentEvent::CompactionApplied);
+    assert_eq!(conv.get_total_tokens_used(&"t1".into()), 0);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -447,16 +467,18 @@ async fn answered_user_choice_emits_complete_and_disappears_from_replay() {
             let (conv, state, _dir) = tmp_stores(model1_ref());
             let (model, mut ctrl) = mock_model();
             let catalog = two_model_catalog(model.clone(), model).await;
-            conv.ensure_root_thread("t1").await.expect("ensure root");
+            conv.ensure_root_thread(&"t1".into())
+                .await
+                .expect("ensure root");
             let (running, mut display_rx, _) = start_daemon_system(
-                "t1",
+                &"t1".into(),
                 conv,
                 state.clone(),
                 catalog,
                 vec![Box::new(AsyncStubTool)],
             );
 
-            running.send_user_text("t1", "use the tool").await;
+            running.send_user_text(&"t1".into(), "use the tool").await;
             let _request = ctrl.next_request().await;
             ctrl.send_tool_call("tc-choice", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -474,7 +496,7 @@ async fn answered_user_choice_emits_complete_and_disappears_from_replay() {
                             default: 0,
                             response_url: "http://example.test/choice".to_owned(),
                         }),
-                        group_id: "t1".to_owned(),
+                        group_id: "t1".into(),
                         metadata: None,
                         synthetic: None,
                         display_as: None,
@@ -490,7 +512,7 @@ async fn answered_user_choice_emits_complete_and_disappears_from_replay() {
 
             running
                 .send(
-                    tool_result_input("t1", "tc-choice", "selected A"),
+                    tool_result_input(&"t1".into(), "tc-choice", "selected A"),
                     "choice-result",
                 )
                 .await;
@@ -514,7 +536,7 @@ async fn answered_user_choice_emits_complete_and_disappears_from_replay() {
             }
             assert!(
                 state
-                    .get_pending_user_choices("t1")
+                    .get_pending_user_choices(&"t1".into())
                     .await
                     .expect("load choices")
                     .is_empty()
@@ -523,7 +545,7 @@ async fn answered_user_choice_emits_complete_and_disappears_from_replay() {
             let (replay_tx, mut replay_rx) = mpsc::unbounded_channel();
             running
                 .subscribe(
-                    "t1",
+                    &"t1".into(),
                     SubscribeRequest {
                         tx: replay_tx,
                         wants_replay: true,
@@ -607,7 +629,7 @@ async fn child_pending_choice_updates_root_session_status() {
                 manager
                     .list_sessions(None)
                     .await
-                    .get(&session_id)
+                    .get(session_id.as_str())
                     .expect("created session is listed")
                     .status,
                 SessionStatus::WaitingForChoice
@@ -622,7 +644,7 @@ async fn child_pending_choice_updates_root_session_status() {
                 manager
                     .list_sessions(None)
                     .await
-                    .get(&session_id)
+                    .get(session_id.as_str())
                     .expect("created session is still listed")
                     .status,
                 SessionStatus::Running
@@ -639,7 +661,7 @@ async fn child_pending_choice_updates_root_session_status() {
                 manager
                     .list_sessions(None)
                     .await
-                    .get(&session_id)
+                    .get(session_id.as_str())
                     .expect("cleaned-up session is listed")
                     .status,
                 SessionStatus::Stopped
@@ -662,8 +684,10 @@ async fn shut_down_session_events_do_not_wake_threads() {
             let (model2, _ctrl2) = mock_model();
             let catalog = two_model_catalog(model, model2).await;
             let (conv, _state, dir) = tmp_stores(model1_ref());
-            conv.ensure_root_thread("live").await.expect("ensure root");
-            conv.ensure_root_thread("stopped")
+            conv.ensure_root_thread(&"live".into())
+                .await
+                .expect("ensure root");
+            conv.ensure_root_thread(&"stopped".into())
                 .await
                 .expect("ensure root");
 
@@ -677,28 +701,28 @@ async fn shut_down_session_events_do_not_wake_threads() {
             ));
             {
                 let mut store = session_store.lock().await;
-                store.create("live", dir.path().to_path_buf());
-                store.create("stopped", dir.path().to_path_buf());
-                store.mark_shut_down("stopped");
+                store.create(&"live".into(), dir.path().to_path_buf());
+                store.create(&"stopped".into(), dir.path().to_path_buf());
+                store.mark_shut_down(&"stopped".into());
             }
             let state =
                 PersistentStateStore::new(dir.path().join("state"), conv.clone(), session_store);
 
             let (mut running, mut display_rx, _smap) =
-                start_daemon_system("live", conv.clone(), state, catalog, vec![]);
+                start_daemon_system(&"live".into(), conv.clone(), state, catalog, vec![]);
 
             // The stopped session's event is dropped: no driver wakes, so no
             // thread exit is ever reported for it.
             running
                 .send(
-                    tool_result_input("stopped", "tc-stale", "late result"),
+                    tool_result_input(&"stopped".into(), "tc-stale", "late result"),
                     "cb-stale",
                 )
                 .await;
 
             // The live session processes user text normally afterwards,
             // proving the router did not stall on the dropped event.
-            running.send_user_text("live", "hello").await;
+            running.send_user_text(&"live".into(), "hello").await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("hi");
             ctrl.finish();
@@ -716,7 +740,8 @@ async fn shut_down_session_events_do_not_wake_threads() {
                 .expect("timed out waiting for the live thread to idle")
                 .expect("thread lifecycle channel closed");
                 assert_eq!(
-                    event.thread_id, "live",
+                    event.thread_id.as_str(),
+                    "live",
                     "only the live session's driver may run"
                 );
                 if event.state == ThreadLifecycleState::Idle {

--- a/crates/infinity-daemon/src/session/tests.rs
+++ b/crates/infinity-daemon/src/session/tests.rs
@@ -88,7 +88,7 @@ fn tmp_stores(
 /// [`DaemonObserver`] per thread. Returns the running handle and a subscriber
 /// channel receiving the root thread's `DaemonMessage`s.
 fn start_daemon_system(
-    root: &ThreadId,
+    root: &ThreadId<str>,
     conv: PersistentConversationStore,
     state: impl StateStore + 'static,
     catalog: Arc<ModelCatalog>,
@@ -112,7 +112,7 @@ fn start_daemon_system(
     let (client_tx, client_rx) = mpsc::unbounded_channel();
     let subscriber_map: SubscriberMap = Default::default();
     subscriber_map.lock().expect("bug: mutex poisoned").insert(
-        root.clone(),
+        root.to_owned(),
         Arc::new(std::sync::Mutex::new(vec![Subscriber {
             tx: client_tx,
             keeps_session_alive: true,
@@ -121,11 +121,11 @@ fn start_daemon_system(
 
     let make_observer = {
         let subscriber_map = subscriber_map.clone();
-        move |thread_id: &ThreadId| {
+        move |thread_id: &ThreadId<str>| {
             let parent_subs = {
                 let parent_id = conv.get_thread_parent_id(thread_id);
                 let smap = subscriber_map.lock().expect("bug: mutex poisoned");
-                let source = parent_id.as_ref().unwrap_or(thread_id);
+                let source = parent_id.as_deref().unwrap_or(thread_id);
                 smap.get(source)
                     .map(|arc| arc.lock().expect("bug: mutex poisoned").clone())
                     .unwrap_or_default()
@@ -160,7 +160,7 @@ async fn collect_until_done(rx: &mut mpsc::UnboundedReceiver<DaemonMessage>) -> 
     texts
 }
 
-fn tool_result_input(group_id: &ThreadId, id: &str, text: &str) -> InputMessage {
+fn tool_result_input(group_id: &ThreadId<str>, id: &str, text: &str) -> InputMessage {
     InputMessage {
         content: InputMessageContent::User(UserContent::ToolResult(
             infinity_provider_protocol::message::ToolResult {
@@ -173,7 +173,7 @@ fn tool_result_input(group_id: &ThreadId, id: &str, text: &str) -> InputMessage 
                 ],
             },
         )),
-        group_id: group_id.clone(),
+        group_id: group_id.to_owned(),
         metadata: None,
         synthetic: None,
         display_as: None,
@@ -218,12 +218,12 @@ async fn model_switch_applies_to_next_completion() {
             let (model1, mut ctrl1) = mock_model();
             let (model2, mut ctrl2) = mock_model();
             let catalog = two_model_catalog(model1, model2).await;
-            conv.ensure_root_thread(&"t1".into())
+            conv.ensure_root_thread(ThreadId::from_ref("t1"))
                 .await
                 .expect("ensure root");
 
             let (running, mut display_rx, _smap) = start_daemon_system(
-                &"t1".into(),
+                ThreadId::from_ref("t1"),
                 conv.clone(),
                 state,
                 catalog,
@@ -232,7 +232,9 @@ async fn model_switch_applies_to_next_completion() {
 
             // First round runs on model1 and leaves an async tool call
             // pending (so the driver stays alive).
-            running.send_user_text(&"t1".into(), "use the tool").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "use the tool")
+                .await;
             let _req = ctrl1.next_request().await;
             ctrl1.send_tool_call("tc-1", "async_tool", serde_json::json!({}));
             ctrl1.finish();
@@ -240,12 +242,12 @@ async fn model_switch_applies_to_next_completion() {
 
             // Switch while the driver waits for the tool result. (The session
             // manager persists the selection; each round resolves it fresh.)
-            conv.set_thread_model(&"t1".into(), model2_ref());
+            conv.set_thread_model(ThreadId::from_ref("t1"), model2_ref());
 
             // The tool result triggers the next round — on model2.
             running
                 .send(
-                    tool_result_input(&"t1".into(), "tc-1", "tool done"),
+                    tool_result_input(ThreadId::from_ref("t1"), "tc-1", "tool done"),
                     "res-1",
                 )
                 .await;
@@ -273,12 +275,12 @@ async fn model_switch_during_completion_applies_to_next_round() {
             let (model1, mut ctrl1) = mock_model();
             let (model2, mut ctrl2) = mock_model();
             let catalog = two_model_catalog(model1, model2).await;
-            conv.ensure_root_thread(&"t1".into())
+            conv.ensure_root_thread(ThreadId::from_ref("t1"))
                 .await
                 .expect("ensure root");
 
             let (running, mut display_rx, _smap) = start_daemon_system(
-                &"t1".into(),
+                ThreadId::from_ref("t1"),
                 conv.clone(),
                 state,
                 catalog,
@@ -286,7 +288,9 @@ async fn model_switch_during_completion_applies_to_next_round() {
             );
 
             // Start a completion on model1 and leave it in flight.
-            running.send_user_text(&"t1".into(), "start").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "start")
+                .await;
             let _req = ctrl1.next_request().await;
             ctrl1.send_text("streaming on model1...");
             loop {
@@ -301,7 +305,7 @@ async fn model_switch_during_completion_applies_to_next_round() {
 
             // Switch mid-completion: the in-flight round keeps streaming on
             // model1 (it resolved its model at round start).
-            conv.set_thread_model(&"t1".into(), model2_ref());
+            conv.set_thread_model(ThreadId::from_ref("t1"), model2_ref());
 
             // The in-flight completion finishes undisturbed on model1
             // (ending with an async tool call so the driver stays alive).
@@ -312,7 +316,7 @@ async fn model_switch_during_completion_applies_to_next_round() {
             // The next round (tool result) goes to model2.
             running
                 .send(
-                    tool_result_input(&"t1".into(), "tc-1", "tool done"),
+                    tool_result_input(ThreadId::from_ref("t1"), "tc-1", "tool done"),
                     "res-1",
                 )
                 .await;
@@ -340,19 +344,24 @@ async fn spawned_thread_inherits_parent_model() {
             let (model2, mut ctrl2) = mock_model();
             let catalog = two_model_catalog(model1, model2).await;
 
-            conv.ensure_root_thread(&"root".into())
+            conv.ensure_root_thread(ThreadId::from_ref("root"))
                 .await
                 .expect("ensure root");
             // Set root thread to use the non-default model (provider2/model2).
-            conv.set_thread_model(&"root".into(), model2_ref());
+            conv.set_thread_model(ThreadId::from_ref("root"), model2_ref());
 
             // The built-in spawn_thread tool comes from the system builder.
-            let (running, mut display_rx, _smap) =
-                start_daemon_system(&"root".into(), conv.clone(), state, catalog, vec![]);
+            let (running, mut display_rx, _smap) = start_daemon_system(
+                ThreadId::from_ref("root"),
+                conv.clone(),
+                state,
+                catalog,
+                vec![],
+            );
 
             // Send user input to root thread (which uses model2).
             running
-                .send_user_text(&"root".into(), "spawn a child")
+                .send_user_text(ThreadId::from_ref("root"), "spawn a child")
                 .await;
 
             // Root thread uses model2, so ctrl2 gets the request.
@@ -426,7 +435,7 @@ async fn observer_persists_usage_and_resets_on_compaction() {
     use infinity_agent_core::system::{AgentEvent, ThreadObserver};
 
     let (conv, _state, _dir) = tmp_stores(model1_ref());
-    conv.ensure_root_thread(&"t1".into())
+    conv.ensure_root_thread(ThreadId::from_ref("t1"))
         .await
         .expect("ensure root");
     let observer = DaemonObserver {
@@ -435,7 +444,7 @@ async fn observer_persists_usage_and_resets_on_compaction() {
     };
 
     observer.on_event(
-        &"t1".into(),
+        ThreadId::from_ref("t1"),
         &AgentEvent::CompletionFinished {
             usage: Some(infinity_provider_protocol::Usage {
                 input_tokens: 40,
@@ -445,18 +454,18 @@ async fn observer_persists_usage_and_resets_on_compaction() {
             }),
         },
     );
-    assert_eq!(conv.get_total_tokens_used(&"t1".into()), 42);
+    assert_eq!(conv.get_total_tokens_used(ThreadId::from_ref("t1")), 42);
 
     // A usage-less response must not reset the stored total.
     observer.on_event(
-        &"t1".into(),
+        ThreadId::from_ref("t1"),
         &AgentEvent::CompletionFinished { usage: None },
     );
-    assert_eq!(conv.get_total_tokens_used(&"t1".into()), 42);
+    assert_eq!(conv.get_total_tokens_used(ThreadId::from_ref("t1")), 42);
 
     // Compaction resets the stale pre-compaction total.
-    observer.on_event(&"t1".into(), &AgentEvent::CompactionApplied);
-    assert_eq!(conv.get_total_tokens_used(&"t1".into()), 0);
+    observer.on_event(ThreadId::from_ref("t1"), &AgentEvent::CompactionApplied);
+    assert_eq!(conv.get_total_tokens_used(ThreadId::from_ref("t1")), 0);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -467,18 +476,20 @@ async fn answered_user_choice_emits_complete_and_disappears_from_replay() {
             let (conv, state, _dir) = tmp_stores(model1_ref());
             let (model, mut ctrl) = mock_model();
             let catalog = two_model_catalog(model.clone(), model).await;
-            conv.ensure_root_thread(&"t1".into())
+            conv.ensure_root_thread(ThreadId::from_ref("t1"))
                 .await
                 .expect("ensure root");
             let (running, mut display_rx, _) = start_daemon_system(
-                &"t1".into(),
+                ThreadId::from_ref("t1"),
                 conv,
                 state.clone(),
                 catalog,
                 vec![Box::new(AsyncStubTool)],
             );
 
-            running.send_user_text(&"t1".into(), "use the tool").await;
+            running
+                .send_user_text(ThreadId::from_ref("t1"), "use the tool")
+                .await;
             let _request = ctrl.next_request().await;
             ctrl.send_tool_call("tc-choice", "async_tool", serde_json::json!({}));
             ctrl.finish();
@@ -512,7 +523,7 @@ async fn answered_user_choice_emits_complete_and_disappears_from_replay() {
 
             running
                 .send(
-                    tool_result_input(&"t1".into(), "tc-choice", "selected A"),
+                    tool_result_input(ThreadId::from_ref("t1"), "tc-choice", "selected A"),
                     "choice-result",
                 )
                 .await;
@@ -536,7 +547,7 @@ async fn answered_user_choice_emits_complete_and_disappears_from_replay() {
             }
             assert!(
                 state
-                    .get_pending_user_choices(&"t1".into())
+                    .get_pending_user_choices(ThreadId::from_ref("t1"))
                     .await
                     .expect("load choices")
                     .is_empty()
@@ -545,7 +556,7 @@ async fn answered_user_choice_emits_complete_and_disappears_from_replay() {
             let (replay_tx, mut replay_rx) = mpsc::unbounded_channel();
             running
                 .subscribe(
-                    &"t1".into(),
+                    ThreadId::from_ref("t1"),
                     SubscribeRequest {
                         tx: replay_tx,
                         wants_replay: true,
@@ -684,10 +695,10 @@ async fn shut_down_session_events_do_not_wake_threads() {
             let (model2, _ctrl2) = mock_model();
             let catalog = two_model_catalog(model, model2).await;
             let (conv, _state, dir) = tmp_stores(model1_ref());
-            conv.ensure_root_thread(&"live".into())
+            conv.ensure_root_thread(ThreadId::from_ref("live"))
                 .await
                 .expect("ensure root");
-            conv.ensure_root_thread(&"stopped".into())
+            conv.ensure_root_thread(ThreadId::from_ref("stopped"))
                 .await
                 .expect("ensure root");
 
@@ -701,28 +712,35 @@ async fn shut_down_session_events_do_not_wake_threads() {
             ));
             {
                 let mut store = session_store.lock().await;
-                store.create(&"live".into(), dir.path().to_path_buf());
-                store.create(&"stopped".into(), dir.path().to_path_buf());
-                store.mark_shut_down(&"stopped".into());
+                store.create(ThreadId::from_ref("live"), dir.path().to_path_buf());
+                store.create(ThreadId::from_ref("stopped"), dir.path().to_path_buf());
+                store.mark_shut_down(ThreadId::from_ref("stopped"));
             }
             let state =
                 PersistentStateStore::new(dir.path().join("state"), conv.clone(), session_store);
 
-            let (mut running, mut display_rx, _smap) =
-                start_daemon_system(&"live".into(), conv.clone(), state, catalog, vec![]);
+            let (mut running, mut display_rx, _smap) = start_daemon_system(
+                ThreadId::from_ref("live"),
+                conv.clone(),
+                state,
+                catalog,
+                vec![],
+            );
 
             // The stopped session's event is dropped: no driver wakes, so no
             // thread exit is ever reported for it.
             running
                 .send(
-                    tool_result_input(&"stopped".into(), "tc-stale", "late result"),
+                    tool_result_input(ThreadId::from_ref("stopped"), "tc-stale", "late result"),
                     "cb-stale",
                 )
                 .await;
 
             // The live session processes user text normally afterwards,
             // proving the router did not stall on the dropped event.
-            running.send_user_text(&"live".into(), "hello").await;
+            running
+                .send_user_text(ThreadId::from_ref("live"), "hello")
+                .await;
             let _req = ctrl.next_request().await;
             ctrl.send_text("hi");
             ctrl.finish();

--- a/crates/infinity-daemon/src/session_store.rs
+++ b/crates/infinity-daemon/src/session_store.rs
@@ -1,3 +1,4 @@
+use infinity_agent_core::ThreadId;
 use std::{collections::HashMap, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -35,15 +36,15 @@ impl SessionEntry {
 
 #[derive(Serialize, Deserialize)]
 pub struct SessionStore {
-    pub sessions: HashMap<String, SessionEntry>,
+    pub sessions: HashMap<ThreadId, SessionEntry>,
     #[serde(skip)]
     path: String,
     #[serde(skip)]
-    change_tx: Option<mpsc::UnboundedSender<String>>,
+    change_tx: Option<mpsc::UnboundedSender<ThreadId>>,
 }
 
 impl SessionStore {
-    pub fn load(path: &str, change_tx: mpsc::UnboundedSender<String>) -> Self {
+    pub fn load(path: &str, change_tx: mpsc::UnboundedSender<ThreadId>) -> Self {
         let sessions = std::fs::read_to_string(path)
             .ok()
             .and_then(|s| {
@@ -54,7 +55,7 @@ impl SessionStore {
                 // Fall back to legacy Vec format
                 #[derive(Deserialize)]
                 struct LegacyEntry {
-                    thread_id: String,
+                    thread_id: ThreadId,
                 }
                 #[derive(Deserialize)]
                 struct LegacyStore {
@@ -96,15 +97,15 @@ impl SessionStore {
         Ok(())
     }
 
-    pub fn notify(&self, session_id: &str) {
+    pub fn notify(&self, session_id: &ThreadId) {
         if let Some(ref tx) = self.change_tx {
-            let _ = tx.send(session_id.to_owned());
+            let _ = tx.send(session_id.clone());
         }
     }
 
-    pub fn create(&mut self, session_id: &str, cwd: PathBuf) {
+    pub fn create(&mut self, session_id: &ThreadId, cwd: PathBuf) {
         self.sessions.insert(
-            session_id.to_owned(),
+            session_id.clone(),
             SessionEntry {
                 cwd,
                 shut_down: false,
@@ -115,7 +116,7 @@ impl SessionStore {
         self.notify(session_id);
     }
 
-    pub fn get_cwd(&self, session_id: &str) -> &PathBuf {
+    pub fn get_cwd(&self, session_id: &ThreadId) -> &PathBuf {
         &self
             .sessions
             .get(session_id)
@@ -123,14 +124,14 @@ impl SessionStore {
             .cwd
     }
 
-    pub fn mark_shut_down(&mut self, session_id: &str) {
+    pub fn mark_shut_down(&mut self, session_id: &ThreadId) {
         if let Some(entry) = self.sessions.get_mut(session_id) {
             entry.shut_down = true;
             self.notify(session_id);
         }
     }
 
-    pub fn clear_shut_down(&mut self, session_id: &str) -> bool {
+    pub fn clear_shut_down(&mut self, session_id: &ThreadId) -> bool {
         tracing::trace!("Clearing shut down status for {}", session_id);
         if let Some(entry) = self.sessions.get_mut(session_id)
             && entry.shut_down
@@ -142,7 +143,7 @@ impl SessionStore {
         false
     }
 
-    pub fn mark_idle(&mut self, session_id: &str) {
+    pub fn mark_idle(&mut self, session_id: &ThreadId) {
         if let Some(entry) = self.sessions.get_mut(session_id)
             && !entry.idle
         {
@@ -151,7 +152,7 @@ impl SessionStore {
         }
     }
 
-    pub fn clear_idle(&mut self, session_id: &str) -> bool {
+    pub fn clear_idle(&mut self, session_id: &ThreadId) -> bool {
         if let Some(entry) = self.sessions.get_mut(session_id)
             && entry.idle
         {
@@ -162,21 +163,21 @@ impl SessionStore {
         false
     }
 
-    pub fn is_idle(&self, session_id: &str) -> bool {
+    pub fn is_idle(&self, session_id: &ThreadId) -> bool {
         self.sessions
             .get(session_id)
             .map(|e| e.idle)
             .unwrap_or(false)
     }
 
-    pub fn is_shut_down(&self, session_id: &str) -> bool {
+    pub fn is_shut_down(&self, session_id: &ThreadId) -> bool {
         self.sessions
             .get(session_id)
             .map(|e| e.shut_down)
             .unwrap_or(false)
     }
 
-    pub fn mark_archived(&mut self, session_id: &str) {
+    pub fn mark_archived(&mut self, session_id: &ThreadId) {
         if let Some(entry) = self.sessions.get_mut(session_id) {
             entry.archived = true;
             self.notify(session_id);

--- a/crates/infinity-daemon/src/session_store.rs
+++ b/crates/infinity-daemon/src/session_store.rs
@@ -97,15 +97,15 @@ impl SessionStore {
         Ok(())
     }
 
-    pub fn notify(&self, session_id: &ThreadId) {
+    pub fn notify(&self, session_id: &ThreadId<str>) {
         if let Some(ref tx) = self.change_tx {
-            let _ = tx.send(session_id.clone());
+            let _ = tx.send(session_id.to_owned());
         }
     }
 
-    pub fn create(&mut self, session_id: &ThreadId, cwd: PathBuf) {
+    pub fn create(&mut self, session_id: &ThreadId<str>, cwd: PathBuf) {
         self.sessions.insert(
-            session_id.clone(),
+            session_id.to_owned(),
             SessionEntry {
                 cwd,
                 shut_down: false,
@@ -116,7 +116,7 @@ impl SessionStore {
         self.notify(session_id);
     }
 
-    pub fn get_cwd(&self, session_id: &ThreadId) -> &PathBuf {
+    pub fn get_cwd(&self, session_id: &ThreadId<str>) -> &PathBuf {
         &self
             .sessions
             .get(session_id)
@@ -124,14 +124,14 @@ impl SessionStore {
             .cwd
     }
 
-    pub fn mark_shut_down(&mut self, session_id: &ThreadId) {
+    pub fn mark_shut_down(&mut self, session_id: &ThreadId<str>) {
         if let Some(entry) = self.sessions.get_mut(session_id) {
             entry.shut_down = true;
             self.notify(session_id);
         }
     }
 
-    pub fn clear_shut_down(&mut self, session_id: &ThreadId) -> bool {
+    pub fn clear_shut_down(&mut self, session_id: &ThreadId<str>) -> bool {
         tracing::trace!("Clearing shut down status for {}", session_id);
         if let Some(entry) = self.sessions.get_mut(session_id)
             && entry.shut_down
@@ -143,7 +143,7 @@ impl SessionStore {
         false
     }
 
-    pub fn mark_idle(&mut self, session_id: &ThreadId) {
+    pub fn mark_idle(&mut self, session_id: &ThreadId<str>) {
         if let Some(entry) = self.sessions.get_mut(session_id)
             && !entry.idle
         {
@@ -152,7 +152,7 @@ impl SessionStore {
         }
     }
 
-    pub fn clear_idle(&mut self, session_id: &ThreadId) -> bool {
+    pub fn clear_idle(&mut self, session_id: &ThreadId<str>) -> bool {
         if let Some(entry) = self.sessions.get_mut(session_id)
             && entry.idle
         {
@@ -163,21 +163,21 @@ impl SessionStore {
         false
     }
 
-    pub fn is_idle(&self, session_id: &ThreadId) -> bool {
+    pub fn is_idle(&self, session_id: &ThreadId<str>) -> bool {
         self.sessions
             .get(session_id)
             .map(|e| e.idle)
             .unwrap_or(false)
     }
 
-    pub fn is_shut_down(&self, session_id: &ThreadId) -> bool {
+    pub fn is_shut_down(&self, session_id: &ThreadId<str>) -> bool {
         self.sessions
             .get(session_id)
             .map(|e| e.shut_down)
             .unwrap_or(false)
     }
 
-    pub fn mark_archived(&mut self, session_id: &ThreadId) {
+    pub fn mark_archived(&mut self, session_id: &ThreadId<str>) {
         if let Some(entry) = self.sessions.get_mut(session_id) {
             entry.archived = true;
             self.notify(session_id);

--- a/crates/infinity-daemon/tests/keep_alive.rs
+++ b/crates/infinity-daemon/tests/keep_alive.rs
@@ -137,7 +137,10 @@ async fn create_session_and_chat(h: &mut TestHarness, keeps_session_alive: bool)
 
 /// Poll until the session's RAP servers have been stopped (the session-idle
 /// teardown path ran), or time out.
-async fn wait_for_server_teardown(manager: &SharedSessionManager, session_id: &ThreadId) -> bool {
+async fn wait_for_server_teardown(
+    manager: &SharedSessionManager,
+    session_id: &ThreadId<str>,
+) -> bool {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     loop {
         {

--- a/crates/infinity-daemon/tests/keep_alive.rs
+++ b/crates/infinity-daemon/tests/keep_alive.rs
@@ -6,6 +6,7 @@
 //! out and its agent task should exit even though the client is still
 //! connected. A normal (keep-alive) connection must keep the session warm.
 
+use infinity_agent_core::ThreadId;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -97,7 +98,7 @@ async fn wait_for_message(
 
 /// Run one full round: create a session with the given keep-alive flag, send
 /// input, complete a mock model response, and return the session id.
-async fn create_session_and_chat(h: &mut TestHarness, keeps_session_alive: bool) -> String {
+async fn create_session_and_chat(h: &mut TestHarness, keeps_session_alive: bool) -> ThreadId {
     h.client_tx
         .send(ClientMessage::CreateSession {
             cwd: h.cwd.path().to_path_buf(),
@@ -131,12 +132,12 @@ async fn create_session_and_chat(h: &mut TestHarness, keeps_session_alive: bool)
     })
     .await;
 
-    session_id
+    ThreadId::from(session_id)
 }
 
 /// Poll until the session's RAP servers have been stopped (the session-idle
 /// teardown path ran), or time out.
-async fn wait_for_server_teardown(manager: &SharedSessionManager, session_id: &str) -> bool {
+async fn wait_for_server_teardown(manager: &SharedSessionManager, session_id: &ThreadId) -> bool {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     loop {
         {
@@ -203,7 +204,7 @@ async fn user_input_restarts_stopped_session() {
 
             h.client_tx
                 .send(ClientMessage::UserInput {
-                    session_id: session_id.clone(),
+                    session_id: session_id.to_string(),
                     text: "resume".to_owned(),
                 })
                 .expect("send user input");
@@ -279,11 +280,12 @@ async fn active_subscription_keeps_rap_servers_warm() {
             let DaemonMessage::Connected { session_id, .. } = connected else {
                 unreachable!()
             };
+            let session_id = ThreadId::from(session_id);
 
             // Round 1 leaves a pending tool call for the subscription setup.
             h.client_tx
                 .send(ClientMessage::UserInput {
-                    session_id: session_id.clone(),
+                    session_id: session_id.to_string(),
                     text: "watch the build".to_owned(),
                 })
                 .expect("send UserInput");

--- a/crates/infinity-daemon/tests/mcp_proxy_callback.rs
+++ b/crates/infinity-daemon/tests/mcp_proxy_callback.rs
@@ -51,7 +51,7 @@ async fn list_tools_callback_deserializes() {
         id: "test-1".to_owned(),
         call_id: None,
         callback_url,
-        group_id: "g1".to_owned(),
+        group_id: "g1".into(),
         user_id: None,
         thread_ancestors: None,
     };

--- a/crates/infinity-daemon/tests/rap_callback_flow.rs
+++ b/crates/infinity-daemon/tests/rap_callback_flow.rs
@@ -254,7 +254,7 @@ async fn view_update_is_broadcast_without_waking_the_session() {
 
             let mgr = h.manager.lock().await;
             assert!(
-                mgr.is_session_idle(&session_id),
+                mgr.is_session_idle(&session_id.clone().into()),
                 "a view update must not wake any thread driver"
             );
         })

--- a/crates/infinity-daemon/tests/rap_callback_flow.rs
+++ b/crates/infinity-daemon/tests/rap_callback_flow.rs
@@ -254,7 +254,7 @@ async fn view_update_is_broadcast_without_waking_the_session() {
 
             let mgr = h.manager.lock().await;
             assert!(
-                mgr.is_session_idle(&session_id.clone().into()),
+                mgr.is_session_idle(rap_protocol::ThreadId::from_ref(&session_id)),
                 "a view update must not wake any thread driver"
             );
         })

--- a/crates/infinity-rap-bridge/src/callback.rs
+++ b/crates/infinity-rap-bridge/src/callback.rs
@@ -33,7 +33,7 @@ pub(crate) fn convert_callback(cb: RapCallback) -> Option<InputMessage> {
                 call_id: tr.call_id,
                 content: tool_result_content(tr.content, tr.text),
             })),
-            group_id: tr.group_id.into_inner(),
+            group_id: tr.group_id,
             metadata: None,
             synthetic: None,
             display_as: tr.display_as,
@@ -47,7 +47,7 @@ pub(crate) fn convert_callback(cb: RapCallback) -> Option<InputMessage> {
                     call_id: None,
                     content: vec![ToolResultContent::Text(Text { text: se.text })],
                 })),
-                group_id: se.group_id.into_inner(),
+                group_id: se.group_id,
                 metadata: None,
                 synthetic: Some(SyntheticKind::Tagged(
                     TaggedSyntheticKind::SubscriptionEvent {
@@ -67,7 +67,7 @@ pub(crate) fn convert_callback(cb: RapCallback) -> Option<InputMessage> {
                 call_id: oa.call_id,
                 auth_url: oa.auth_url,
             }),
-            group_id: oa.group_id.into_inner(),
+            group_id: oa.group_id,
             metadata: None,
             synthetic: None,
             display_as: None,
@@ -83,7 +83,7 @@ pub(crate) fn convert_callback(cb: RapCallback) -> Option<InputMessage> {
                 default: uc.default,
                 response_url: uc.response_url,
             }),
-            group_id: uc.group_id.into_inner(),
+            group_id: uc.group_id,
             metadata: None,
             synthetic: None,
             display_as: None,
@@ -146,7 +146,7 @@ mod tests {
     fn text_tool_result_converts() {
         let msg = convert_callback(tool_result_cb(None, Some("plain output".to_owned())))
             .expect("tool results convert");
-        assert_eq!(msg.group_id, "t1");
+        assert_eq!(msg.group_id.as_str(), "t1");
         assert!(!msg.subscription);
         assert!(msg.synthetic.is_none());
         match msg.content {

--- a/crates/infinity-rap-bridge/src/callback.rs
+++ b/crates/infinity-rap-bridge/src/callback.rs
@@ -33,7 +33,7 @@ pub(crate) fn convert_callback(cb: RapCallback) -> Option<InputMessage> {
                 call_id: tr.call_id,
                 content: tool_result_content(tr.content, tr.text),
             })),
-            group_id: tr.group_id,
+            group_id: tr.group_id.into_inner(),
             metadata: None,
             synthetic: None,
             display_as: tr.display_as,
@@ -47,7 +47,7 @@ pub(crate) fn convert_callback(cb: RapCallback) -> Option<InputMessage> {
                     call_id: None,
                     content: vec![ToolResultContent::Text(Text { text: se.text })],
                 })),
-                group_id: se.group_id,
+                group_id: se.group_id.into_inner(),
                 metadata: None,
                 synthetic: Some(SyntheticKind::Tagged(
                     TaggedSyntheticKind::SubscriptionEvent {
@@ -67,7 +67,7 @@ pub(crate) fn convert_callback(cb: RapCallback) -> Option<InputMessage> {
                 call_id: oa.call_id,
                 auth_url: oa.auth_url,
             }),
-            group_id: oa.group_id,
+            group_id: oa.group_id.into_inner(),
             metadata: None,
             synthetic: None,
             display_as: None,
@@ -83,7 +83,7 @@ pub(crate) fn convert_callback(cb: RapCallback) -> Option<InputMessage> {
                 default: uc.default,
                 response_url: uc.response_url,
             }),
-            group_id: uc.group_id,
+            group_id: uc.group_id.into_inner(),
             metadata: None,
             synthetic: None,
             display_as: None,
@@ -132,7 +132,7 @@ mod tests {
         text: Option<String>,
     ) -> RapCallback {
         RapCallback::ToolResult(RapToolResult {
-            group_id: "t1".to_owned(),
+            group_id: "t1".into(),
             id: "call-1".to_owned(),
             call_id: Some("prov-1".to_owned()),
             text,
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn display_as_and_subscription_flag_pass_through() {
         let cb = RapCallback::ToolResult(RapToolResult {
-            group_id: "t1".to_owned(),
+            group_id: "t1".into(),
             id: "call-1".to_owned(),
             call_id: None,
             text: Some("done".to_owned()),
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn subscription_event_converts_with_flags() {
         let cb = RapCallback::SubscriptionEvent(RapSubscriptionEvent {
-            group_id: "t1".to_owned(),
+            group_id: "t1".into(),
             tool_call_id: "sub-1".to_owned(),
             text: "tick".to_owned(),
             associative: true,
@@ -207,7 +207,7 @@ mod tests {
     #[test]
     fn oauth_converts() {
         let cb = RapCallback::OAuth(RapOAuth {
-            group_id: "t1".to_owned(),
+            group_id: "t1".into(),
             id: "call-1".to_owned(),
             call_id: None,
             auth_url: "https://auth".to_owned(),
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn user_choice_converts() {
         let cb = RapCallback::UserChoice(RapUserChoice {
-            group_id: "t1".to_owned(),
+            group_id: "t1".into(),
             id: "choice-1".to_owned(),
             call_id: None,
             prompt: "pick one".to_owned(),
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn view_update_is_not_agent_input() {
         let cb = RapCallback::ViewUpdate(RapViewUpdate {
-            group_id: "t1".to_owned(),
+            group_id: "t1".into(),
             view_type: "diff".to_owned(),
             content: serde_json::json!({}),
         });

--- a/crates/infinity-rap-bridge/src/lib.rs
+++ b/crates/infinity-rap-bridge/src/lib.rs
@@ -289,7 +289,7 @@ mod tests {
     /// An [`InputSender`] that records deliveries for assertions.
     #[derive(Clone, Default)]
     struct RecordingSender {
-        sent: Arc<Mutex<Vec<(String, String)>>>,
+        sent: Arc<Mutex<Vec<(rap_protocol::ThreadId, String)>>>,
     }
 
     #[derive(Debug)]
@@ -351,7 +351,7 @@ mod tests {
                 .lock()
                 .expect("bug: test mutex poisoned")
                 .as_slice(),
-            &[("t1".to_owned(), "rap-tool-result-call-1".to_owned())]
+            &[("t1".into(), "rap-tool-result-call-1".to_owned())]
         );
 
         let view = serde_json::to_string(&RapCallback::ViewUpdate(RapViewUpdate {

--- a/crates/rap-client/src/notifier.rs
+++ b/crates/rap-client/src/notifier.rs
@@ -20,7 +20,7 @@ impl<H: HttpClient> RapNotifier<H> {
     }
 
     /// Best-effort notification that a thread has been closed.
-    pub async fn notify_thread_closed(&self, thread_id: &str) {
+    pub async fn notify_thread_closed(&self, thread_id: &rap_protocol::ThreadId) {
         let payload = serde_json::json!({ "thread_id": thread_id }).to_string();
         for url in &self.server_urls {
             let endpoint = format!("{}/close_thread", url.trim_end_matches('/'));
@@ -36,7 +36,11 @@ impl<H: HttpClient> RapNotifier<H> {
     }
 
     /// Best-effort notification that a tool call has been cancelled.
-    pub async fn notify_tool_cancelled(&self, thread_id: &str, tool_call_id: &str) {
+    pub async fn notify_tool_cancelled(
+        &self,
+        thread_id: &rap_protocol::ThreadId,
+        tool_call_id: &str,
+    ) {
         let payload = serde_json::json!({
             "thread_id": thread_id,
             "tool_call_id": tool_call_id,

--- a/crates/rap-github-event-poller/src/lib.rs
+++ b/crates/rap-github-event-poller/src/lib.rs
@@ -27,7 +27,7 @@ pub struct Subscription {
     pub tool_call_id: String,
     pub call_id: Option<String>,
     pub callback_url: String,
-    pub group_id: String,
+    pub group_id: rap_protocol::ThreadId,
     pub filters: Filters,
 }
 

--- a/crates/rap-protocol/Cargo.toml
+++ b/crates/rap-protocol/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = { workspace = true }
 reqwest = { workspace = true }
 tracing = { workspace = true }
 futures-util = { workspace = true }
+strkind = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rap-protocol/src/lib.rs
+++ b/crates/rap-protocol/src/lib.rs
@@ -3,6 +3,19 @@ use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 
+// ── Identifier kinds ──
+
+strkind::strkind! {
+    /// Identifies a conversation thread.
+    ///
+    /// This is the identifier RAP calls `group_id` on the wire: every
+    /// invocation and callback carries the thread it belongs to. In the
+    /// embedded daemon runtime thread IDs are UUIDs; in the Lambda runtime a
+    /// root thread ID is the caller-chosen conversation key (which doubles as
+    /// the SQS FIFO `MessageGroupId`). Treat the contents as opaque.
+    pub ThreadId;
+}
+
 // ── RAP protocol types ──
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -13,12 +26,12 @@ pub struct RapInvocation {
     pub id: String,
     pub call_id: Option<String>,
     pub callback_url: String,
-    pub group_id: String,
+    pub group_id: ThreadId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<String>,
     /// Ordered ancestor thread group IDs, from root to the parent of the current thread.
     #[serde(default)]
-    pub thread_ancestors: Option<Vec<String>>,
+    pub thread_ancestors: Option<Vec<ThreadId>>,
 }
 
 /// A segment of display content for human-facing UIs.
@@ -92,7 +105,7 @@ pub enum RapToolResultContent {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RapToolResult {
-    pub group_id: String,
+    pub group_id: ThreadId,
     pub id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub call_id: Option<String>,
@@ -115,7 +128,7 @@ pub struct RapToolResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RapUserChoice {
-    pub group_id: String,
+    pub group_id: ThreadId,
     pub id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub call_id: Option<String>,
@@ -128,7 +141,7 @@ pub struct RapUserChoice {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RapSubscriptionEvent {
-    pub group_id: String,
+    pub group_id: ThreadId,
     pub tool_call_id: String,
     pub text: String,
     #[serde(default)]
@@ -141,7 +154,7 @@ pub struct RapSubscriptionEvent {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RapViewUpdate {
-    pub group_id: String,
+    pub group_id: ThreadId,
     /// The type of view being updated (e.g. "diff").
     pub view_type: String,
     /// View-specific payload. The runtime passes this through to clients without interpretation.
@@ -150,7 +163,7 @@ pub struct RapViewUpdate {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RapOAuth {
-    pub group_id: String,
+    pub group_id: ThreadId,
     pub id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub call_id: Option<String>,
@@ -301,7 +314,7 @@ pub async fn send_user_choice<C: CallbackClient>(
 pub async fn send_subscription_event<C: CallbackClient>(
     client: &C,
     callback_url: &str,
-    group_id: String,
+    group_id: ThreadId,
     tool_call_id: String,
     text: &str,
     associative: bool,
@@ -324,7 +337,7 @@ pub async fn send_subscription_event<C: CallbackClient>(
 pub async fn send_view_update<C: CallbackClient>(
     client: &C,
     callback_url: &str,
-    group_id: String,
+    group_id: ThreadId,
     view_type: &str,
     content: serde_json::Value,
 ) {

--- a/crates/sandbox-core/src/error.rs
+++ b/crates/sandbox-core/src/error.rs
@@ -1,9 +1,10 @@
+use rap_protocol::ThreadId;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum SandboxError {
     #[error("repo not found for group_id: {0}")]
-    RepoNotFound(String),
+    RepoNotFound(ThreadId),
 
     #[error("jujutsu command failed: {0}")]
     JujutsuError(String),

--- a/crates/sandbox-core/src/lib.rs
+++ b/crates/sandbox-core/src/lib.rs
@@ -7,6 +7,11 @@ pub mod sandbox;
 pub mod server;
 pub mod types;
 
+/// The thread identifier used to key sandboxes and repo state (RAP's
+/// `group_id`). Re-exported so backend crates can name it without a direct
+/// `rap-protocol` dependency.
+pub use rap_protocol::ThreadId;
+
 pub const DEFAULT_SANDBOX_NAME: &str = "Infinity 🤖";
 pub const DEFAULT_SANDBOX_EMAIL: &str = "infinity@hydro.run";
 

--- a/crates/sandbox-core/src/metadata.rs
+++ b/crates/sandbox-core/src/metadata.rs
@@ -8,9 +8,9 @@ use crate::types::RepoState;
 /// In-memory for local, DynamoDB for remote.
 #[async_trait]
 pub trait MetadataStore: Send + Sync {
-    async fn get(&self, group_id: &ThreadId) -> Result<Option<RepoState>, SandboxError>;
+    async fn get(&self, group_id: &ThreadId<str>) -> Result<Option<RepoState>, SandboxError>;
     async fn put(&self, state: &RepoState) -> Result<(), SandboxError>;
-    async fn delete(&self, group_id: &ThreadId) -> Result<(), SandboxError>;
+    async fn delete(&self, group_id: &ThreadId<str>) -> Result<(), SandboxError>;
     async fn list_all(&self) -> Result<Vec<RepoState>, SandboxError> {
         Ok(Vec::new())
     }

--- a/crates/sandbox-core/src/metadata.rs
+++ b/crates/sandbox-core/src/metadata.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use rap_protocol::ThreadId;
 
 use crate::error::SandboxError;
 use crate::types::RepoState;
@@ -7,9 +8,9 @@ use crate::types::RepoState;
 /// In-memory for local, DynamoDB for remote.
 #[async_trait]
 pub trait MetadataStore: Send + Sync {
-    async fn get(&self, group_id: &str) -> Result<Option<RepoState>, SandboxError>;
+    async fn get(&self, group_id: &ThreadId) -> Result<Option<RepoState>, SandboxError>;
     async fn put(&self, state: &RepoState) -> Result<(), SandboxError>;
-    async fn delete(&self, group_id: &str) -> Result<(), SandboxError>;
+    async fn delete(&self, group_id: &ThreadId) -> Result<(), SandboxError>;
     async fn list_all(&self) -> Result<Vec<RepoState>, SandboxError> {
         Ok(Vec::new())
     }

--- a/crates/sandbox-core/src/sandbox.rs
+++ b/crates/sandbox-core/src/sandbox.rs
@@ -15,7 +15,7 @@ pub struct SpawnedCommand {
 /// they can set up the repository and build a [`RepoState`].
 pub struct CloneContext<'a> {
     /// The group_id (thread id) initializing the repo.
-    pub group_id: &'a ThreadId,
+    pub group_id: &'a ThreadId<str>,
     /// The path (or remote URI) as originally requested by the caller,
     /// before any backend resolution. Providers that use their own root
     /// markers should walk up from here (and return the root they find via
@@ -182,7 +182,7 @@ pub trait SandboxBackend: Send + Sync {
     async fn push_sandbox(
         &self,
         sandbox_dir: &Path,
-        group_id: &ThreadId,
+        group_id: &ThreadId<str>,
         description: Option<&str>,
     ) -> Result<(), SandboxError>;
 
@@ -195,7 +195,10 @@ pub trait SandboxBackend: Send + Sync {
     /// On the local backend this runs `jj workspace forget` and deletes the
     /// cached directory. On the remote backend this is a no-op since sandboxes
     /// are ephemeral temp dirs cleaned up after each invocation.
-    async fn cleanup_sandbox_permanently(&self, _group_id: &ThreadId) -> Result<(), SandboxError> {
+    async fn cleanup_sandbox_permanently(
+        &self,
+        _group_id: &ThreadId<str>,
+    ) -> Result<(), SandboxError> {
         Ok(())
     }
 

--- a/crates/sandbox-core/src/sandbox.rs
+++ b/crates/sandbox-core/src/sandbox.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
+use rap_protocol::ThreadId;
 
 use crate::error::SandboxError;
 use crate::types::{ChangedFile, RepoState, SandboxMode};
@@ -14,7 +15,7 @@ pub struct SpawnedCommand {
 /// they can set up the repository and build a [`RepoState`].
 pub struct CloneContext<'a> {
     /// The group_id (thread id) initializing the repo.
-    pub group_id: &'a str,
+    pub group_id: &'a ThreadId,
     /// The path (or remote URI) as originally requested by the caller,
     /// before any backend resolution. Providers that use their own root
     /// markers should walk up from here (and return the root they find via
@@ -181,7 +182,7 @@ pub trait SandboxBackend: Send + Sync {
     async fn push_sandbox(
         &self,
         sandbox_dir: &Path,
-        group_id: &str,
+        group_id: &ThreadId,
         description: Option<&str>,
     ) -> Result<(), SandboxError>;
 
@@ -194,7 +195,7 @@ pub trait SandboxBackend: Send + Sync {
     /// On the local backend this runs `jj workspace forget` and deletes the
     /// cached directory. On the remote backend this is a no-op since sandboxes
     /// are ephemeral temp dirs cleaned up after each invocation.
-    async fn cleanup_sandbox_permanently(&self, _group_id: &str) -> Result<(), SandboxError> {
+    async fn cleanup_sandbox_permanently(&self, _group_id: &ThreadId) -> Result<(), SandboxError> {
         Ok(())
     }
 

--- a/crates/sandbox-core/src/server.rs
+++ b/crates/sandbox-core/src/server.rs
@@ -17,8 +17,8 @@ use tracing;
 
 use rap_protocol::{
     CallbackClient, DiffContent, DisplaySegment, RapCallback, RapInvocation, RapToolResult,
-    RapToolResultContent, ToolDef, ToolsetManifest, send_subscription_event, send_tool_result,
-    send_user_choice,
+    RapToolResultContent, ThreadId, ToolDef, ToolsetManifest, send_subscription_event,
+    send_tool_result, send_user_choice,
 };
 
 type DisplayResult = Result<(String, Option<Vec<DisplaySegment>>), SandboxError>;
@@ -325,7 +325,7 @@ fn with_content(result: DisplayResult) -> ContentResult {
 /// Request payload for the `/close_thread` RAP protocol endpoint.
 #[derive(Debug, Deserialize)]
 struct CloseThreadRequest {
-    thread_id: String,
+    thread_id: ThreadId,
 }
 
 /// Best-effort notification endpoint for thread closure.
@@ -368,7 +368,7 @@ async fn close_thread_handler<
 #[derive(Debug, Deserialize)]
 struct CancelToolCallRequest {
     tool_call_id: String,
-    thread_id: String,
+    thread_id: ThreadId,
 }
 
 /// Best-effort notification endpoint for tool call cancellation.
@@ -444,8 +444,8 @@ async fn user_choice_response_handler<
 }
 
 /// Build the full thread chain: ancestors (if any) + current group_id.
-fn thread_chain(invocation: &RapInvocation) -> Vec<String> {
-    let mut chain: Vec<String> = invocation
+fn thread_chain(invocation: &RapInvocation) -> Vec<ThreadId> {
+    let mut chain: Vec<ThreadId> = invocation
         .thread_ancestors
         .as_deref()
         .unwrap_or_default()
@@ -455,7 +455,7 @@ fn thread_chain(invocation: &RapInvocation) -> Vec<String> {
 }
 
 /// Check if write-orig is granted on any thread in the chain.
-async fn is_write_orig_granted<M: MetadataStore>(metadata: &M, chain: &[String]) -> bool {
+async fn is_write_orig_granted<M: MetadataStore>(metadata: &M, chain: &[ThreadId]) -> bool {
     for id in chain {
         if let Ok(Some(s)) = metadata.get(id).await
             && s.write_orig_granted
@@ -467,7 +467,10 @@ async fn is_write_orig_granted<M: MetadataStore>(metadata: &M, chain: &[String])
 }
 
 /// Return the set of paths already granted across the thread chain.
-async fn granted_write_paths<M: MetadataStore>(metadata: &M, chain: &[String]) -> HashSet<String> {
+async fn granted_write_paths<M: MetadataStore>(
+    metadata: &M,
+    chain: &[ThreadId],
+) -> HashSet<String> {
     let mut granted = HashSet::new();
     for id in chain {
         if let Ok(Some(s)) = metadata.get(id).await {
@@ -480,7 +483,7 @@ async fn granted_write_paths<M: MetadataStore>(metadata: &M, chain: &[String]) -
 /// Build per-thread-level "Yes" choices from root to current thread.
 /// Returns `(choices, thread_ids)` where `choices[i]` is the label and
 /// `thread_ids[i]` is the group_id to persist the grant on.
-fn build_grant_choices(chain: &[String]) -> (Vec<String>, Vec<String>) {
+fn build_grant_choices(chain: &[ThreadId]) -> (Vec<String>, Vec<ThreadId>) {
     let mut choices = Vec::new();
     let mut ids = Vec::new();
     for id in chain {
@@ -1829,7 +1832,7 @@ fn build_edit_diff(path: &str, old_str: &str, new_str: &str) -> Vec<DisplaySegme
 
 #[derive(Debug, Deserialize)]
 struct MigrateRequest {
-    session_id: String,
+    session_id: ThreadId,
     destination_url: String,
 }
 
@@ -1880,7 +1883,7 @@ async fn migrate_inner<B: SandboxBackend, M: MetadataStore, C: CallbackClient>(
         .list_all()
         .await?
         .into_iter()
-        .filter(|s| s.root_thread_id.as_deref() == Some(&request.session_id))
+        .filter(|s| s.root_thread_id.as_ref() == Some(&request.session_id))
         .collect();
     if all_states.is_empty() {
         return Err(SandboxError::Other(

--- a/crates/sandbox-core/src/types.rs
+++ b/crates/sandbox-core/src/types.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use rap_protocol::ThreadId;
 use serde::{Deserialize, Serialize};
 
 /// The version-control mode used by a sandbox.
@@ -78,7 +79,7 @@ pub(crate) fn parse_changed_files(output: &str) -> Vec<(FileChangeStatus, &str)>
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RepoState {
     /// The group_id this state belongs to.
-    pub group_id: String,
+    pub group_id: ThreadId,
     /// The git remote URI (local path or s3 URI).
     pub remote_uri: String,
     /// The bookmark name used to track state.
@@ -96,7 +97,7 @@ pub struct RepoState {
     pub write_path_grants: HashSet<String>,
     /// The root thread (session) this sandbox belongs to.
     #[serde(default)]
-    pub root_thread_id: Option<String>,
+    pub root_thread_id: Option<ThreadId>,
 }
 
 /// Input for the clone_repo tool.
@@ -105,7 +106,7 @@ pub struct CloneRepoArgs {
     /// Local path to a git repo, or a git remote URI.
     pub repo: String,
     /// Optional thread ID to base this sandbox on top of.
-    pub base_thread_id: Option<String>,
+    pub base_thread_id: Option<ThreadId>,
 }
 
 /// Input for the open_sandbox_direct tool.
@@ -169,7 +170,7 @@ pub struct DescribeOverallChangesArgs {
 #[derive(Debug, Deserialize)]
 pub struct SquashSandboxArgs {
     /// The thread ID of the child sandbox to squash from.
-    pub from_thread_id: String,
+    pub from_thread_id: ThreadId,
 }
 
 /// Input for the grep tool.

--- a/crates/sandbox-local/src/backend.rs
+++ b/crates/sandbox-local/src/backend.rs
@@ -446,7 +446,7 @@ impl SandboxBackend for LocalBackend {
     async fn push_sandbox(
         &self,
         sandbox_dir: &Path,
-        group_id: &ThreadId,
+        group_id: &ThreadId<str>,
         description: Option<&str>,
     ) -> Result<(), SandboxError> {
         let state = {
@@ -478,7 +478,10 @@ impl SandboxBackend for LocalBackend {
     ///
     /// Delegates to the mode's provider (e.g. `jj workspace forget` and
     /// deleting the sandbox directory for jj mode).
-    async fn cleanup_sandbox_permanently(&self, group_id: &ThreadId) -> Result<(), SandboxError> {
+    async fn cleanup_sandbox_permanently(
+        &self,
+        group_id: &ThreadId<str>,
+    ) -> Result<(), SandboxError> {
         let entry = {
             let mut cache = self.cache.lock().unwrap_or_else(|e| e.into_inner());
             cache.remove(group_id)

--- a/crates/sandbox-local/src/backend.rs
+++ b/crates/sandbox-local/src/backend.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
+use sandbox_core::ThreadId;
 use sandbox_core::error::SandboxError;
 use sandbox_core::sandbox::{CloneContext, ModeInit, ModeProvider, SandboxBackend, SpawnedCommand};
 use sandbox_core::types::{ChangedFile, RepoState, SandboxMode};
@@ -33,7 +34,7 @@ struct CachedSandbox {
 /// Sandbox temp directories are created under `{remote_uri}/.infinity/.sandboxes/`.
 pub struct LocalBackend {
     /// group_id -> cached sandbox
-    cache: Mutex<HashMap<String, CachedSandbox>>,
+    cache: Mutex<HashMap<ThreadId, CachedSandbox>>,
     /// Whether to use platform-specific sandboxing for command execution
     /// (macOS sandbox-exec or Linux bubblewrap).
     sandbox_enabled: bool,
@@ -445,7 +446,7 @@ impl SandboxBackend for LocalBackend {
     async fn push_sandbox(
         &self,
         sandbox_dir: &Path,
-        group_id: &str,
+        group_id: &ThreadId,
         description: Option<&str>,
     ) -> Result<(), SandboxError> {
         let state = {
@@ -477,7 +478,7 @@ impl SandboxBackend for LocalBackend {
     ///
     /// Delegates to the mode's provider (e.g. `jj workspace forget` and
     /// deleting the sandbox directory for jj mode).
-    async fn cleanup_sandbox_permanently(&self, group_id: &str) -> Result<(), SandboxError> {
+    async fn cleanup_sandbox_permanently(&self, group_id: &ThreadId) -> Result<(), SandboxError> {
         let entry = {
             let mut cache = self.cache.lock().unwrap_or_else(|e| e.into_inner());
             cache.remove(group_id)

--- a/crates/sandbox-local/src/metadata.rs
+++ b/crates/sandbox-local/src/metadata.rs
@@ -20,14 +20,14 @@ impl FileMetadataStore {
         Self { base_dir }
     }
 
-    fn path_for(&self, group_id: &ThreadId) -> PathBuf {
+    fn path_for(&self, group_id: &ThreadId<str>) -> PathBuf {
         self.base_dir.join(format!("{group_id}.json"))
     }
 }
 
 #[async_trait]
 impl MetadataStore for FileMetadataStore {
-    async fn get(&self, group_id: &ThreadId) -> Result<Option<RepoState>, SandboxError> {
+    async fn get(&self, group_id: &ThreadId<str>) -> Result<Option<RepoState>, SandboxError> {
         let path = self.path_for(group_id);
         match std::fs::read_to_string(&path) {
             Ok(contents) => {
@@ -52,7 +52,7 @@ impl MetadataStore for FileMetadataStore {
         Ok(())
     }
 
-    async fn delete(&self, group_id: &ThreadId) -> Result<(), SandboxError> {
+    async fn delete(&self, group_id: &ThreadId<str>) -> Result<(), SandboxError> {
         let path = self.path_for(group_id);
         match std::fs::remove_file(&path) {
             Ok(()) => Ok(()),

--- a/crates/sandbox-local/src/metadata.rs
+++ b/crates/sandbox-local/src/metadata.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 
+use sandbox_core::ThreadId;
 use sandbox_core::error::SandboxError;
 use sandbox_core::metadata::MetadataStore;
 use sandbox_core::types::RepoState;
@@ -19,14 +20,14 @@ impl FileMetadataStore {
         Self { base_dir }
     }
 
-    fn path_for(&self, group_id: &str) -> PathBuf {
+    fn path_for(&self, group_id: &ThreadId) -> PathBuf {
         self.base_dir.join(format!("{group_id}.json"))
     }
 }
 
 #[async_trait]
 impl MetadataStore for FileMetadataStore {
-    async fn get(&self, group_id: &str) -> Result<Option<RepoState>, SandboxError> {
+    async fn get(&self, group_id: &ThreadId) -> Result<Option<RepoState>, SandboxError> {
         let path = self.path_for(group_id);
         match std::fs::read_to_string(&path) {
             Ok(contents) => {
@@ -51,7 +52,7 @@ impl MetadataStore for FileMetadataStore {
         Ok(())
     }
 
-    async fn delete(&self, group_id: &str) -> Result<(), SandboxError> {
+    async fn delete(&self, group_id: &ThreadId) -> Result<(), SandboxError> {
         let path = self.path_for(group_id);
         match std::fs::remove_file(&path) {
             Ok(()) => Ok(()),

--- a/crates/sandbox-local/tests/common.rs
+++ b/crates/sandbox-local/tests/common.rs
@@ -10,6 +10,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use rap_protocol::{RapCallback, RapInvocation, RapToolResult, RapViewUpdate};
+use sandbox_core::ThreadId;
 use sandbox_core::callback::PlainCallbackClient;
 use sandbox_core::server::build_router;
 use sandbox_local::backend::LocalBackend;
@@ -55,7 +56,7 @@ pub async fn invoke(
     operation: &str,
     arguments: serde_json::Value,
     rx: &mut tokio::sync::mpsc::UnboundedReceiver<RapCallback>,
-    thread_ancestors: Option<Vec<String>>,
+    thread_ancestors: Option<Vec<ThreadId>>,
 ) -> String {
     invoke_raw(
         server_url,
@@ -79,7 +80,7 @@ pub async fn invoke_raw(
     operation: &str,
     arguments: serde_json::Value,
     rx: &mut tokio::sync::mpsc::UnboundedReceiver<RapCallback>,
-    thread_ancestors: Option<Vec<String>>,
+    thread_ancestors: Option<Vec<ThreadId>>,
 ) -> RapToolResult {
     let invocation = RapInvocation {
         operation: operation.to_owned(),
@@ -90,7 +91,7 @@ pub async fn invoke_raw(
         ),
         call_id: None,
         callback_url: callback_url.to_owned(),
-        group_id: group_id.to_owned(),
+        group_id: group_id.into(),
         user_id: None,
         thread_ancestors,
     };
@@ -175,7 +176,7 @@ pub async fn invoke_collecting_views(
         ),
         call_id: None,
         callback_url: callback_url.to_owned(),
-        group_id: group_id.to_owned(),
+        group_id: group_id.into(),
         user_id: None,
         thread_ancestors: None,
     };

--- a/crates/sandbox-local/tests/migrate.rs
+++ b/crates/sandbox-local/tests/migrate.rs
@@ -288,7 +288,7 @@ async fn migrate_multiple_threads() {
             "clone_repo",
             serde_json::json!({ "repo": source_path.to_str().expect("path") }),
             &mut rx,
-            Some(vec!["session-root".to_owned()]),
+            Some(vec!["session-root".into()]),
         )
         .await;
         assert!(text.contains("Repository initialized"), "got: {text}");
@@ -675,7 +675,7 @@ async fn migrate_after_squash_child() {
             "clone_repo",
             serde_json::json!({ "repo": source_path.to_str().expect("path") }),
             &mut rx,
-            Some(vec!["session-root".to_owned()]),
+            Some(vec!["session-root".into()]),
         )
         .await;
         assert!(text.contains("Repository initialized"), "got: {text}");

--- a/crates/sandbox-local/tests/stale_workspace_cleanup.rs
+++ b/crates/sandbox-local/tests/stale_workspace_cleanup.rs
@@ -68,7 +68,7 @@ async fn workspace_forget_succeeds_when_child_is_stale() {
         "clone_repo",
         serde_json::json!({ "repo": repo_str, "base_thread_id": parent_id }),
         &mut rx,
-        Some(vec![parent_id.to_owned()]),
+        Some(vec![parent_id.into()]),
     )
     .await;
     assert!(text.contains("Repository initialized"), "got: {text}");
@@ -81,7 +81,7 @@ async fn workspace_forget_succeeds_when_child_is_stale() {
         "create_file",
         serde_json::json!({ "path": "child.txt", "content": "from child\n" }),
         &mut rx,
-        Some(vec![parent_id.to_owned()]),
+        Some(vec![parent_id.into()]),
     )
     .await;
     assert!(text.contains("Created file"), "got: {text}");

--- a/crates/sandbox-local/tests/subagent_no_squash.rs
+++ b/crates/sandbox-local/tests/subagent_no_squash.rs
@@ -66,7 +66,7 @@ async fn child_changes_preserved_after_close_without_squash() {
         "clone_repo",
         serde_json::json!({ "repo": repo_str, "base_thread_id": parent_id }),
         &mut rx,
-        Some(vec![parent_id.to_owned()]),
+        Some(vec![parent_id.into()]),
     )
     .await;
     assert!(text.contains("Repository initialized"), "got: {text}");
@@ -79,7 +79,7 @@ async fn child_changes_preserved_after_close_without_squash() {
         "create_file",
         serde_json::json!({ "path": "child.txt", "content": "from child\n" }),
         &mut rx,
-        Some(vec![parent_id.to_owned()]),
+        Some(vec![parent_id.into()]),
     )
     .await;
     assert!(text.contains("Created file"), "got: {text}");

--- a/crates/sandbox-remote/src/backend.rs
+++ b/crates/sandbox-remote/src/backend.rs
@@ -3,6 +3,7 @@ use std::process::Stdio;
 
 use async_trait::async_trait;
 
+use sandbox_core::ThreadId;
 use sandbox_core::error::SandboxError;
 use sandbox_core::jj::{self, run_jj};
 use sandbox_core::sandbox::{CloneContext, ModeInit, SandboxBackend, SpawnedCommand};
@@ -64,7 +65,7 @@ impl EfsBackend {
     }
     /// Mirror the source repo into a bare repo on EFS, named by the normalized URI.
     /// If the bare repo already exists, fetch latest changes from the upstream remote.
-    async fn mirror_repo(&self, repo: &str, group_id: &str) -> Result<PathBuf, SandboxError> {
+    async fn mirror_repo(&self, repo: &str, group_id: &ThreadId) -> Result<PathBuf, SandboxError> {
         let bare_path = self.bare_repo_path(repo);
 
         if bare_path.exists() {
@@ -165,7 +166,7 @@ impl SandboxBackend for EfsBackend {
     async fn push_sandbox(
         &self,
         sandbox_dir: &Path,
-        group_id: &str,
+        group_id: &ThreadId,
         _description: Option<&str>,
     ) -> Result<(), SandboxError> {
         let bookmark = format!("sandbox-{group_id}");

--- a/crates/sandbox-remote/src/backend.rs
+++ b/crates/sandbox-remote/src/backend.rs
@@ -65,7 +65,11 @@ impl EfsBackend {
     }
     /// Mirror the source repo into a bare repo on EFS, named by the normalized URI.
     /// If the bare repo already exists, fetch latest changes from the upstream remote.
-    async fn mirror_repo(&self, repo: &str, group_id: &ThreadId) -> Result<PathBuf, SandboxError> {
+    async fn mirror_repo(
+        &self,
+        repo: &str,
+        group_id: &ThreadId<str>,
+    ) -> Result<PathBuf, SandboxError> {
         let bare_path = self.bare_repo_path(repo);
 
         if bare_path.exists() {
@@ -166,7 +170,7 @@ impl SandboxBackend for EfsBackend {
     async fn push_sandbox(
         &self,
         sandbox_dir: &Path,
-        group_id: &ThreadId,
+        group_id: &ThreadId<str>,
         _description: Option<&str>,
     ) -> Result<(), SandboxError> {
         let bookmark = format!("sandbox-{group_id}");

--- a/crates/sandbox-remote/src/metadata.rs
+++ b/crates/sandbox-remote/src/metadata.rs
@@ -20,7 +20,7 @@ impl DynamoMetadataStore {
 
 #[async_trait]
 impl MetadataStore for DynamoMetadataStore {
-    async fn get(&self, group_id: &ThreadId) -> Result<Option<RepoState>, SandboxError> {
+    async fn get(&self, group_id: &ThreadId<str>) -> Result<Option<RepoState>, SandboxError> {
         let result = self
             .client
             .get_item()
@@ -53,7 +53,7 @@ impl MetadataStore for DynamoMetadataStore {
             .unwrap_or_default();
 
         Ok(Some(RepoState {
-            group_id: group_id.clone(),
+            group_id: group_id.to_owned(),
             remote_uri,
             bookmark,
             mode: SandboxMode::Jj { base_revision },
@@ -87,7 +87,7 @@ impl MetadataStore for DynamoMetadataStore {
         Ok(())
     }
 
-    async fn delete(&self, group_id: &ThreadId) -> Result<(), SandboxError> {
+    async fn delete(&self, group_id: &ThreadId<str>) -> Result<(), SandboxError> {
         self.client
             .delete_item()
             .table_name(&self.table_name)

--- a/crates/sandbox-remote/src/metadata.rs
+++ b/crates/sandbox-remote/src/metadata.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use aws_sdk_dynamodb::Client;
 use aws_sdk_dynamodb::types::AttributeValue;
 
+use sandbox_core::ThreadId;
 use sandbox_core::error::SandboxError;
 use sandbox_core::metadata::MetadataStore;
 use sandbox_core::types::{RepoState, SandboxMode};
@@ -19,12 +20,12 @@ impl DynamoMetadataStore {
 
 #[async_trait]
 impl MetadataStore for DynamoMetadataStore {
-    async fn get(&self, group_id: &str) -> Result<Option<RepoState>, SandboxError> {
+    async fn get(&self, group_id: &ThreadId) -> Result<Option<RepoState>, SandboxError> {
         let result = self
             .client
             .get_item()
             .table_name(&self.table_name)
-            .key("group_id", AttributeValue::S(group_id.to_owned()))
+            .key("group_id", AttributeValue::S(group_id.as_str().to_owned()))
             .send()
             .await
             .map_err(|e| SandboxError::MetadataError(format!("DynamoDB get failed: {e}")))?;
@@ -52,7 +53,7 @@ impl MetadataStore for DynamoMetadataStore {
             .unwrap_or_default();
 
         Ok(Some(RepoState {
-            group_id: group_id.to_owned(),
+            group_id: group_id.clone(),
             remote_uri,
             bookmark,
             mode: SandboxMode::Jj { base_revision },
@@ -68,7 +69,10 @@ impl MetadataStore for DynamoMetadataStore {
             .client
             .put_item()
             .table_name(&self.table_name)
-            .item("group_id", AttributeValue::S(state.group_id.clone()))
+            .item(
+                "group_id",
+                AttributeValue::S(state.group_id.as_str().to_owned()),
+            )
             .item("remote_uri", AttributeValue::S(state.remote_uri.clone()))
             .item("bookmark", AttributeValue::S(state.bookmark.clone()));
 
@@ -83,11 +87,11 @@ impl MetadataStore for DynamoMetadataStore {
         Ok(())
     }
 
-    async fn delete(&self, group_id: &str) -> Result<(), SandboxError> {
+    async fn delete(&self, group_id: &ThreadId) -> Result<(), SandboxError> {
         self.client
             .delete_item()
             .table_name(&self.table_name)
-            .key("group_id", AttributeValue::S(group_id.to_owned()))
+            .key("group_id", AttributeValue::S(group_id.as_str().to_owned()))
             .send()
             .await
             .map_err(|e| SandboxError::MetadataError(format!("DynamoDB delete failed: {e}")))?;


### PR DESCRIPTION
Stage 1 of the string-ID to typed-ID migration (#108). Defines `ThreadId`
via the published `strkind` 0.0.1 macro and converts every RAP `group_id`
on the wire types, plus all consumers. Serialization is transparent, so
the wire format and persisted metadata are byte-identical (verified: no
insta snapshot changes; full test suite passes).

Stage 2 of the string-ID to typed-ID migration (#108). The agent runtime's
interior now carries `ThreadId` end to end; the Stage-1 boundary seams in
rap-bridge/rap_tool dissolved into direct pass-throughs. Wire formats,
persisted session files, and DB column values are unchanged (serde
transparent; zero insta snapshot diffs; full test suite + web e2e pass).

* rap-protocol: `strkind! { pub ThreadId; }` with docs (RAP calls it
  `group_id` on the wire; UUIDs in the daemon, caller-chosen conversation
  keys in the Lambda runtime). `group_id: ThreadId` on `RapInvocation`,
  `RapToolResult`, `RapUserChoice`, `RapSubscriptionEvent`,
  `RapViewUpdate`, `RapOAuth`; `thread_ancestors: Option<Vec<ThreadId>>`;
  `send_subscription_event`/`send_view_update` take `ThreadId`
* sandbox-core/local/remote (via sub-agent): `ThreadId` re-exported from
  sandbox-core root; `MetadataStore::get/delete(&ThreadId)`;
  `SandboxBackend::push_sandbox`/`cleanup_sandbox_permanently` typed;
  `RepoState.{group_id, root_thread_id}`, `CloneRepoArgs.base_thread_id`,
  `SquashSandboxArgs.from_thread_id`, `CloneContext.group_id`,
  `SandboxError::RepoNotFound`, and server request payload structs typed
* infinity-agent-core: rap_tool boundary converts `ToolContext` strings
  into `ThreadId` when building invocations (context types themselves are
  Stage 2)
* infinity-rap-bridge: callback conversion unwraps `ThreadId` into
  `InputMessage.group_id` (String until Stage 2)
* rap-github-event-poller: `Subscription.group_id: ThreadId`
* infinity-daemon: view-update routing + test fixture conversions
* Workspace: `strkind = "0.0.1"` added to workspace dependencies

Stage 2:

* infinity-agent-core: `InputMessage.group_id: ThreadId`;
  `ToolContext.{group_id, thread_stack}` typed; `ConversationStore`/
  `StateStore` methods take `&ThreadId` (spawn_thread returns `ThreadId`,
  get_thread_parent_info/get_ancestor_chain return typed tuples);
  `ThreadInfo` fields, in-memory store maps, `HistoryManager.{thread_id,
  root_thread_id, ancestor_chain}`, `SyntheticKind` child-thread fields,
  `system/` internals (router/driver/handle/launch channels and maps,
  `ActiveThreads`, `ThreadObserver::on_event`, observer factories,
  `ThreadHandle::thread_id()`, `ThreadLifecycleEvent`, `step()` outcome
  keys) all typed. `ThreadId` re-exported from the crate root.
* rap-client: `RapNotifier::{notify_thread_closed, notify_tool_cancelled}`
  take `&ThreadId`
* infinity-rap-bridge: callback conversion is now pass-through (Stage-1
  `.into_inner()` seams removed)
* infinity-daemon (sub-agent): memory_store trait impls + internal
  maps/extras/views typed; session_store sessions keyed by ThreadId
  (sessions.json byte-identical); SessionManager APIs, SubscriberMap,
  display/observer paths typed; client_handler converts wire Strings once
  per match arm; migrate.rs local paths typed (remote "remote/uuid"
  composite handling stays String pending Stage-3 ThreadRef)
* infinity-agent-lambda (sub-agent): DSQL/Dynamo trait impls take
  `&ThreadId` (.as_str() at sqlx/Dynamo boundaries, values unchanged);
  SQS message_group_id via .into_inner(); rap-receiver PreparedEnqueue typed


BREAKING CHANGE: `rap_protocol` and `sandbox_core` public types now use
`ThreadId` where they previously used `String` (wire format unchanged).

BREAKING CHANGE: infinity-agent-core public traits and types now use
`ThreadId` where they previously used `String`/`&str`.

Conventions: owned-first (fields own `ThreadId`, params take `&ThreadId`,
clone freely); borrow/storage optimization deferred to a benchmark-driven
pass. Remaining stages: agent-core internals (2), session_id to
root_thread_id + ThreadRef (3), ToolCallId/ProviderCallId (4), long tail (5)

Noted for Stage 3: client_handler's is_remote_session/prefix_daemon_message
string encoding is where `ThreadRef` lands; rap-client's
ToolsetLoader::load_toolsets and request_migration still take &str.