### PR TITLE
refactor(infinity-protocol)!: session_id becomes root_thread_id; add ThreadRef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,6 +3359,7 @@ dependencies = [
  "rap-protocol",
  "serde",
  "serde_json",
+ "strkind",
  "tokio-util",
 ]
 

--- a/crates/infinity-agent-cli/src/acp_server.rs
+++ b/crates/infinity-agent-cli/src/acp_server.rs
@@ -36,7 +36,7 @@ struct SessionConnection {
     /// ACP session ID (what the client sees).
     acp_id: String,
     /// Daemon session ID (what the daemon sees). None until Connected arrives.
-    daemon_id: Option<String>,
+    daemon_id: Option<infinity_protocol::ThreadRef>,
     /// ACP connection for sending notifications.
     cx: ConnectionTo<Client>,
     /// Pending prompt responder.
@@ -60,7 +60,7 @@ impl SessionConnection {
 /// Global state shared across all ACP request handlers.
 struct GlobalState {
     /// Sessions known from the daemon Welcome/SessionsUpdated.
-    sessions: HashMap<String, SessionInfo>,
+    sessions: HashMap<infinity_protocol::ThreadRef, SessionInfo>,
     /// Maps daemon session ID → ACP session ID.
     daemon_to_acp: HashMap<String, String>,
     /// Maps ACP session ID → daemon session ID.
@@ -165,7 +165,9 @@ pub async fn run() -> Result<(), BoxError> {
                                 info.status != infinity_protocol::SessionStatus::Archived
                             })
                             .map(|(id, info)| {
-                                let acp_id = s.daemon_to_acp.get(id).unwrap_or(id).clone();
+                                let rendered = id.to_string();
+                                let acp_id =
+                                    s.daemon_to_acp.get(&rendered).unwrap_or(&rendered).clone();
                                 agent_client_protocol::schema::SessionInfo::new(
                                     acp_id,
                                     std::env::current_dir().unwrap_or_default(),
@@ -202,19 +204,23 @@ pub async fn run() -> Result<(), BoxError> {
                                 cx: ConnectionTo<Client>| {
                         let mut s = state.lock().expect("bug: lock poisoned");
                         let acp_id = req.session_id.0.to_string();
-                        let daemon_id = s
+                        let daemon_id: infinity_protocol::ThreadRef = s
                             .acp_to_daemon
                             .get(&acp_id)
                             .cloned()
-                            .unwrap_or_else(|| acp_id.clone());
+                            .unwrap_or_else(|| acp_id.clone())
+                            .as_str()
+                            .into();
                         if !s.sessions.contains_key(&daemon_id) {
                             return responder.respond_with_error(
                                 agent_client_protocol::schema::Error::invalid_params()
                                     .data(format!("session '{}' not found", acp_id)),
                             );
                         }
-                        s.daemon_to_acp.insert(daemon_id.clone(), acp_id.clone());
-                        s.acp_to_daemon.insert(acp_id.clone(), daemon_id.clone());
+                        s.daemon_to_acp
+                            .insert(daemon_id.to_string(), acp_id.clone());
+                        s.acp_to_daemon
+                            .insert(acp_id.clone(), daemon_id.to_string());
                         save_session_mappings(&s);
 
                         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
@@ -309,11 +315,13 @@ pub async fn run() -> Result<(), BoxError> {
                         }
 
                         // Unknown session — try connecting by daemon ID.
-                        let daemon_id = s
+                        let daemon_id: infinity_protocol::ThreadRef = s
                             .acp_to_daemon
                             .get(&acp_id)
                             .cloned()
-                            .unwrap_or_else(|| acp_id.clone());
+                            .unwrap_or_else(|| acp_id.clone())
+                            .as_str()
+                            .into();
                         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
                         s.session_connections.insert(acp_id.clone(), cmd_tx);
                         drop(s);
@@ -384,7 +392,8 @@ pub async fn run() -> Result<(), BoxError> {
                             s.sessions = sessions;
                             // Notify all active sessions of info updates.
                             for (daemon_id, info) in &s.sessions {
-                                let acp_id = s.daemon_to_acp.get(daemon_id).unwrap_or(daemon_id);
+                                let rendered = daemon_id.to_string();
+                                let acp_id = s.daemon_to_acp.get(&rendered).unwrap_or(&rendered);
                                 if let Some(ref cx) = s.cx {
                                     let notif = SessionNotification::new(
                                         acp_id.clone(),
@@ -416,7 +425,7 @@ pub async fn run() -> Result<(), BoxError> {
 /// How a session connection starts.
 enum SessionStart {
     Load {
-        daemon_id: String,
+        daemon_id: infinity_protocol::ThreadRef,
         responder: Responder<LoadSessionResponse>,
     },
     Create {
@@ -425,7 +434,7 @@ enum SessionStart {
         responder: Responder<PromptResponse>,
     },
     ConnectAndPrompt {
-        daemon_id: String,
+        daemon_id: infinity_protocol::ThreadRef,
         text: String,
         responder: Responder<PromptResponse>,
     },
@@ -462,7 +471,7 @@ async fn run_session_connection(
             responder,
         } => {
             let msg = ClientMessage::Connect {
-                session_id: daemon_id.clone(),
+                root_thread_id: daemon_id.clone(),
                 thread_id: None,
                 keeps_session_alive: true,
             };
@@ -518,18 +527,25 @@ async fn run_session_connection(
                 let msg = recv(&mut framed).await?;
                 match msg {
                     DaemonMessage::Connected {
-                        session_id, title, ..
+                        root_thread_id: session_id,
+                        title,
+                        ..
                     } => {
                         conn.daemon_id = Some(session_id.clone());
                         // Register mapping.
                         {
                             let mut g = global.lock().expect("bug: lock poisoned");
-                            g.daemon_to_acp.insert(session_id.clone(), acp_id.clone());
-                            g.acp_to_daemon.insert(acp_id.clone(), session_id.clone());
+                            g.daemon_to_acp
+                                .insert(session_id.to_string(), acp_id.clone());
+                            g.acp_to_daemon
+                                .insert(acp_id.clone(), session_id.to_string());
                             save_session_mappings(&g);
                         }
 
-                        let input_msg = ClientMessage::UserInput { session_id, text };
+                        let input_msg = ClientMessage::UserInput {
+                            root_thread_id: session_id,
+                            text,
+                        };
                         send(&mut framed, &input_msg).await?;
                         conn.pending_prompt = Some(responder);
 
@@ -559,7 +575,7 @@ async fn run_session_connection(
             responder,
         } => {
             let msg = ClientMessage::Connect {
-                session_id: daemon_id.clone(),
+                root_thread_id: daemon_id.clone(),
                 thread_id: None,
                 keeps_session_alive: true,
             };
@@ -571,7 +587,7 @@ async fn run_session_connection(
                 match msg {
                     DaemonMessage::Connected { .. } => {
                         let input_msg = ClientMessage::UserInput {
-                            session_id: daemon_id,
+                            root_thread_id: daemon_id,
                             text,
                         };
                         send(&mut framed, &input_msg).await?;
@@ -615,7 +631,7 @@ async fn run_session_connection(
                 }
                 if let Some(ref daemon_id) = conn.daemon_id {
                     let msg = ClientMessage::UserInput {
-                        session_id: daemon_id.clone(),
+                        root_thread_id: daemon_id.clone(),
                         text,
                     };
                     if let Err(e) = send(&mut framed, &msg).await {

--- a/crates/infinity-agent-cli/src/acp_server.rs
+++ b/crates/infinity-agent-cli/src/acp_server.rs
@@ -543,7 +543,7 @@ async fn run_session_connection(
                         }
 
                         let input_msg = ClientMessage::UserInput {
-                            root_thread_id: session_id,
+                            thread_id: session_id,
                             text,
                         };
                         send(&mut framed, &input_msg).await?;
@@ -587,7 +587,7 @@ async fn run_session_connection(
                 match msg {
                     DaemonMessage::Connected { .. } => {
                         let input_msg = ClientMessage::UserInput {
-                            root_thread_id: daemon_id,
+                            thread_id: daemon_id,
                             text,
                         };
                         send(&mut framed, &input_msg).await?;
@@ -631,7 +631,7 @@ async fn run_session_connection(
                 }
                 if let Some(ref daemon_id) = conn.daemon_id {
                     let msg = ClientMessage::UserInput {
-                        root_thread_id: daemon_id.clone(),
+                        thread_id: daemon_id.clone(),
                         text,
                     };
                     if let Err(e) = send(&mut framed, &msg).await {

--- a/crates/infinity-agent-cli/src/daemon_client.rs
+++ b/crates/infinity-agent-cli/src/daemon_client.rs
@@ -6,7 +6,8 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
 use infinity_protocol::{
-    ClientMessage, DaemonMessage, ModelRef, SessionInfo, TokenUsage, length_delimited_codec,
+    ClientMessage, DaemonMessage, ModelRef, SessionInfo, ThreadRef, TokenUsage,
+    length_delimited_codec,
 };
 use std::path::PathBuf;
 use tokio::io::AsyncBufReadExt;
@@ -35,7 +36,7 @@ fn convert_token_usage(u: &TokenUsage) -> infinity_provider_protocol::Usage {
 
 /// Convert a DaemonMessage into a (thread_id, DisplayEvent) tuple.
 /// Returns None for messages that are handled separately (Connected, Welcome, etc.).
-fn daemon_msg_to_display(msg: DaemonMessage) -> Option<(Option<String>, DisplayEvent)> {
+fn daemon_msg_to_display(msg: DaemonMessage) -> Option<(Option<ThreadRef>, DisplayEvent)> {
     Some(match msg {
         DaemonMessage::StartOutput { thread_id } => (thread_id, DisplayEvent::StartOutput),
         DaemonMessage::TextChunk { thread_id, chunk } => {
@@ -372,7 +373,7 @@ pub async fn run_headless(message: String) -> Result<(), BoxError> {
     // Wait for Connected to get the session ID.
     let session_id = loop {
         match recv(&mut framed).await? {
-            DaemonMessage::Connected { session_id, .. } => break session_id,
+            DaemonMessage::Connected { root_thread_id, .. } => break root_thread_id,
             DaemonMessage::Error { text, .. } => return Err(text.into()),
             _ => continue, // skip SessionsUpdated, etc.
         }
@@ -380,7 +381,7 @@ pub async fn run_headless(message: String) -> Result<(), BoxError> {
 
     // Send the user's message.
     let msg = ClientMessage::UserInput {
-        session_id: session_id.clone(),
+        root_thread_id: session_id.clone(),
         text: message,
     };
     framed.send(Bytes::from(serde_json::to_vec(&msg)?)).await?;
@@ -540,15 +541,15 @@ where
         _ => return Err("expected Welcome from daemon".into()),
     };
 
-    let (display_tx, display_rx) = mpsc::unbounded_channel::<(Option<String>, DisplayEvent)>();
+    let (display_tx, display_rx) = mpsc::unbounded_channel::<(Option<ThreadRef>, DisplayEvent)>();
     let (input_tx, input_rx) = mpsc::unbounded_channel::<String>();
-    let (load_session_tx, load_session_rx) = mpsc::unbounded_channel::<(Option<String>, bool)>();
+    let (load_session_tx, load_session_rx) = mpsc::unbounded_channel::<(Option<ThreadRef>, bool)>();
     let (model_switch_tx, model_switch_rx) = mpsc::unbounded_channel::<usize>();
     let (session_tx, session_rx) = mpsc::unbounded_channel::<SessionChanged>();
     let (model_switched_tx, model_switched_rx) =
         mpsc::unbounded_channel::<crate::terminal::ModelSwitched>();
     let (sessions_updated_tx, sessions_updated_rx) =
-        mpsc::unbounded_channel::<HashMap<String, SessionInfo>>();
+        mpsc::unbounded_channel::<HashMap<ThreadRef, SessionInfo>>();
     let (soft_detach_tx, soft_detach_rx) = mpsc::unbounded_channel::<()>();
     let (detach_result_tx, detach_result_rx) = mpsc::unbounded_channel::<DetachResult>();
     let (choice_answered_tx, choice_answered_rx) = mpsc::unbounded_channel::<(String, usize)>();
@@ -559,19 +560,20 @@ where
 
     // If --session was provided, connect to it immediately (supports prefix matching).
     if let Some(ref session_id) = session {
-        let matches: Vec<&String> = sessions
+        let matches: Vec<(&ThreadRef, String)> = sessions
             .keys()
-            .filter(|k| k.starts_with(session_id.as_str()))
+            .map(|k| (k, k.to_string()))
+            .filter(|(_, rendered)| rendered.starts_with(session_id.as_str()))
             .collect();
         let resolved = match matches.len() {
             0 => return Err(format!("no session found matching prefix '{session_id}'").into()),
-            1 => matches[0].clone(),
+            1 => matches[0].0.clone(),
             _ => {
                 return Err(format!(
                     "ambiguous session prefix '{session_id}' — matches: {}",
                     matches
                         .iter()
-                        .map(|s| s.as_str())
+                        .map(|(_, rendered)| rendered.as_str())
                         .collect::<Vec<_>>()
                         .join(", ")
                 )
@@ -579,7 +581,7 @@ where
             }
         };
         to_daemon.send(ClientMessage::Connect {
-            session_id: resolved,
+            root_thread_id: resolved,
             thread_id: None,
             keeps_session_alive: true,
         })?;
@@ -608,7 +610,7 @@ where
         choice_answered_tx,
     ));
 
-    let mut active_session: Option<String> = None;
+    let mut active_session: Option<ThreadRef> = None;
     let mut pending_input: Vec<String> = Vec::new();
     // The model most recently selected via the model picker. Stored locally so
     // it can be passed when creating new sessions, even if no session is active.
@@ -637,12 +639,12 @@ where
                         break;
                     };
                     match msg {
-                        DaemonMessage::Connected { session_id, title, total_tokens_used, model_name, context_window, provider_id, .. } => {
-                            active_session = Some(session_id.clone());
-                            let _ = session_tx.send(SessionChanged { session_id, title, total_tokens_used, model_name, context_window, provider_id });
+                        DaemonMessage::Connected { root_thread_id, title, total_tokens_used, model_name, context_window, provider_id, .. } => {
+                            active_session = Some(root_thread_id.clone());
+                            let _ = session_tx.send(SessionChanged { session_id: root_thread_id, title, total_tokens_used, model_name, context_window, provider_id });
                             for text in pending_input.drain(..) {
                                 let sid = active_session.as_ref().expect("bug: active_session should be set after Connected").clone();
-                                let _ = to_daemon.send(ClientMessage::UserInput { session_id: sid, text });
+                                let _ = to_daemon.send(ClientMessage::UserInput { root_thread_id: sid, text });
                             }
                         }
                         DaemonMessage::ModelSwitched { thread_id, model_name, context_window, provider_id } => {
@@ -699,7 +701,7 @@ where
                     let Some(()) = msg else { break };
                     if let Some(ref sid) = active_session {
                         pending_soft_detach = true;
-                        let _ = to_daemon.send(ClientMessage::SoftDetach { session_id: sid.clone() });
+                        let _ = to_daemon.send(ClientMessage::SoftDetach { root_thread_id: sid.clone() });
                     }
                 }
 
@@ -707,7 +709,7 @@ where
                     let Some((maybe_target, shut_down_old)) = maybe_target else { break };
                     if let Some(ref sid) = active_session {
                         if shut_down_old {
-                            let _ = to_daemon.send(ClientMessage::ShutdownSession { session_id: sid.clone() });
+                            let _ = to_daemon.send(ClientMessage::ShutdownSession { root_thread_id: sid.clone() });
                         } else {
                             let _ = to_daemon.send(ClientMessage::Disconnect);
                         }
@@ -721,7 +723,7 @@ where
                     }
 
                     if let Some(target) = maybe_target {
-                        let _ = to_daemon.send(ClientMessage::Connect { session_id: target, thread_id: None, keeps_session_alive: true });
+                        let _ = to_daemon.send(ClientMessage::Connect { root_thread_id: target, thread_id: None, keeps_session_alive: true });
                     } // if none, will be created on next user input
                 }
 
@@ -736,7 +738,7 @@ where
                         selected_model = Some(model.clone());
                         if let Some(sid) = &active_session {
                             let _ = to_daemon.send(ClientMessage::SwitchModel {
-                                session_id: sid.clone(), model,
+                                thread_id: sid.clone(), model,
                             });
                         }
                     }
@@ -756,12 +758,12 @@ where
                     let Some(text) = text else { break };
                     if let Some(ref sid) = active_session {
                         if text == "__compact__" {
-                            let _ = to_daemon.send(ClientMessage::TriggerCompaction { session_id: sid.clone() });
+                            let _ = to_daemon.send(ClientMessage::TriggerCompaction { root_thread_id: sid.clone() });
                         } else if text == "__archive__" {
-                            let _ = to_daemon.send(ClientMessage::ArchiveSession { session_id: sid.clone() });
+                            let _ = to_daemon.send(ClientMessage::ArchiveSession { root_thread_id: sid.clone() });
                             active_session = None;
                         } else {
-                            let _ = to_daemon.send(ClientMessage::UserInput { session_id: sid.clone(), text });
+                            let _ = to_daemon.send(ClientMessage::UserInput { root_thread_id: sid.clone(), text });
                         }
                     } else {
                         pending_input.push(text);
@@ -789,7 +791,9 @@ where
         if keep_running {
             let _ = to_daemon.send(ClientMessage::Disconnect);
         } else {
-            let _ = to_daemon.send(ClientMessage::ShutdownSession { session_id: sid });
+            let _ = to_daemon.send(ClientMessage::ShutdownSession {
+                root_thread_id: sid,
+            });
         }
     }
 

--- a/crates/infinity-agent-cli/src/daemon_client.rs
+++ b/crates/infinity-agent-cli/src/daemon_client.rs
@@ -381,7 +381,7 @@ pub async fn run_headless(message: String) -> Result<(), BoxError> {
 
     // Send the user's message.
     let msg = ClientMessage::UserInput {
-        root_thread_id: session_id.clone(),
+        thread_id: session_id.clone(),
         text: message,
     };
     framed.send(Bytes::from(serde_json::to_vec(&msg)?)).await?;
@@ -644,7 +644,7 @@ where
                             let _ = session_tx.send(SessionChanged { session_id: root_thread_id, title, total_tokens_used, model_name, context_window, provider_id });
                             for text in pending_input.drain(..) {
                                 let sid = active_session.as_ref().expect("bug: active_session should be set after Connected").clone();
-                                let _ = to_daemon.send(ClientMessage::UserInput { root_thread_id: sid, text });
+                                let _ = to_daemon.send(ClientMessage::UserInput { thread_id: sid, text });
                             }
                         }
                         DaemonMessage::ModelSwitched { thread_id, model_name, context_window, provider_id } => {
@@ -763,7 +763,7 @@ where
                             let _ = to_daemon.send(ClientMessage::ArchiveSession { root_thread_id: sid.clone() });
                             active_session = None;
                         } else {
-                            let _ = to_daemon.send(ClientMessage::UserInput { root_thread_id: sid.clone(), text });
+                            let _ = to_daemon.send(ClientMessage::UserInput { thread_id: sid.clone(), text });
                         }
                     } else {
                         pending_input.push(text);

--- a/crates/infinity-agent-cli/src/main.rs
+++ b/crates/infinity-agent-cli/src/main.rs
@@ -250,11 +250,11 @@ async fn async_main(cli: Cli) -> Result<(), BoxError> {
                                 );
                             }
                         };
-                    if remotes.iter().any(|r| r.name == name) {
+                    if remotes.iter().any(|r| r.name.as_str() == name) {
                         return Err(format!("remote '{name}' already exists").into());
                     }
                     remotes.push(infinity_daemon::remote::RemoteConfig {
-                        name: name.clone(),
+                        name: name.clone().into(),
                         ssh_args: ssh_args.to_vec(),
                     });
                     if let Some(parent) = path.parent() {

--- a/crates/infinity-agent-cli/src/session_picker.rs
+++ b/crates/infinity-agent-cli/src/session_picker.rs
@@ -12,20 +12,23 @@ pub const MAX_VISIBLE_ROWS: u16 = 5;
 
 pub enum SessionPickerResult {
     /// User selected a session (id).
-    Selected(String),
+    Selected(infinity_protocol::ThreadRef),
     Cancelled,
 }
 
 pub struct SessionPicker {
-    pub sessions: Vec<(String, SessionInfo)>,
+    pub sessions: Vec<(infinity_protocol::ThreadRef, SessionInfo)>,
     pub selected: usize,
     scroll_offset: usize,
     result: Option<SessionPickerResult>,
-    pub current_session_id: Option<String>,
+    pub current_session_id: Option<infinity_protocol::ThreadRef>,
 }
 
 impl SessionPicker {
-    pub fn new(sessions: Vec<(String, SessionInfo)>, current_session_id: Option<String>) -> Self {
+    pub fn new(
+        sessions: Vec<(infinity_protocol::ThreadRef, SessionInfo)>,
+        current_session_id: Option<infinity_protocol::ThreadRef>,
+    ) -> Self {
         let selected = current_session_id
             .as_ref()
             .and_then(|cid| sessions.iter().position(|s| &s.0 == cid))
@@ -131,7 +134,7 @@ impl SessionPicker {
                 (Color::DarkGray, Color::Reset, Modifier::empty())
             };
 
-            let is_current = self.current_session_id.as_deref() == Some(id.as_str());
+            let is_current = self.current_session_id.as_ref() == Some(id);
             let current_suffix = if is_current { " (current)" } else { "" };
             let suffix_len = current_suffix.len();
             let remote_label = info
@@ -149,11 +152,14 @@ impl SessionPicker {
                 } else {
                     format!("{}{}{}", title, remote_label, current_suffix)
                 }
-            } else if id.len() + extra_len > name_width {
-                let trunc = name_width.saturating_sub(extra_len + 1);
-                format!("{}…{}{}", &id[..trunc], remote_label, current_suffix)
             } else {
-                format!("{}{}{}", id, remote_label, current_suffix)
+                let id = id.to_string();
+                if id.len() + extra_len > name_width {
+                    let trunc = name_width.saturating_sub(extra_len + 1);
+                    format!("{}…{}{}", &id[..trunc], remote_label, current_suffix)
+                } else {
+                    format!("{}{}{}", id, remote_label, current_suffix)
+                }
             };
             // Column ranges for the "(current)" and "[remote]" labels (1 for leading space)
             let name_char_len = name.chars().count();

--- a/crates/infinity-agent-cli/src/terminal.rs
+++ b/crates/infinity-agent-cli/src/terminal.rs
@@ -68,7 +68,7 @@ const SLASH_COMMANDS: &[(&str, &str)] = &[
 ];
 
 pub struct SessionChanged {
-    pub session_id: String,
+    pub session_id: infinity_protocol::ThreadRef,
     pub title: Option<String>,
     pub total_tokens_used: usize,
     /// Display name of the model associated with the session's root thread.
@@ -83,7 +83,7 @@ pub struct SessionChanged {
 /// [`infinity_protocol::DaemonMessage::ModelSwitched`]). Updates the status
 /// line when it targets the thread currently being viewed.
 pub struct ModelSwitched {
-    pub thread_id: String,
+    pub thread_id: infinity_protocol::ThreadRef,
     pub model_name: String,
     pub provider_id: String,
     pub context_window: usize,
@@ -99,7 +99,7 @@ pub enum DetachResult {
 
 enum SoftDetachAction {
     Quit,
-    SwitchSession(Option<String>),
+    SwitchSession(Option<infinity_protocol::ThreadRef>),
 }
 
 /// A queued user choice request waiting to be shown in the TUI.
@@ -115,19 +115,22 @@ pub async fn run<T, E>(
     mut term: T,
     mut events: E,
     input_tx: mpsc::UnboundedSender<String>,
-    mut display_rx: mpsc::UnboundedReceiver<(Option<String>, DisplayEvent)>,
+    mut display_rx: mpsc::UnboundedReceiver<(Option<infinity_protocol::ThreadRef>, DisplayEvent)>,
     mut model_name: String,
     mut provider_id: String,
     mut context_window: usize,
-    initial_sessions: std::collections::HashMap<String, infinity_protocol::SessionInfo>,
-    load_session_tx: mpsc::UnboundedSender<(Option<String>, bool)>,
+    initial_sessions: std::collections::HashMap<
+        infinity_protocol::ThreadRef,
+        infinity_protocol::SessionInfo,
+    >,
+    load_session_tx: mpsc::UnboundedSender<(Option<infinity_protocol::ThreadRef>, bool)>,
     model_switch_tx: mpsc::UnboundedSender<usize>,
     available_models: Vec<crate::model_picker::ModelInfo>,
     initial_message: Option<String>,
     mut session_rx: mpsc::UnboundedReceiver<SessionChanged>,
     mut model_switched_rx: mpsc::UnboundedReceiver<ModelSwitched>,
     mut sessions_updated_rx: mpsc::UnboundedReceiver<
-        std::collections::HashMap<String, infinity_protocol::SessionInfo>,
+        std::collections::HashMap<infinity_protocol::ThreadRef, infinity_protocol::SessionInfo>,
     >,
     soft_detach_tx: mpsc::UnboundedSender<()>,
     mut detach_result_rx: mpsc::UnboundedReceiver<DetachResult>,
@@ -180,8 +183,8 @@ where
     let mut spinner_state: Option<SpinnerState> = None;
     let mut thinking_start = Instant::now();
     let mut total_tokens_used = 0;
-    let mut thread_buffers: BTreeMap<String, String> = BTreeMap::new();
-    let mut thread_tool_call_active: HashSet<String> = HashSet::new();
+    let mut thread_buffers: BTreeMap<infinity_protocol::ThreadRef, String> = BTreeMap::new();
+    let mut thread_tool_call_active: HashSet<infinity_protocol::ThreadRef> = HashSet::new();
     let mut thinking_text_buffer = String::new();
     // Number of root-thread tool calls still awaiting their result; the
     // "waiting for tool call result" spinner text is cleared when it hits 0.
@@ -261,7 +264,7 @@ where
 
                 // Only the currently viewed thread's model is shown in the
                 // status line; switches on other threads don't affect it.
-                if thread_id.as_deref() == Some(switched.thread_id.as_str()) {
+                if thread_id.as_ref() == Some(&switched.thread_id) {
                     model_name = switched.model_name;
                     provider_id = switched.provider_id;
                     context_window = switched.context_window;
@@ -292,7 +295,7 @@ where
                 if let Some(session_picker) = session_picker.as_mut() {
                     let last_picked_id = session_picker.sessions.get(session_picker.selected).map(|s| s.0.clone());
 
-                    let mut all_sessions: Vec<(String, infinity_protocol::SessionInfo)> = sessions.iter()
+                    let mut all_sessions: Vec<(infinity_protocol::ThreadRef, infinity_protocol::SessionInfo)> = sessions.iter()
                         .map(|(id, info)| (id.clone(), info.clone()))
                         .collect();
                     all_sessions.sort_by(|a, b| b.1.last_updated.cmp(&a.1.last_updated));
@@ -382,8 +385,10 @@ where
                     return Ok(true);
                 };
                 let is_root = evt_thread_id.is_none() || evt_thread_id.as_ref() == thread_id.as_ref();
-                // For non-root events, the thread_id is always Some.
-                let child_tid = evt_thread_id.unwrap_or_default();
+                // For non-root events, the thread_id is always Some; root
+                // events never consult `child_tid`, so a placeholder is fine.
+                let child_tid =
+                    evt_thread_id.unwrap_or_else(|| infinity_protocol::ThreadRef::local("".into()));
                 match evt {
                     DisplayEvent::ThinkingStart => {
                         if is_root {
@@ -627,7 +632,12 @@ where
                     }
                     DisplayEvent::SubscriptionEvent { name, text } => {
                         end_stream(&mut viewport, &mut mid_stream)?;
-                        let pfx = if !is_root { format!("[{}] ", &child_tid[..child_tid.len().min(8)]) } else { String::new() };
+                        let pfx = if !is_root {
+                            let rendered = child_tid.to_string();
+                            format!("[{}] ", &rendered[..rendered.len().min(8)])
+                        } else {
+                            String::new()
+                        };
                         let name = strip_ansi(&name);
                         let text = strip_ansi(&text);
                         let lines: Vec<&str> = text.lines().collect();
@@ -903,7 +913,7 @@ where
                                                 }
                                             }
                                             Some("/load") => {
-                                                let mut all_sessions: Vec<(String, infinity_protocol::SessionInfo)> = sessions.iter()
+                                                let mut all_sessions: Vec<(infinity_protocol::ThreadRef, infinity_protocol::SessionInfo)> = sessions.iter()
                                                     .filter(|(_, info)| info.status != infinity_protocol::SessionStatus::Archived)
                                                     .map(|(id, info)| (id.clone(), info.clone()))
                                                     .collect();
@@ -1093,10 +1103,10 @@ fn draw_viewport<T: TermOut>(
     provider_id: &str,
     total_tokens_used: usize,
     context_window: usize,
-    thread_buffers: &BTreeMap<String, String>,
+    thread_buffers: &BTreeMap<infinity_protocol::ThreadRef, String>,
     thinking_text: &str,
     tab_complete: &Option<(String, usize)>,
-    thread_id: &Option<String>,
+    thread_id: &Option<infinity_protocol::ThreadRef>,
 ) -> Result<(), BoxError> {
     let max_context = context_window;
     let current_width = viewport.area().width;
@@ -1127,6 +1137,7 @@ fn draw_viewport<T: TermOut>(
         }
         UiMode::Normal { .. } => {
             if let Some(tid) = thread_id {
+                let tid = tid.to_string();
                 let short_id = if tid.len() > 8 {
                     &tid[..8]
                 } else {
@@ -1143,7 +1154,7 @@ fn draw_viewport<T: TermOut>(
     let thread_lines: Vec<Line<'_>> = thread_buffers
         .iter()
         .map(|(id, buf)| {
-            let prefix_len = unicode_width::UnicodeWidthStr::width(id.as_str()) + 1;
+            let prefix_len = unicode_width::UnicodeWidthStr::width(id.to_string().as_str()) + 1;
             let avail = (current_width as usize).saturating_sub(prefix_len);
             let tail = wrap_tail(buf, avail);
             Line::from(vec![

--- a/crates/infinity-agent-cli/tests/common/mod.rs
+++ b/crates/infinity-agent-cli/tests/common/mod.rs
@@ -47,7 +47,7 @@ use tokio::sync::mpsc;
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 /// The display-event payload type the harness feeds to the UI.
-pub type DisplayItem = (Option<String>, DisplayEvent);
+pub type DisplayItem = (Option<infinity_protocol::ThreadRef>, DisplayEvent);
 
 // ── Emulator abstraction ────────────────────────────────────────────────────
 
@@ -394,7 +394,7 @@ pub struct HarnessOptions {
     pub model_name: String,
     pub provider_id: String,
     pub context_window: usize,
-    pub initial_sessions: HashMap<String, SessionInfo>,
+    pub initial_sessions: HashMap<infinity_protocol::ThreadRef, SessionInfo>,
     pub available_models: Vec<ModelInfo>,
     pub initial_message: Option<String>,
 }
@@ -435,10 +435,11 @@ pub struct TuiHarness {
     pub display_tx: mpsc::UnboundedSender<DisplayItem>,
     pub session_tx: mpsc::UnboundedSender<SessionChanged>,
     pub model_switched_tx: mpsc::UnboundedSender<terminal::ModelSwitched>,
-    pub sessions_updated_tx: mpsc::UnboundedSender<HashMap<String, SessionInfo>>,
+    pub sessions_updated_tx:
+        mpsc::UnboundedSender<HashMap<infinity_protocol::ThreadRef, SessionInfo>>,
     pub detach_result_tx: mpsc::UnboundedSender<DetachResult>,
     pub input_rx: mpsc::UnboundedReceiver<String>,
-    pub load_session_rx: mpsc::UnboundedReceiver<(Option<String>, bool)>,
+    pub load_session_rx: mpsc::UnboundedReceiver<(Option<infinity_protocol::ThreadRef>, bool)>,
     pub model_switch_rx: mpsc::UnboundedReceiver<usize>,
     pub soft_detach_rx: mpsc::UnboundedReceiver<()>,
     pub choice_answered_rx: mpsc::UnboundedReceiver<(String, usize)>,
@@ -565,7 +566,7 @@ impl TuiHarness {
     /// Send a display event attributed to a child thread.
     pub fn display_for_thread(&self, thread_id: &str, event: DisplayEvent) {
         self.display_tx
-            .send((Some(thread_id.to_owned()), event))
+            .send((Some(thread_id.into()), event))
             .expect("bug: UI task dropped display channel");
     }
 

--- a/crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
+++ b/crates/infinity-agent-cli/tests/tui_flow_snapshots.rs
@@ -28,7 +28,7 @@ fn usage(total: u64) -> Usage {
 fn send_session(h: &TuiHarness, id: &str, title: &str, tokens: usize) {
     h.session_tx
         .send(SessionChanged {
-            session_id: id.to_owned(),
+            session_id: id.into(),
             title: Some(title.to_owned()),
             total_tokens_used: tokens,
             model_name: "mock-model".to_owned(),
@@ -353,7 +353,7 @@ async fn queued_choices_and_external_complete() {
 async fn sessions_updated_while_picker_open() {
     let mut sessions = std::collections::HashMap::new();
     sessions.insert(
-        "session-aaaa".to_owned(),
+        "session-aaaa".into(),
         infinity_protocol::SessionInfo {
             title: Some("Old title".to_owned()),
             last_updated: "2025-01-01T00:00:00Z".to_owned(),
@@ -378,7 +378,7 @@ async fn sessions_updated_while_picker_open() {
 
     let mut updates = std::collections::HashMap::new();
     updates.insert(
-        "session-aaaa".to_owned(),
+        "session-aaaa".into(),
         infinity_protocol::SessionInfo {
             title: Some("Renamed title".to_owned()),
             last_updated: "2025-01-02T00:00:00Z".to_owned(),
@@ -389,7 +389,7 @@ async fn sessions_updated_while_picker_open() {
         },
     );
     updates.insert(
-        "session-bbbb".to_owned(),
+        "session-bbbb".into(),
         infinity_protocol::SessionInfo {
             title: Some("Brand new session".to_owned()),
             last_updated: "2025-01-03T00:00:00Z".to_owned(),

--- a/crates/infinity-agent-cli/tests/tui_reflow_snapshots.rs
+++ b/crates/infinity-agent-cli/tests/tui_reflow_snapshots.rs
@@ -351,7 +351,7 @@ async fn vertical_shrink_under_session_picker() {
     let mut sessions = HashMap::new();
     for i in 1..=8 {
         sessions.insert(
-            format!("session-{i:04}aaaa-bbbb-cccc"),
+            format!("session-{i:04}aaaa-bbbb-cccc").as_str().into(),
             SessionInfo {
                 title: Some(format!("Session number {i}")),
                 last_updated: format!("2025-01-{:02}T00:00:00Z", i),

--- a/crates/infinity-agent-cli/tests/tui_snapshots.rs
+++ b/crates/infinity-agent-cli/tests/tui_snapshots.rs
@@ -181,7 +181,7 @@ async fn session_loaded_updates_title_and_status() {
 
     h.session_tx
         .send(infinity_agent_cli::terminal::SessionChanged {
-            session_id: "f00dcafe-1234-5678-9abc-def012345678".to_owned(),
+            session_id: "f00dcafe-1234-5678-9abc-def012345678".into(),
             title: Some("My fancy session".to_owned()),
             total_tokens_used: 42_000,
             model_name: "mock-model".to_owned(),
@@ -200,7 +200,7 @@ async fn session_loaded_updates_model_name() {
     // Load a session whose thread uses a different model than the default.
     h.session_tx
         .send(infinity_agent_cli::terminal::SessionChanged {
-            session_id: "aaa-bbb".to_owned(),
+            session_id: "aaa-bbb".into(),
             title: Some("Other model session".to_owned()),
             total_tokens_used: 10_000,
             model_name: "Mock Mini".to_owned(),

--- a/crates/infinity-agent-lambda/src/event_handler.rs
+++ b/crates/infinity-agent-lambda/src/event_handler.rs
@@ -331,7 +331,7 @@ impl ThreadConfigSource<SqsMessageSender, RapHttpClient> for LambdaThreadConfig 
         if !self.toolset_server_urls.is_empty() {
             match self
                 .toolset_loader
-                .load_toolsets(&self.toolset_server_urls, thread_id.as_str())
+                .load_toolsets(&self.toolset_server_urls, thread_id)
                 .await
             {
                 Ok(loaded) => {

--- a/crates/infinity-daemon/src/client_handler.rs
+++ b/crates/infinity-daemon/src/client_handler.rs
@@ -354,7 +354,8 @@ pub async fn handle_client_channels(
                     let _ = daemon_tx.send(DaemonMessage::Error { thread_id: None, text: format!("Remote '{rn}' connection closed") });
                     break;
                 };
-                let rn = active_remote_name.clone().unwrap_or_else(|| "".into());
+                let rn = active_remote_name.clone()
+                    .expect("bug: remote proxy active but no remote name");
                 if daemon_tx.send(prefix_daemon_message(msg, &rn)).is_err() { break; }
             }
             // Handle client messages
@@ -367,7 +368,6 @@ pub async fn handle_client_channels(
 
                 // If connected to a remote session, forward most messages there
                 if let Some(ref proxy_tx) = remote_proxy_tx {
-                    let rn = active_remote_name.clone().unwrap_or_else(|| "".into());
                     match &msg {
                         ClientMessage::Disconnect => {
                             // Disconnect from remote: drop proxy, also disconnect locally
@@ -398,7 +398,9 @@ pub async fn handle_client_channels(
                         }
                         _ => {
                             // Forward everything else to remote (stripped)
-                            let _ = proxy_tx.send(strip_client_message(msg, &rn));
+                            let rn = active_remote_name.as_ref()
+                                .expect("bug: remote proxy active but no remote name");
+                            let _ = proxy_tx.send(strip_client_message(msg, rn));
                             continue;
                         }
                     }

--- a/crates/infinity-daemon/src/client_handler.rs
+++ b/crates/infinity-daemon/src/client_handler.rs
@@ -208,11 +208,8 @@ fn prefix_daemon_message(msg: DaemonMessage, remote_name: &RemoteName) -> Daemon
 
 fn strip_client_message(msg: ClientMessage, remote_name: &RemoteName) -> ClientMessage {
     match msg {
-        ClientMessage::UserInput {
-            root_thread_id,
-            text,
-        } => ClientMessage::UserInput {
-            root_thread_id: root_thread_id.strip(remote_name),
+        ClientMessage::UserInput { thread_id, text } => ClientMessage::UserInput {
+            thread_id: thread_id.strip(remote_name),
             text,
         },
         ClientMessage::SoftDetach { root_thread_id } => ClientMessage::SoftDetach {
@@ -499,7 +496,7 @@ pub async fn handle_client_channels(
                             }
                         }
                     }
-                    ClientMessage::UserInput { root_thread_id: thread_id, text } => {
+                    ClientMessage::UserInput { thread_id, text } => {
                         if thread_id.remote.is_some() {
                             let _ = daemon_tx.send(DaemonMessage::Error { thread_id: Some(thread_id), text: "remote is not connected".into() });
                             continue;

--- a/crates/infinity-daemon/src/client_handler.rs
+++ b/crates/infinity-daemon/src/client_handler.rs
@@ -4,7 +4,9 @@ use infinity_agent_core::ThreadId;
 use infinity_agent_core::message::{
     InputMessage, InputMessageContent, SyntheticKind, TaggedSyntheticKind,
 };
-use infinity_protocol::{ClientMessage, DaemonMessage, length_delimited_codec};
+use infinity_protocol::{
+    ClientMessage, DaemonMessage, RemoteName, ThreadRef, length_delimited_codec,
+};
 use infinity_provider_protocol::message::UserContent;
 use tokio::net::UnixStream;
 use tokio::sync::mpsc;
@@ -54,19 +56,14 @@ async fn list_directory_completions(input: &str) -> Vec<String> {
     entries
 }
 
-/// Split "remote_name/real_id" into (remote_name, real_id).
-fn is_remote_session(session_id: &str) -> Option<(&str, &str)> {
-    session_id.split_once('/')
+fn prefix_thread_id(thread_id: Option<ThreadRef>, remote_name: &RemoteName) -> Option<ThreadRef> {
+    thread_id.map(|id| id.prefixed(remote_name))
 }
 
-fn prefix_thread_id(thread_id: Option<String>, remote_name: &str) -> Option<String> {
-    thread_id.map(|id| format!("{remote_name}/{id}"))
-}
-
-fn prefix_daemon_message(msg: DaemonMessage, remote_name: &str) -> DaemonMessage {
+fn prefix_daemon_message(msg: DaemonMessage, remote_name: &RemoteName) -> DaemonMessage {
     match msg {
         DaemonMessage::Connected {
-            session_id,
+            root_thread_id,
             thread_id,
             model_name,
             context_window,
@@ -74,8 +71,8 @@ fn prefix_daemon_message(msg: DaemonMessage, remote_name: &str) -> DaemonMessage
             total_tokens_used,
             provider_id,
         } => DaemonMessage::Connected {
-            session_id: format!("{remote_name}/{session_id}"),
-            thread_id: format!("{remote_name}/{thread_id}"),
+            root_thread_id: root_thread_id.prefixed(remote_name),
+            thread_id: thread_id.prefixed(remote_name),
             model_name,
             context_window,
             title,
@@ -170,7 +167,7 @@ fn prefix_daemon_message(msg: DaemonMessage, remote_name: &str) -> DaemonMessage
             context_window,
             provider_id,
         } => DaemonMessage::ModelSwitched {
-            thread_id: format!("{remote_name}/{thread_id}"),
+            thread_id: thread_id.prefixed(remote_name),
             model_name,
             context_window,
             provider_id,
@@ -209,33 +206,30 @@ fn prefix_daemon_message(msg: DaemonMessage, remote_name: &str) -> DaemonMessage
     }
 }
 
-fn strip_id(id: &str, remote_name: &str) -> String {
-    id.strip_prefix(&format!("{remote_name}/"))
-        .unwrap_or(id)
-        .to_owned()
-}
-
-fn strip_client_message(msg: ClientMessage, remote_name: &str) -> ClientMessage {
+fn strip_client_message(msg: ClientMessage, remote_name: &RemoteName) -> ClientMessage {
     match msg {
-        ClientMessage::UserInput { session_id, text } => ClientMessage::UserInput {
-            session_id: strip_id(&session_id, remote_name),
+        ClientMessage::UserInput {
+            root_thread_id,
+            text,
+        } => ClientMessage::UserInput {
+            root_thread_id: root_thread_id.strip(remote_name),
             text,
         },
-        ClientMessage::SoftDetach { session_id } => ClientMessage::SoftDetach {
-            session_id: strip_id(&session_id, remote_name),
+        ClientMessage::SoftDetach { root_thread_id } => ClientMessage::SoftDetach {
+            root_thread_id: root_thread_id.strip(remote_name),
         },
-        ClientMessage::ShutdownSession { session_id } => ClientMessage::ShutdownSession {
-            session_id: strip_id(&session_id, remote_name),
+        ClientMessage::ShutdownSession { root_thread_id } => ClientMessage::ShutdownSession {
+            root_thread_id: root_thread_id.strip(remote_name),
         },
-        ClientMessage::ArchiveSession { session_id } => ClientMessage::ArchiveSession {
-            session_id: strip_id(&session_id, remote_name),
+        ClientMessage::ArchiveSession { root_thread_id } => ClientMessage::ArchiveSession {
+            root_thread_id: root_thread_id.strip(remote_name),
         },
-        ClientMessage::SwitchModel { session_id, model } => ClientMessage::SwitchModel {
-            session_id: strip_id(&session_id, remote_name),
+        ClientMessage::SwitchModel { thread_id, model } => ClientMessage::SwitchModel {
+            thread_id: thread_id.strip(remote_name),
             model,
         },
-        ClientMessage::TriggerCompaction { session_id } => ClientMessage::TriggerCompaction {
-            session_id: strip_id(&session_id, remote_name),
+        ClientMessage::TriggerCompaction { root_thread_id } => ClientMessage::TriggerCompaction {
+            root_thread_id: root_thread_id.strip(remote_name),
         },
         other => other,
     }
@@ -306,7 +300,7 @@ pub async fn handle_client_channels(
     let mut attached_thread_id: Option<ThreadId> = None;
     let mut remote_proxy_tx: Option<mpsc::UnboundedSender<ClientMessage>> = None;
     let mut remote_proxy_rx: Option<mpsc::UnboundedReceiver<DaemonMessage>> = None;
-    let mut active_remote_name: Option<String> = None;
+    let mut active_remote_name: Option<RemoteName> = None;
     let mut _booted_rap_servers: Vec<crate::rap_servers::MigrationServer> = Vec::new(); // prevents shutdown until close
 
     // Send Welcome immediately
@@ -359,12 +353,12 @@ pub async fn handle_client_channels(
                 }
             } => {
                 let Some(msg) = msg else {
-                    let rn = active_remote_name.as_deref().unwrap_or("unknown");
+                    let rn = active_remote_name.as_ref().map(|r| r.as_str()).unwrap_or("unknown");
                     let _ = daemon_tx.send(DaemonMessage::Error { thread_id: None, text: format!("Remote '{rn}' connection closed") });
                     break;
                 };
-                let rn = active_remote_name.as_deref().unwrap_or("");
-                if daemon_tx.send(prefix_daemon_message(msg, rn)).is_err() { break; }
+                let rn = active_remote_name.clone().unwrap_or_else(|| "".into());
+                if daemon_tx.send(prefix_daemon_message(msg, &rn)).is_err() { break; }
             }
             // Handle client messages
             msg = client_rx.recv() => {
@@ -376,7 +370,7 @@ pub async fn handle_client_channels(
 
                 // If connected to a remote session, forward most messages there
                 if let Some(ref proxy_tx) = remote_proxy_tx {
-                    let rn = active_remote_name.as_deref().unwrap_or("");
+                    let rn = active_remote_name.clone().unwrap_or_else(|| "".into());
                     match &msg {
                         ClientMessage::Disconnect => {
                             // Disconnect from remote: drop proxy, also disconnect locally
@@ -407,7 +401,7 @@ pub async fn handle_client_channels(
                         }
                         _ => {
                             // Forward everything else to remote (stripped)
-                            let _ = proxy_tx.send(strip_client_message(msg, rn));
+                            let _ = proxy_tx.send(strip_client_message(msg, &rn));
                             continue;
                         }
                     }
@@ -459,32 +453,32 @@ pub async fn handle_client_channels(
                                 }
                             }
                         }
-                    ClientMessage::Connect { session_id, thread_id, keeps_session_alive } => {
-                        if let Some((rname, real_session_id)) = is_remote_session(&session_id) {
-                            let real_thread_id = thread_id.as_deref().map(|t| strip_id(t, rname));
-                            let rname = rname.to_owned();
+                    ClientMessage::Connect { root_thread_id, thread_id, keeps_session_alive } => {
+                        if let Some(rname) = root_thread_id.remote.clone() {
+                            let real_session_id = root_thread_id.id.clone();
+                            let real_thread_id = thread_id.clone().map(|t| t.strip(&rname).id);
                             let rd = {
                                 let mgr = session_manager.lock().await;
                                 mgr.remote_daemons.clone()
                             };
                             if let Some(rd) = rd {
-                                match rd.connect_remote_session(&rname, real_session_id, real_thread_id.as_deref()).await {
+                                match rd.connect_remote_session(&rname, &real_session_id, real_thread_id.as_deref()).await {
                                     Ok((tx, rx)) => {
                                         remote_proxy_tx = Some(tx);
                                         remote_proxy_rx = Some(rx);
                                         active_remote_name = Some(rname);
-                                        attached_session_id = Some(ThreadId::from(session_id));
+                                        attached_session_id = Some(real_session_id);
                                     }
                                     Err(e) => {
                                         let _ = daemon_tx.send(DaemonMessage::Error {
-                                            thread_id: Some(session_id),
+                                            thread_id: Some(root_thread_id),
                                             text: format!("failed to connect to remote: {e}"),
                                         });
                                     }
                                 }
                             } else {
                                 let _ = daemon_tx.send(DaemonMessage::Error {
-                                    thread_id: Some(session_id),
+                                    thread_id: Some(root_thread_id),
                                     text: "no remote daemons configured".into(),
                                 });
                             }
@@ -493,20 +487,20 @@ pub async fn handle_client_channels(
                             let mut emit = async |msg: DaemonMessage| {
                                 let _ = daemon_tx.send(msg);
                             };
-                            let session_tid = ThreadId::from(session_id.as_str());
-                            let target = thread_id.as_deref().map(ThreadId::from).unwrap_or_else(|| session_tid.clone());
+                            let session_tid = root_thread_id.id.clone();
+                            let target = thread_id.map(|t| t.id).unwrap_or_else(|| session_tid.clone());
                             match mgr.resume_session(&session_tid, &target, &mut emit).await {
                                 Ok(()) => {
                                     mgr.attach_client(&target, client_tx.clone(), true, keeps_session_alive).await;
                                     attached_thread_id = Some(target);
                                     attached_session_id = Some(session_tid);
                                 }
-                                Err(e) => { let _ = daemon_tx.send(DaemonMessage::Error { thread_id: Some(session_id), text: format!("failed to resume session: {e}") }); }
+                                Err(e) => { let _ = daemon_tx.send(DaemonMessage::Error { thread_id: Some(root_thread_id), text: format!("failed to resume session: {e}") }); }
                             }
                         }
                     }
-                    ClientMessage::UserInput { session_id: thread_id, text } => {
-                        if is_remote_session(&thread_id).is_some() {
+                    ClientMessage::UserInput { root_thread_id: thread_id, text } => {
+                        if thread_id.remote.is_some() {
                             let _ = daemon_tx.send(DaemonMessage::Error { thread_id: Some(thread_id), text: "remote is not connected".into() });
                             continue;
                         }
@@ -515,7 +509,7 @@ pub async fn handle_client_channels(
                             .send_input((
                                 InputMessage {
                                     content: InputMessageContent::User(UserContent::text(&text)),
-                                    group_id: thread_id.clone().into(),
+                                    group_id: thread_id.id.clone(),
                                     metadata: None,
                                     synthetic: None,
                                     display_as: None,
@@ -542,8 +536,8 @@ pub async fn handle_client_channels(
                         attached_session_id = None;
                         attached_thread_id = None;
                     }
-                    ClientMessage::SoftDetach { session_id } => {
-                        let session_id = ThreadId::from(session_id);
+                    ClientMessage::SoftDetach { root_thread_id } => {
+                        let session_id = root_thread_id.id;
                         let mgr = session_manager.lock().await;
                         let do_cleanup = mgr.is_session_idle(&session_id);
                         tracing::debug!(do_cleanup, "Handling SoftDetach");
@@ -559,15 +553,15 @@ pub async fn handle_client_channels(
                             let _ = daemon_tx.send(DaemonMessage::DisconnectNotIdle);
                         }
                     }
-                    ClientMessage::ShutdownSession { session_id } => {
-                        let session_id = ThreadId::from(session_id);
+                    ClientMessage::ShutdownSession { root_thread_id } => {
+                        let session_id = root_thread_id.id;
                         let mgr = session_manager.lock().await;
                         mgr.cleanup_session(&session_id).await;
                         attached_session_id = None;
                         attached_thread_id = None;
                     }
-                    ClientMessage::ArchiveSession { session_id } => {
-                        let session_id = ThreadId::from(session_id);
+                    ClientMessage::ArchiveSession { root_thread_id } => {
+                        let session_id = root_thread_id.id;
                         let mgr = session_manager.lock().await;
                         mgr.cleanup_session(&session_id).await;
                         let mut store = mgr.session_store.lock().await;
@@ -578,12 +572,12 @@ pub async fn handle_client_channels(
                         attached_session_id = None;
                         attached_thread_id = None;
                     }
-                    ClientMessage::TriggerCompaction { session_id } => {
+                    ClientMessage::TriggerCompaction { root_thread_id } => {
                         let mgr = session_manager.lock().await;
                         mgr.send_input((
                             InputMessage {
                                 content: InputMessageContent::User(UserContent::text("")),
-                                group_id: session_id.clone().into(),
+                                group_id: root_thread_id.id.clone(),
                                 metadata: None,
                                 synthetic: Some(SyntheticKind::Tagged(
                                     TaggedSyntheticKind::Compaction,
@@ -595,12 +589,12 @@ pub async fn handle_client_channels(
                         ))
                         .await;
                     }
-                    ClientMessage::SwitchModel { session_id: thread_id, model } => {
+                    ClientMessage::SwitchModel { thread_id, model } => {
                         let mgr = session_manager.lock().await;
                         // `switch_model` delivers the confirmation to this
                         // client exactly once: via its subscription when
                         // attached, directly otherwise.
-                        if let Err(e) = mgr.switch_model(&ThreadId::from(thread_id.as_str()), model, Some(&client_tx)) {
+                        if let Err(e) = mgr.switch_model(&thread_id.id, model, Some(&client_tx)) {
                             let _ = daemon_tx.send(DaemonMessage::Error {
                                 thread_id: Some(thread_id),
                                 text: format!("failed to switch model: {e}"),
@@ -627,20 +621,20 @@ pub async fn handle_client_channels(
                             }
                         }
                     }
-                    ClientMessage::RequestMigrate { session_id, to, dest_cwd } => {
+                    ClientMessage::RequestMigrate { root_thread_id, to, dest_cwd } => {
                         let mgr = session_manager.clone();
                         let tx = daemon_tx.clone();
                         tokio::task::spawn_local(crate::migrate::orchestrate_migration(
-                            session_id, to, dest_cwd, mgr, tx,
+                            root_thread_id, to, dest_cwd, mgr, tx,
                         ));
                     }
-                    ClientMessage::Emigrate { session_id, dest_rap_urls } => {
+                    ClientMessage::Emigrate { root_thread_id, dest_rap_urls } => {
                         // Daemon-to-daemon: shut down session, migrate RAP servers, serialize, return data
                         let mgr = session_manager.clone();
-                        match crate::migrate::handle_emigrate(&ThreadId::from(session_id.as_str()), dest_rap_urls, &mgr).await {
+                        match crate::migrate::handle_emigrate(&root_thread_id, dest_rap_urls, &mgr).await {
                             Ok(data) => {
                                 let _ = daemon_tx.send(DaemonMessage::EmigrateResult {
-                                    session_id,
+                                    root_thread_id,
                                     session_data: data,
                                 });
                             }
@@ -652,25 +646,24 @@ pub async fn handle_client_channels(
                             }
                         }
                     }
-                    ClientMessage::EmigrateDone { session_id } => {
+                    ClientMessage::EmigrateDone { root_thread_id } => {
                         // Daemon-to-daemon: immigration complete, archive local session
-                        let session_id = ThreadId::from(session_id);
+                        let session_id = root_thread_id;
                         let mgr = session_manager.lock().await;
                         let mut store = mgr.session_store.lock().await;
                         store.mark_archived(&session_id);
                         let _ = store.save();
                     }
-                    ClientMessage::ImportSession { session_id, cwd, session_data } => {
+                    ClientMessage::ImportSession { root_thread_id, cwd, session_data } => {
                         // Daemon-to-daemon: import a serialized session
                         let mgr = session_manager.lock().await;
                         match mgr.conversation_store().import_session(&session_data) {
                             Ok(()) => {
                                 let mut store = mgr.session_store.lock().await;
-                                let session_tid = ThreadId::from(session_id.as_str());
-                                store.create(&session_tid, cwd);
-                                store.mark_shut_down(&session_tid);
+                                store.create(&root_thread_id, cwd);
+                                store.mark_shut_down(&root_thread_id);
                                 let _ = store.save();
-                                let _ = daemon_tx.send(DaemonMessage::ImportComplete { session_id });
+                                let _ = daemon_tx.send(DaemonMessage::ImportComplete { root_thread_id });
                             }
                             Err(e) => {
                                 let _ = daemon_tx.send(DaemonMessage::Error {

--- a/crates/infinity-daemon/src/ids.rs
+++ b/crates/infinity-daemon/src/ids.rs
@@ -10,10 +10,12 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use infinity_agent_core::ThreadId;
+
 /// A source of unique ids.
 pub trait IdSource: Send + Sync {
     /// Generate the next id.
-    fn generate(&self) -> String;
+    fn generate(&self) -> ThreadId;
 }
 
 /// Random v4 UUIDs — the production default.
@@ -21,8 +23,8 @@ pub trait IdSource: Send + Sync {
 pub struct UuidIdSource;
 
 impl IdSource for UuidIdSource {
-    fn generate(&self) -> String {
-        uuid::Uuid::new_v4().to_string()
+    fn generate(&self) -> ThreadId {
+        ThreadId::from(uuid::Uuid::new_v4().to_string())
     }
 }
 
@@ -40,9 +42,9 @@ impl SequentialIdSource {
 }
 
 impl IdSource for SequentialIdSource {
-    fn generate(&self) -> String {
+    fn generate(&self) -> ThreadId {
         let n = self.counter.fetch_add(1, Ordering::Relaxed) + 1;
-        format!("00000000-0000-4000-8000-{n:012x}")
+        ThreadId::from(format!("00000000-0000-4000-8000-{n:012x}"))
     }
 }
 
@@ -55,10 +57,19 @@ mod tests {
     #[test]
     fn sequential_ids_are_stable_and_shared() {
         let ids: Arc<dyn IdSource> = Arc::new(SequentialIdSource::new());
-        assert_eq!(ids.generate(), "00000000-0000-4000-8000-000000000001");
+        assert_eq!(
+            ids.generate().as_str(),
+            "00000000-0000-4000-8000-000000000001"
+        );
         let shared = Arc::clone(&ids);
-        assert_eq!(shared.generate(), "00000000-0000-4000-8000-000000000002");
-        assert_eq!(ids.generate(), "00000000-0000-4000-8000-000000000003");
+        assert_eq!(
+            shared.generate().as_str(),
+            "00000000-0000-4000-8000-000000000002"
+        );
+        assert_eq!(
+            ids.generate().as_str(),
+            "00000000-0000-4000-8000-000000000003"
+        );
     }
 
     #[test]

--- a/crates/infinity-daemon/src/memory_store.rs
+++ b/crates/infinity-daemon/src/memory_store.rs
@@ -565,8 +565,8 @@ impl PersistentConversationStore {
                         extras.get(&child_id).and_then(|e| e.title.clone())
                     };
                     result.push(infinity_protocol::SubthreadInfo {
-                        thread_id: child_id.to_string(),
-                        parent_thread_id: pid.to_string(),
+                        thread_id: infinity_protocol::ThreadRef::local(child_id.clone()),
+                        parent_thread_id: infinity_protocol::ThreadRef::local(pid.clone()),
                         title,
                     });
                     queue.push(child_id);
@@ -814,7 +814,7 @@ impl ConversationStore for PersistentConversationStore {
         spawn_order_override: Option<usize>,
     ) -> Result<ThreadId, MemoryError> {
         self.ensure_thread_loaded(parent_thread_id);
-        let new_id = ThreadId::from(self.id_source.generate());
+        let new_id = self.id_source.generate();
         {
             // Hold the load-tracking locks while creating the thread so a
             // concurrent load cannot interleave with the creation.

--- a/crates/infinity-daemon/src/migrate.rs
+++ b/crates/infinity-daemon/src/migrate.rs
@@ -7,7 +7,7 @@ use infinity_agent_core::ThreadId;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use infinity_protocol::{ClientMessage, DaemonMessage};
+use infinity_protocol::{ClientMessage, DaemonMessage, RemoteName, ThreadRef};
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::rap_servers::{MigrationServer, boot_migration_servers, migration_server_ports};
@@ -19,36 +19,31 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 /// Run the full migration flow for a `RequestMigrate` message.
 /// This is spawned as a task from the client handler.
 pub async fn orchestrate_migration(
-    session_id: String,
-    to: Option<String>,
+    root_thread_id: ThreadRef,
+    to: Option<RemoteName>,
     dest_cwd: PathBuf,
     session_manager: SharedSessionManager,
     daemon_tx: UnboundedSender<DaemonMessage>,
 ) {
     let _ = daemon_tx.send(DaemonMessage::MigrateStarted {
-        session_id: session_id.clone(),
+        root_thread_id: root_thread_id.clone(),
     });
 
-    let real_session_id = ThreadId::from(
-        session_id
-            .split_once('/')
-            .map_or(session_id.as_str(), |(_, s)| s),
-    );
-    let new_session_id = match &to {
-        None => real_session_id.to_string(),
-        Some(remote) => format!("{remote}/{real_session_id}"),
+    let new_root_thread_id = ThreadRef {
+        remote: to.clone(),
+        id: root_thread_id.id.clone(),
     };
 
-    match run_migration(&session_id, to.as_deref(), &dest_cwd, &session_manager).await {
+    match run_migration(&root_thread_id, to.as_ref(), &dest_cwd, &session_manager).await {
         Ok(()) => {
             let _ = daemon_tx.send(DaemonMessage::MigrateComplete {
-                session_id,
-                new_session_id,
+                root_thread_id,
+                new_root_thread_id,
             });
         }
         Err(e) => {
             let _ = daemon_tx.send(DaemonMessage::MigrateError {
-                session_id,
+                root_thread_id,
                 error: e.to_string(),
             });
         }
@@ -56,20 +51,14 @@ pub async fn orchestrate_migration(
 }
 
 async fn run_migration(
-    session_id: &str,
-    to: Option<&str>,
+    session_ref: &ThreadRef,
+    to: Option<&RemoteName>,
     dest_cwd: &Path,
     session_manager: &SharedSessionManager,
 ) -> Result<(), BoxError> {
-    let source_is_local = !session_id.contains('/');
-    let (source_remote, real_session_id) = if source_is_local {
-        (None, ThreadId::from(session_id))
-    } else {
-        let (r, s) = session_id
-            .split_once('/')
-            .ok_or("invalid remote session id")?;
-        (Some(r.to_owned()), ThreadId::from(s))
-    };
+    let source_is_local = session_ref.remote.is_none();
+    let source_remote = session_ref.remote.clone();
+    let real_session_id = session_ref.id.clone();
     let dest_is_local = to.is_none();
 
     // Shut down the source session first (kills agent + original RAP servers)
@@ -107,7 +96,7 @@ async fn run_migration(
             rap_client::http::SimpleHttpClient::new(),
         );
         if let Err(errors) = notifier
-            .request_migration(real_session_id.as_str(), &migration_servers, &dest_rap_urls)
+            .request_migration(&real_session_id, &migration_servers, &dest_rap_urls)
             .await
         {
             return Err(format!("RAP migration failed: {}", errors.join("; ")).into());
@@ -128,9 +117,9 @@ async fn run_migration(
         emigrate_from_remote(
             &rd,
             source_remote
-                .as_deref()
+                .as_ref()
                 .expect("bug: source remote but no name"),
-            real_session_id.as_str(),
+            &real_session_id,
             dest_rap_urls,
         )
         .await?
@@ -158,7 +147,7 @@ async fn run_migration(
         immigrate_to_remote(
             &rd,
             to.expect("bug: dest is remote"),
-            real_session_id.as_str(),
+            &real_session_id,
             dest_cwd,
             &session_data,
         )
@@ -181,9 +170,9 @@ async fn run_migration(
             send_emigrate_done(
                 &rd,
                 source_remote
-                    .as_deref()
+                    .as_ref()
                     .expect("bug: source remote but no name"),
-                real_session_id.as_str(),
+                &real_session_id,
             )
             .await?;
         }
@@ -242,7 +231,7 @@ pub async fn handle_emigrate(
             rap_client::http::SimpleHttpClient::new(),
         );
         if let Err(errors) = notifier
-            .request_migration(session_id.as_str(), &migration_servers, &dest_rap_urls)
+            .request_migration(session_id, &migration_servers, &dest_rap_urls)
             .await
         {
             return Err(format!("RAP migration failed: {}", errors.join("; ")).into());
@@ -261,9 +250,9 @@ pub enum LocalOrRemoteSpawned {
 /// Boot RAP servers on the destination and set up SSH tunnels so the source can reach them.
 /// Returns (config_id → reachable_url, tunnel guards, spawned dest servers).
 async fn boot_dest_and_tunnel(
-    to: Option<&str>,
+    to: Option<&RemoteName>,
     dest_cwd: &Path,
-    source_remote: &Option<String>,
+    source_remote: &Option<RemoteName>,
     session_manager: &SharedSessionManager,
 ) -> Result<
     (
@@ -322,7 +311,7 @@ async fn boot_dest_and_tunnel(
         };
         let rd = rd.ok_or("no remote daemons configured")?;
         let source_remote_name = source_remote
-            .as_deref()
+            .as_ref()
             .expect("bug: source remote but no name");
         let ssh_args = rd
             .get_ssh_args(source_remote_name)
@@ -360,7 +349,7 @@ async fn boot_dest_and_tunnel(
             .get_ssh_args(to.expect("bug: dest is remote"))
             .ok_or("unknown dest remote")?;
         let source_remote_name = source_remote
-            .as_deref()
+            .as_ref()
             .expect("bug: source remote but no name");
         let source_ssh_args = rd
             .get_ssh_args(source_remote_name)
@@ -384,14 +373,14 @@ async fn boot_dest_and_tunnel(
 /// Send Emigrate to a remote daemon and receive the serialized session data.
 async fn emigrate_from_remote(
     rd: &RemoteDaemons,
-    remote_name: &str,
-    session_id: &str,
+    remote_name: &RemoteName,
+    session_id: &ThreadId<str>,
     dest_rap_urls: HashMap<String, String>,
 ) -> Result<String, BoxError> {
     let (tx, mut rx) = rd.open_raw_connection(remote_name).await?;
 
     tx.send(ClientMessage::Emigrate {
-        session_id: session_id.to_owned(),
+        root_thread_id: session_id.to_owned(),
         dest_rap_urls,
     })?;
 
@@ -405,15 +394,15 @@ async fn emigrate_from_remote(
 /// Send session data to a remote daemon for immigration.
 async fn immigrate_to_remote(
     rd: &RemoteDaemons,
-    remote_name: &str,
-    session_id: &str,
+    remote_name: &RemoteName,
+    session_id: &ThreadId<str>,
     dest_cwd: &Path,
     session_data: &str,
 ) -> Result<(), BoxError> {
     let (tx, mut rx) = rd.open_raw_connection(remote_name).await?;
 
     tx.send(ClientMessage::ImportSession {
-        session_id: session_id.to_owned(),
+        root_thread_id: session_id.to_owned(),
         cwd: dest_cwd.to_path_buf(),
         session_data: session_data.to_owned(),
     })?;
@@ -428,12 +417,12 @@ async fn immigrate_to_remote(
 /// Send EmigrateDone to a remote daemon so it can clean up.
 async fn send_emigrate_done(
     rd: &RemoteDaemons,
-    remote_name: &str,
-    session_id: &str,
+    remote_name: &RemoteName,
+    session_id: &ThreadId<str>,
 ) -> Result<(), BoxError> {
     let (tx, _rx) = rd.open_raw_connection(remote_name).await?;
     tx.send(ClientMessage::EmigrateDone {
-        session_id: session_id.to_owned(),
+        root_thread_id: session_id.to_owned(),
     })
     .map_err(|e| e.into())
 }

--- a/crates/infinity-daemon/src/rap_servers.rs
+++ b/crates/infinity-daemon/src/rap_servers.rs
@@ -461,7 +461,7 @@ impl SessionRapManager {
     /// Send an informational message to the session's subscribers.
     fn info(&self, session_id: &ThreadId<str>, text: String) {
         let msg = DaemonMessage::Info {
-            thread_id: Some(session_id.to_string()),
+            thread_id: Some(infinity_protocol::ThreadRef::local(session_id.to_owned())),
             text,
         };
         crate::session::observer::broadcast_to_thread(&self.subscriber_map, session_id, &msg, None);

--- a/crates/infinity-daemon/src/remote.rs
+++ b/crates/infinity-daemon/src/remote.rs
@@ -15,7 +15,7 @@ pub type BroadcastClients = Arc<std::sync::Mutex<Vec<mpsc::UnboundedSender<Daemo
 
 #[derive(serde::Serialize, Deserialize, Clone, Debug)]
 pub struct RemoteConfig {
-    pub name: String,
+    pub name: infinity_protocol::RemoteName,
     pub ssh_args: Vec<String>,
 }
 
@@ -36,14 +36,14 @@ pub enum RemoteStatus {
 
 pub struct RemoteState {
     pub status: RemoteStatus,
-    pub sessions: HashMap<String, SessionInfo>,
+    pub sessions: HashMap<infinity_protocol::ThreadRef, SessionInfo>,
     /// Local socket path for the SSH tunnel (set when connected).
     pub local_sock: Option<std::path::PathBuf>,
     /// SSH args for this remote.
     pub ssh_args: Vec<String>,
 }
 
-type RemoteMap = Arc<std::sync::Mutex<HashMap<String, RemoteState>>>;
+type RemoteMap = Arc<std::sync::Mutex<HashMap<infinity_protocol::RemoteName, RemoteState>>>;
 
 #[derive(Clone)]
 pub struct RemoteDaemons {
@@ -76,7 +76,7 @@ impl RemoteDaemons {
     }
 
     /// Collect all remote sessions with prefixed IDs (used for initial Welcome).
-    pub fn all_remote_sessions(&self) -> HashMap<String, SessionInfo> {
+    pub fn all_remote_sessions(&self) -> HashMap<infinity_protocol::ThreadRef, SessionInfo> {
         let map = self.remotes.lock().expect("bug: mutex poisoned");
         let mut result = HashMap::new();
         for (remote_name, state) in map.iter() {
@@ -87,10 +87,10 @@ impl RemoteDaemons {
                 let mut info = info.clone();
                 info.remote = Some(remote_name.clone());
                 for t in &mut info.threads {
-                    t.thread_id = format!("{remote_name}/{}", t.thread_id);
-                    t.parent_thread_id = format!("{remote_name}/{}", t.parent_thread_id);
+                    t.thread_id = t.thread_id.clone().prefixed(remote_name);
+                    t.parent_thread_id = t.parent_thread_id.clone().prefixed(remote_name);
                 }
-                result.insert(format!("{}/{}", remote_name, sid), info);
+                result.insert(sid.clone().prefixed(remote_name), info);
             }
         }
         result
@@ -100,9 +100,9 @@ impl RemoteDaemons {
     /// Reuses the existing SSH tunnel socket when available.
     pub async fn connect_remote_session(
         &self,
-        remote_name: &str,
-        session_id: &str,
-        thread_id: Option<&str>,
+        remote_name: &infinity_protocol::RemoteName,
+        session_id: &infinity_agent_core::ThreadId<str>,
+        thread_id: Option<&infinity_agent_core::ThreadId<str>>,
     ) -> Result<
         (
             mpsc::UnboundedSender<ClientMessage>,
@@ -114,8 +114,8 @@ impl RemoteDaemons {
 
         res.0
             .send(ClientMessage::Connect {
-                session_id: session_id.to_owned(),
-                thread_id: thread_id.map(|t| t.to_owned()),
+                root_thread_id: infinity_protocol::ThreadRef::local(session_id.to_owned()),
+                thread_id: thread_id.map(|t| infinity_protocol::ThreadRef::local(t.to_owned())),
                 keeps_session_alive: true,
             })
             .map_err(|e| format!("send Connect failed: {e}"))?;
@@ -127,7 +127,7 @@ impl RemoteDaemons {
     /// Used for migration flows where we send custom messages.
     pub async fn open_raw_connection(
         &self,
-        remote_name: &str,
+        remote_name: &infinity_protocol::RemoteName,
     ) -> Result<
         (
             mpsc::UnboundedSender<ClientMessage>,
@@ -208,7 +208,7 @@ impl RemoteDaemons {
     }
 
     /// Get the SSH args for a remote by name.
-    pub fn get_ssh_args(&self, remote_name: &str) -> Option<Vec<String>> {
+    pub fn get_ssh_args(&self, remote_name: &infinity_protocol::RemoteName) -> Option<Vec<String>> {
         let map = self.remotes.lock().expect("bug: mutex poisoned");
         map.get(remote_name).map(|s| s.ssh_args.clone())
     }
@@ -341,18 +341,18 @@ pub struct SshPortForward {
 
 /// Prefix session IDs in a sessions map with the remote name.
 fn prefix_sessions(
-    name: &str,
-    sessions: HashMap<String, SessionInfo>,
-) -> HashMap<String, SessionInfo> {
+    name: &infinity_protocol::RemoteName,
+    sessions: HashMap<infinity_protocol::ThreadRef, SessionInfo>,
+) -> HashMap<infinity_protocol::ThreadRef, SessionInfo> {
     sessions
         .into_iter()
         .map(|(id, mut info)| {
-            info.remote = Some(name.to_owned());
+            info.remote = Some(name.clone());
             for t in &mut info.threads {
-                t.thread_id = format!("{name}/{}", t.thread_id);
-                t.parent_thread_id = format!("{name}/{}", t.parent_thread_id);
+                t.thread_id = t.thread_id.clone().prefixed(name);
+                t.parent_thread_id = t.parent_thread_id.clone().prefixed(name);
             }
-            (format!("{name}/{id}"), info)
+            (id.prefixed(name), info)
         })
         .collect()
 }
@@ -437,7 +437,7 @@ async fn open_remote_connection(
 /// Long-running control worker for a single remote daemon.
 /// Maintains the connection and directly broadcasts prefixed SessionsUpdated.
 async fn control_worker(
-    name: String,
+    name: infinity_protocol::RemoteName,
     ssh_args: Vec<String>,
     remotes: RemoteMap,
     broadcast_clients: BroadcastClients,
@@ -484,7 +484,7 @@ async fn control_worker(
 }
 
 async fn control_worker_inner(
-    name: &str,
+    name: &infinity_protocol::RemoteName,
     ssh_args: &[String],
     remotes: &RemoteMap,
     broadcast_clients: &BroadcastClients,

--- a/crates/infinity-daemon/src/session/display.rs
+++ b/crates/infinity-daemon/src/session/display.rs
@@ -1,11 +1,11 @@
 use infinity_agent_core::ThreadId;
 use infinity_agent_core::message::InfinityMessage;
 use infinity_agent_core::system::AgentEvent;
-use infinity_protocol::{DaemonMessage, TokenUsage};
+use infinity_protocol::{DaemonMessage, ThreadRef, TokenUsage};
 use infinity_provider_protocol::message::{AssistantContent, ToolResultContent, UserContent};
 
 pub(crate) fn agent_event_to_daemon(thread_id: &ThreadId<str>, evt: &AgentEvent) -> DaemonMessage {
-    let tid = Some(thread_id.to_string());
+    let tid = Some(ThreadRef::local(thread_id.to_owned()));
     match evt {
         AgentEvent::CompletionStarted => DaemonMessage::StartOutput { thread_id: tid },
         AgentEvent::TextChunk { text } => DaemonMessage::TextChunk {
@@ -79,7 +79,7 @@ pub(crate) fn history_message_to_daemon(
     tid: &ThreadId<str>,
     history: &[InfinityMessage],
 ) -> Option<DaemonMessage> {
-    let thread_id = Some(tid.to_string());
+    let thread_id = Some(ThreadRef::local(tid.to_owned()));
     match msg {
         InfinityMessage::SubscriptionEvent {
             result,

--- a/crates/infinity-daemon/src/session/mod.rs
+++ b/crates/infinity-daemon/src/session/mod.rs
@@ -207,7 +207,10 @@ impl SessionManager {
                     };
                     drop(store);
                     let mut sessions = HashMap::new();
-                    sessions.insert(session_id.to_string(), info);
+                    sessions.insert(
+                        infinity_protocol::ThreadRef::local(session_id.to_owned()),
+                        info,
+                    );
                     let msg = DaemonMessage::SessionsUpdated { sessions };
                     bc.lock()
                         .expect("bug: mutex poisoned")
@@ -433,7 +436,7 @@ impl SessionManager {
             .set_view(group_id, view_type, content.clone());
 
         let msg = DaemonMessage::ViewUpdate {
-            thread_id: Some(group_id.to_string()),
+            thread_id: Some(infinity_protocol::ThreadRef::local(group_id.to_owned())),
             view_type: view_type.to_owned(),
             content,
         };
@@ -449,7 +452,7 @@ impl SessionManager {
         model: ModelRef,
         emit: &mut impl AsyncFnMut(DaemonMessage),
     ) -> Result<ThreadId, BoxError> {
-        let session_id = ThreadId::from(self.id_source.generate());
+        let session_id = self.id_source.generate();
         {
             let mut store = self.session_store.lock().await;
             store.create(&session_id, cwd.to_path_buf());
@@ -495,8 +498,8 @@ impl SessionManager {
         let selected = self.conversation_store.get_thread_model(thread_id);
         let (model_ref, entry, _) = self.catalog.resolve(&selected);
         DaemonMessage::Connected {
-            session_id: session_id.to_string(),
-            thread_id: thread_id.to_string(),
+            root_thread_id: infinity_protocol::ThreadRef::local(session_id.to_owned()),
+            thread_id: infinity_protocol::ThreadRef::local(thread_id.to_owned()),
             model_name: entry.display_name.clone(),
             context_window: entry.context_window,
             title: self.conversation_store.get_thread_title(session_id),
@@ -596,7 +599,7 @@ impl SessionManager {
             .set_thread_model(thread_id, model.clone());
 
         let msg = DaemonMessage::ModelSwitched {
-            thread_id: thread_id.to_string(),
+            thread_id: infinity_protocol::ThreadRef::local(thread_id.to_owned()),
             model_name: entry.display_name.clone(),
             context_window: entry.context_window,
             provider_id: model.provider_id.clone(),
@@ -617,7 +620,7 @@ impl SessionManager {
     pub async fn list_sessions(
         &self,
         subscribe: Option<mpsc::UnboundedSender<DaemonMessage>>,
-    ) -> HashMap<String, SessionInfo> {
+    ) -> HashMap<infinity_protocol::ThreadRef, SessionInfo> {
         if let Some(tx) = subscribe {
             self.broadcast_clients
                 .lock()
@@ -626,12 +629,12 @@ impl SessionManager {
         }
 
         let store = self.session_store.lock().await;
-        let mut result: HashMap<String, SessionInfo> = HashMap::new();
+        let mut result: HashMap<infinity_protocol::ThreadRef, SessionInfo> = HashMap::new();
 
         for (id, entry) in &store.sessions {
             let threads = self.conversation_store.get_open_subthreads(id);
             result.insert(
-                id.to_string(),
+                infinity_protocol::ThreadRef::local(id.to_owned()),
                 SessionInfo {
                     title: self.conversation_store.get_thread_title(id),
                     last_updated: self.conversation_store.get_last_updated(id),

--- a/crates/infinity-daemon/src/session/observer.rs
+++ b/crates/infinity-daemon/src/session/observer.rs
@@ -149,10 +149,10 @@ impl ThreadObserver for DaemonObserver {
             // the replay instead of appearing idle.
             if let Some(thinking) = snapshot.current_thinking {
                 history.push(DaemonMessage::ThinkingStart {
-                    thread_id: Some(thread_id.to_string()),
+                    thread_id: Some(infinity_protocol::ThreadRef::local(thread_id.to_owned())),
                 });
                 history.push(DaemonMessage::ThinkingChunk {
-                    thread_id: Some(thread_id.to_string()),
+                    thread_id: Some(infinity_protocol::ThreadRef::local(thread_id.to_owned())),
                     chunk: thinking,
                 });
             }
@@ -160,7 +160,7 @@ impl ThreadObserver for DaemonObserver {
                 .pending_choices
                 .iter()
                 .map(|choice| DaemonMessage::UserChoiceRequired {
-                    thread_id: Some(thread_id.to_string()),
+                    thread_id: Some(infinity_protocol::ThreadRef::local(thread_id.to_owned())),
                     id: choice.id.clone(),
                     prompt: choice.prompt.clone(),
                     choices: choice.choices.clone(),

--- a/crates/infinity-daemon/src/session/tests.rs
+++ b/crates/infinity-daemon/src/session/tests.rs
@@ -640,7 +640,7 @@ async fn child_pending_choice_updates_root_session_status() {
                 manager
                     .list_sessions(None)
                     .await
-                    .get(session_id.as_str())
+                    .get(&infinity_protocol::ThreadRef::local(session_id.clone()))
                     .expect("created session is listed")
                     .status,
                 SessionStatus::WaitingForChoice
@@ -655,7 +655,7 @@ async fn child_pending_choice_updates_root_session_status() {
                 manager
                     .list_sessions(None)
                     .await
-                    .get(session_id.as_str())
+                    .get(&infinity_protocol::ThreadRef::local(session_id.clone()))
                     .expect("created session is still listed")
                     .status,
                 SessionStatus::Running
@@ -672,7 +672,7 @@ async fn child_pending_choice_updates_root_session_status() {
                 manager
                     .list_sessions(None)
                     .await
-                    .get(session_id.as_str())
+                    .get(&infinity_protocol::ThreadRef::local(session_id.clone()))
                     .expect("cleaned-up session is listed")
                     .status,
                 SessionStatus::Stopped

--- a/crates/infinity-daemon/tests/keep_alive.rs
+++ b/crates/infinity-daemon/tests/keep_alive.rs
@@ -122,7 +122,7 @@ async fn create_session_and_chat(h: &mut TestHarness, keeps_session_alive: bool)
 
     h.client_tx
         .send(ClientMessage::UserInput {
-            root_thread_id: session_id.clone(),
+            thread_id: session_id.clone(),
             text: "hello".to_owned(),
         })
         .expect("send UserInput");
@@ -211,7 +211,7 @@ async fn user_input_restarts_stopped_session() {
 
             h.client_tx
                 .send(ClientMessage::UserInput {
-                    root_thread_id: infinity_protocol::ThreadRef::local(session_id.clone()),
+                    thread_id: infinity_protocol::ThreadRef::local(session_id.clone()),
                     text: "resume".to_owned(),
                 })
                 .expect("send user input");
@@ -296,7 +296,7 @@ async fn active_subscription_keeps_rap_servers_warm() {
             // Round 1 leaves a pending tool call for the subscription setup.
             h.client_tx
                 .send(ClientMessage::UserInput {
-                    root_thread_id: infinity_protocol::ThreadRef::local(session_id.clone()),
+                    thread_id: infinity_protocol::ThreadRef::local(session_id.clone()),
                     text: "watch the build".to_owned(),
                 })
                 .expect("send UserInput");

--- a/crates/infinity-daemon/tests/keep_alive.rs
+++ b/crates/infinity-daemon/tests/keep_alive.rs
@@ -112,13 +112,17 @@ async fn create_session_and_chat(h: &mut TestHarness, keeps_session_alive: bool)
         matches!(m, DaemonMessage::Connected { .. })
     })
     .await;
-    let DaemonMessage::Connected { session_id, .. } = connected else {
+    let DaemonMessage::Connected {
+        root_thread_id: session_id,
+        ..
+    } = connected
+    else {
         unreachable!()
     };
 
     h.client_tx
         .send(ClientMessage::UserInput {
-            session_id: session_id.clone(),
+            root_thread_id: session_id.clone(),
             text: "hello".to_owned(),
         })
         .expect("send UserInput");
@@ -132,7 +136,7 @@ async fn create_session_and_chat(h: &mut TestHarness, keeps_session_alive: bool)
     })
     .await;
 
-    ThreadId::from(session_id)
+    session_id.id
 }
 
 /// Poll until the session's RAP servers have been stopped (the session-idle
@@ -207,7 +211,7 @@ async fn user_input_restarts_stopped_session() {
 
             h.client_tx
                 .send(ClientMessage::UserInput {
-                    session_id: session_id.to_string(),
+                    root_thread_id: infinity_protocol::ThreadRef::local(session_id.clone()),
                     text: "resume".to_owned(),
                 })
                 .expect("send user input");
@@ -280,15 +284,19 @@ async fn active_subscription_keeps_rap_servers_warm() {
                 matches!(m, DaemonMessage::Connected { .. })
             })
             .await;
-            let DaemonMessage::Connected { session_id, .. } = connected else {
+            let DaemonMessage::Connected {
+                root_thread_id: session_id,
+                ..
+            } = connected
+            else {
                 unreachable!()
             };
-            let session_id = ThreadId::from(session_id);
+            let session_id = session_id.id;
 
             // Round 1 leaves a pending tool call for the subscription setup.
             h.client_tx
                 .send(ClientMessage::UserInput {
-                    session_id: session_id.to_string(),
+                    root_thread_id: infinity_protocol::ThreadRef::local(session_id.clone()),
                     text: "watch the build".to_owned(),
                 })
                 .expect("send UserInput");

--- a/crates/infinity-daemon/tests/rap_callback_flow.rs
+++ b/crates/infinity-daemon/tests/rap_callback_flow.rs
@@ -123,7 +123,7 @@ async fn create_session_and_chat(h: &mut TestHarness) -> infinity_protocol::Thre
 
     h.client_tx
         .send(ClientMessage::UserInput {
-            root_thread_id: session_id.clone(),
+            thread_id: session_id.clone(),
             text: "hello".to_owned(),
         })
         .expect("send UserInput");
@@ -201,7 +201,7 @@ async fn session_status_follows_thread_activity() {
 
             h.client_tx
                 .send(ClientMessage::UserInput {
-                    root_thread_id: session_id.clone(),
+                    thread_id: session_id.clone(),
                     text: "hello".to_owned(),
                 })
                 .expect("send UserInput");

--- a/crates/infinity-daemon/tests/rap_callback_flow.rs
+++ b/crates/infinity-daemon/tests/rap_callback_flow.rs
@@ -99,7 +99,7 @@ async fn wait_for_message(
 }
 
 /// Create a session, run one chat round, and return the session id.
-async fn create_session_and_chat(h: &mut TestHarness) -> String {
+async fn create_session_and_chat(h: &mut TestHarness) -> infinity_protocol::ThreadRef {
     h.client_tx
         .send(ClientMessage::CreateSession {
             cwd: h.cwd.path().to_path_buf(),
@@ -113,13 +113,17 @@ async fn create_session_and_chat(h: &mut TestHarness) -> String {
         matches!(m, DaemonMessage::Connected { .. })
     })
     .await;
-    let DaemonMessage::Connected { session_id, .. } = connected else {
+    let DaemonMessage::Connected {
+        root_thread_id: session_id,
+        ..
+    } = connected
+    else {
         unreachable!()
     };
 
     h.client_tx
         .send(ClientMessage::UserInput {
-            session_id: session_id.clone(),
+            root_thread_id: session_id.clone(),
             text: "hello".to_owned(),
         })
         .expect("send UserInput");
@@ -139,7 +143,7 @@ async fn create_session_and_chat(h: &mut TestHarness) -> String {
 /// Wait until a `SessionsUpdated` broadcast reports the given status.
 async fn wait_for_status(
     rx: &mut mpsc::UnboundedReceiver<DaemonMessage>,
-    session_id: &str,
+    session_id: &infinity_protocol::ThreadRef,
     status: SessionStatus,
 ) {
     tokio::time::timeout(Duration::from_secs(5), async {
@@ -187,13 +191,17 @@ async fn session_status_follows_thread_activity() {
                 matches!(m, DaemonMessage::Connected { .. })
             })
             .await;
-            let DaemonMessage::Connected { session_id, .. } = connected else {
+            let DaemonMessage::Connected {
+                root_thread_id: session_id,
+                ..
+            } = connected
+            else {
                 unreachable!()
             };
 
             h.client_tx
                 .send(ClientMessage::UserInput {
-                    session_id: session_id.clone(),
+                    root_thread_id: session_id.clone(),
                     text: "hello".to_owned(),
                 })
                 .expect("send UserInput");
@@ -249,12 +257,12 @@ async fn view_update_is_broadcast_without_waking_the_session() {
             else {
                 unreachable!()
             };
-            assert_eq!(thread_id.as_deref(), Some(session_id.as_str()));
+            assert_eq!(thread_id.as_ref(), Some(&session_id));
             assert_eq!(view_type, "diff");
 
             let mgr = h.manager.lock().await;
             assert!(
-                mgr.is_session_idle(rap_protocol::ThreadId::from_ref(&session_id)),
+                mgr.is_session_idle(&session_id.id),
                 "a view update must not wake any thread driver"
             );
         })

--- a/crates/infinity-protocol/Cargo.toml
+++ b/crates/infinity-protocol/Cargo.toml
@@ -13,6 +13,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 dirs = "6"
 rap-protocol = { path = "../rap-protocol", version = "^0.1.0" }
+strkind = { workspace = true }
 tokio-util = { version = "0.7", features = ["codec"] }
 
 [lints]

--- a/crates/infinity-protocol/src/lib.rs
+++ b/crates/infinity-protocol/src/lib.rs
@@ -40,7 +40,16 @@ impl ThreadRef {
     }
 
     /// A reference to a thread on the named remote daemon.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `remote` contains `/`, which would make the composite wire
+    /// encoding (`"{remote}/{id}"`) ambiguous.
     pub fn remote(remote: RemoteName, id: ThreadId) -> Self {
+        assert!(
+            !remote.as_str().contains('/'),
+            "bug: remote name {remote:?} contains '/'"
+        );
         Self {
             remote: Some(remote),
             id,
@@ -49,11 +58,13 @@ impl ThreadRef {
 
     /// Re-home this reference onto `remote` (used when a daemon proxies a
     /// remote daemon's messages to its own clients).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `remote` contains `/`, which would make the composite wire
+    /// encoding (`"{remote}/{id}"`) ambiguous.
     pub fn prefixed(self, remote: &RemoteName) -> Self {
-        Self {
-            remote: Some(remote.clone()),
-            id: self.id,
-        }
+        Self::remote(remote.clone(), self.id)
     }
 
     /// Strip the given remote, yielding the thread's ID on its home daemon.
@@ -78,25 +89,61 @@ impl std::fmt::Display for ThreadRef {
     }
 }
 
+/// Error parsing a [`ThreadRef`] from its composite string form.
+///
+/// Produced when the input is not a bare thread ID or a well-formed
+/// `"{remote}/{id}"` composite: an empty remote or ID half, or a second `/`
+/// (remote names and thread IDs must not contain `/`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadRefParseError {
+    input: String,
+    reason: &'static str,
+}
+
+impl std::fmt::Display for ThreadRefParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid thread ref {:?}: {}", self.input, self.reason)
+    }
+}
+
+impl std::error::Error for ThreadRefParseError {}
+
 impl std::str::FromStr for ThreadRef {
-    type Err = std::convert::Infallible;
+    type Err = ThreadRefParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s.split_once('/') {
-            Some((remote, id)) => Self {
-                remote: Some(remote.into()),
-                id: id.into(),
-            },
-            None => Self {
+        let err = |reason| {
+            Err(ThreadRefParseError {
+                input: s.to_owned(),
+                reason,
+            })
+        };
+        match s.split_once('/') {
+            Some((remote, id)) => {
+                if remote.is_empty() {
+                    return err("empty remote name");
+                }
+                if id.is_empty() {
+                    return err("empty thread ID");
+                }
+                if id.contains('/') {
+                    return err("more than one '/'");
+                }
+                Ok(Self {
+                    remote: Some(remote.into()),
+                    id: id.into(),
+                })
+            }
+            None => Ok(Self {
                 remote: None,
                 id: s.into(),
-            },
-        })
+            }),
+        }
     }
 }
 
 impl From<&str> for ThreadRef {
     fn from(s: &str) -> Self {
-        s.parse().expect("bug: ThreadRef parsing is infallible")
+        s.parse().expect("invalid ThreadRef")
     }
 }
 
@@ -121,7 +168,7 @@ impl Serialize for ThreadRef {
 impl<'de> Deserialize<'de> for ThreadRef {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
-        Ok(s.as_str().into())
+        s.parse().map_err(serde::de::Error::custom)
     }
 }
 
@@ -523,4 +570,44 @@ pub struct ModelRef {
 pub struct RemoteInfo {
     pub name: RemoteName,
     pub status: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thread_ref_parse_local() {
+        let r: ThreadRef = "abc-123".parse().expect("local ref should parse");
+        assert_eq!(r, ThreadRef::local("abc-123".into()));
+        assert_eq!(r.to_string(), "abc-123");
+    }
+
+    #[test]
+    fn thread_ref_parse_remote() {
+        let r: ThreadRef = "devbox/abc-123".parse().expect("remote ref should parse");
+        assert_eq!(r, ThreadRef::remote("devbox".into(), "abc-123".into()));
+        assert_eq!(r.to_string(), "devbox/abc-123");
+    }
+
+    #[test]
+    fn thread_ref_parse_rejects_malformed() {
+        assert!("a/b/c".parse::<ThreadRef>().is_err(), "second '/'");
+        assert!("/abc".parse::<ThreadRef>().is_err(), "empty remote");
+        assert!("devbox/".parse::<ThreadRef>().is_err(), "empty thread ID");
+    }
+
+    #[test]
+    fn thread_ref_deserialize_rejects_malformed() {
+        assert!(serde_json::from_str::<ThreadRef>("\"a/b/c\"").is_err());
+        let r: ThreadRef =
+            serde_json::from_str("\"devbox/abc-123\"").expect("valid composite should deserialize");
+        assert_eq!(r, ThreadRef::remote("devbox".into(), "abc-123".into()));
+    }
+
+    #[test]
+    #[should_panic(expected = "contains '/'")]
+    fn thread_ref_remote_rejects_slash_in_name() {
+        ThreadRef::remote("dev/box".into(), "abc-123".into());
+    }
 }

--- a/crates/infinity-protocol/src/lib.rs
+++ b/crates/infinity-protocol/src/lib.rs
@@ -3,6 +3,128 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio_util::codec::LengthDelimitedCodec;
 
+/// The thread identifier used throughout the runtime (re-exported from
+/// `rap-protocol`).
+pub use rap_protocol::ThreadId;
+
+strkind::strkind! {
+    /// The name of a configured remote daemon (from `remotes.json`), e.g.
+    /// `"devbox"`. Remote names must not contain `/` (they are joined with
+    /// thread IDs in [`ThreadRef`]'s wire encoding).
+    pub RemoteName;
+}
+
+/// A client-facing reference to a thread: which daemon it lives on
+/// (`remote: None` means the local daemon) plus its thread ID there.
+///
+/// On the wire this serializes as the historical composite string —
+/// `"{remote}/{id}"` for remote threads, bare `"{id}"` for local ones — so
+/// clients see a plain string and the daemon parses it back losslessly.
+/// A session is identified by its root thread's `ThreadRef`.
+///
+/// Ordering is `(remote, id)`: local threads sort before remote ones, then
+/// by thread ID. (This differs from lexicographic ordering of the composite
+/// string, which would interleave remotes with local IDs.)
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ThreadRef {
+    /// The remote daemon hosting the thread; `None` for the local daemon.
+    pub remote: Option<RemoteName>,
+    /// The thread's ID on its home daemon.
+    pub id: ThreadId,
+}
+
+impl ThreadRef {
+    /// A reference to a thread on the local daemon.
+    pub fn local(id: ThreadId) -> Self {
+        Self { remote: None, id }
+    }
+
+    /// A reference to a thread on the named remote daemon.
+    pub fn remote(remote: RemoteName, id: ThreadId) -> Self {
+        Self {
+            remote: Some(remote),
+            id,
+        }
+    }
+
+    /// Re-home this reference onto `remote` (used when a daemon proxies a
+    /// remote daemon's messages to its own clients).
+    pub fn prefixed(self, remote: &RemoteName) -> Self {
+        Self {
+            remote: Some(remote.clone()),
+            id: self.id,
+        }
+    }
+
+    /// Strip the given remote, yielding the thread's ID on its home daemon.
+    /// References to other remotes (or local ones) are returned unchanged.
+    pub fn strip(self, remote: &RemoteName) -> Self {
+        match self.remote {
+            Some(ref r) if r == remote => Self {
+                remote: None,
+                id: self.id,
+            },
+            _ => self,
+        }
+    }
+}
+
+impl std::fmt::Display for ThreadRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.remote {
+            Some(remote) => write!(f, "{}/{}", remote, self.id),
+            None => write!(f, "{}", self.id),
+        }
+    }
+}
+
+impl std::str::FromStr for ThreadRef {
+    type Err = std::convert::Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.split_once('/') {
+            Some((remote, id)) => Self {
+                remote: Some(remote.into()),
+                id: id.into(),
+            },
+            None => Self {
+                remote: None,
+                id: s.into(),
+            },
+        })
+    }
+}
+
+impl From<&str> for ThreadRef {
+    fn from(s: &str) -> Self {
+        s.parse().expect("bug: ThreadRef parsing is infallible")
+    }
+}
+
+impl From<String> for ThreadRef {
+    fn from(s: String) -> Self {
+        s.as_str().into()
+    }
+}
+
+impl From<ThreadId> for ThreadRef {
+    fn from(id: ThreadId) -> Self {
+        Self::local(id)
+    }
+}
+
+impl Serialize for ThreadRef {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for ThreadRef {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(s.as_str().into())
+    }
+}
+
 /// Maximum frame size for daemon ↔ client communication (256 MiB).
 ///
 /// The default `LengthDelimitedCodec` limit is 8 MiB, which is too small for
@@ -65,7 +187,7 @@ pub enum ClientMessage {
         /// Optional target location. `None` means local.
         /// Otherwise, the name of a remote.
         #[serde(default)]
-        location: Option<String>,
+        location: Option<RemoteName>,
         /// Optional model to use for the new session. `None` uses the
         /// daemon's default model.
         #[serde(default)]
@@ -78,8 +200,8 @@ pub enum ClientMessage {
     },
     /// Connect to an existing session (optionally a specific thread).
     Connect {
-        session_id: String,
-        thread_id: Option<String>,
+        root_thread_id: ThreadRef,
+        thread_id: Option<ThreadRef>,
         /// When `false`, this connection will not prevent the session from
         /// going idle and being shut down by the daemon. Defaults to `true`
         /// so that normal interactive clients keep sessions alive.
@@ -87,7 +209,7 @@ pub enum ClientMessage {
         keeps_session_alive: bool,
     },
     UserInput {
-        session_id: String,
+        root_thread_id: ThreadRef,
         text: String,
     },
     /// Disconnect from the session while letting the agent continue to run in the background.
@@ -95,72 +217,57 @@ pub enum ClientMessage {
     /// Immediately attempt to detach. If the agent is idle, the daemon shuts
     /// down the session (closing the display channel). If not idle, the daemon
     /// responds with `DisconnectNotIdle` so the client can show a picker.
-    SoftDetach {
-        session_id: String,
-    },
+    SoftDetach { root_thread_id: ThreadRef },
     /// Disconnects from the session and shuts down the agent so that it can only be woken bu
     /// new user inputs.
-    ShutdownSession {
-        session_id: String,
-    },
+    ShutdownSession { root_thread_id: ThreadRef },
     /// Archive a session (shut it down and hide from the main list).
-    ArchiveSession {
-        session_id: String,
-    },
-    /// Switch the model used for future requests on a thread. `session_id`
-    /// may be any thread id (root or subthread); the switch affects only that
+    ArchiveSession { root_thread_id: ThreadRef },
+    /// Switch the model used for future requests on a thread. `thread_id`
+    /// may be any thread (root or subthread); the switch affects only that
     /// specific thread — it does not propagate to child threads. If a
     /// completion is currently in flight on the thread, it finishes on the
     /// old model and the switch applies to subsequent requests.
     SwitchModel {
-        session_id: String,
+        thread_id: ThreadRef,
         model: ModelRef,
     },
     /// Notify the daemon that a user choice was answered so it can be
     /// removed from the pending replay list.
-    UserChoiceAnswered {
-        choice_id: String,
-        selected: usize,
-    },
+    UserChoiceAnswered { choice_id: String, selected: usize },
     /// Trigger compaction for the given session.
-    TriggerCompaction {
-        session_id: String,
-    },
+    TriggerCompaction { root_thread_id: ThreadRef },
     /// Request migration of a session to a different host.
     RequestMigrate {
-        session_id: String,
+        root_thread_id: ThreadRef,
         /// `None` means local, `Some(name)` means a remote.
         #[serde(default)]
-        to: Option<String>,
+        to: Option<RemoteName>,
         dest_cwd: PathBuf,
     },
     /// Daemon-to-daemon: request a session to emigrate. Includes destination RAP URLs
     /// so source RAP servers can migrate their state.
     Emigrate {
-        session_id: String,
+        root_thread_id: ThreadId,
         /// config_id → destination URL
         dest_rap_urls: HashMap<String, String>,
     },
     /// Daemon-to-daemon: immigration is complete, source can clean up.
-    EmigrateDone {
-        session_id: String,
-    },
+    EmigrateDone { root_thread_id: ThreadId },
     /// Daemon-to-daemon: import a serialized session at the given cwd.
     ImportSession {
-        session_id: String,
+        root_thread_id: ThreadId,
         cwd: PathBuf,
         session_data: String,
     },
     /// Daemon-to-daemon: boot RAP servers at the given cwd and return their ports.
-    BootRapServers {
-        cwd: PathBuf,
-    },
+    BootRapServers { cwd: PathBuf },
     /// Request directory listing for path completion.
     ListDirectory {
         path: String,
         /// Target remote name. `None` means list on the local filesystem.
         #[serde(default)]
-        on: Option<String>,
+        on: Option<RemoteName>,
     },
 }
 
@@ -169,8 +276,8 @@ pub enum ClientMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum DaemonMessage {
     Connected {
-        session_id: String,
-        thread_id: String,
+        root_thread_id: ThreadRef,
+        thread_id: ThreadRef,
         model_name: String,
         context_window: usize,
         title: Option<String>,
@@ -179,46 +286,46 @@ pub enum DaemonMessage {
         provider_id: String,
     },
     StartOutput {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
     },
     TextChunk {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
         chunk: String,
     },
     ToolCall {
         name: String,
         args: String,
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
         display_as: Option<String>,
     },
     ToolResult {
         /// Prioritized display segments. Clients use the first type they support.
         segments: Vec<rap_protocol::DisplaySegment>,
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
     },
     Info {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
         text: String,
     },
     ResponseDone {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
         token_usage: Option<TokenUsage>,
     },
     UserInputEcho {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
         text: String,
     },
     SubscriptionEvent {
         name: String,
         text: String,
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
     },
     OAuthRequired {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
         auth_url: String,
     },
     UserChoiceRequired {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
         id: String,
         prompt: String,
         choices: Vec<String>,
@@ -228,35 +335,35 @@ pub enum DaemonMessage {
         choice_id: String,
     },
     ThinkingStart {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
     },
     ThinkingEnd {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
     },
     ThinkingChunk {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
         chunk: String,
     },
     CompactionApplied {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
     },
     /// Confirmation that a thread's model was switched (via
     /// [`ClientMessage::SwitchModel`]). Sent to the requesting client and
     /// broadcast to the thread's subscribers so every attached UI can update
     /// its model indicator.
     ModelSwitched {
-        thread_id: String,
+        thread_id: ThreadRef,
         model_name: String,
         context_window: usize,
         provider_id: String,
     },
     Error {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
         text: String,
     },
     /// A view update pushed by a RAP tool server.
     ViewUpdate {
-        thread_id: Option<String>,
+        thread_id: Option<ThreadRef>,
         view_type: String,
         content: serde_json::Value,
     },
@@ -277,7 +384,7 @@ pub enum DaemonMessage {
     },
     /// Sent immediately on socket connection with session list and default model info.
     Welcome {
-        sessions: HashMap<String, SessionInfo>,
+        sessions: HashMap<ThreadRef, SessionInfo>,
         available_models: Vec<ModelInfo>,
         default_model_name: String,
         default_context_window: usize,
@@ -287,7 +394,7 @@ pub enum DaemonMessage {
     },
     /// Broadcast: one or more sessions were created or updated.
     SessionsUpdated {
-        sessions: HashMap<String, SessionInfo>,
+        sessions: HashMap<ThreadRef, SessionInfo>,
     },
     /// Broadcast: remote connection statuses changed.
     RemotesUpdated {
@@ -300,23 +407,23 @@ pub enum DaemonMessage {
     DetachedIdle,
     /// Response to Emigrate: serialized session data (thread tree as JSON).
     EmigrateResult {
-        session_id: String,
+        root_thread_id: ThreadId,
         session_data: String,
     },
     MigrateStarted {
-        session_id: String,
+        root_thread_id: ThreadRef,
     },
     MigrateComplete {
-        session_id: String,
-        new_session_id: String,
+        root_thread_id: ThreadRef,
+        new_root_thread_id: ThreadRef,
     },
     MigrateError {
-        session_id: String,
+        root_thread_id: ThreadRef,
         error: String,
     },
     /// Response to ImportSession.
     ImportComplete {
-        session_id: String,
+        root_thread_id: ThreadId,
     },
     /// Response to BootRapServers: maps config ID → local port for servers needing migration.
     RapServersBooted {
@@ -331,7 +438,7 @@ pub enum DaemonMessage {
         entries: Vec<String>,
         /// The remote that was queried, if any.
         #[serde(default)]
-        on: Option<String>,
+        on: Option<RemoteName>,
     },
 }
 
@@ -357,13 +464,13 @@ pub struct SessionInfo {
     pub threads: Vec<SubthreadInfo>,
     /// If set, this session lives on a remote daemon with this name.
     #[serde(default)]
-    pub remote: Option<String>,
+    pub remote: Option<RemoteName>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubthreadInfo {
-    pub thread_id: String,
-    pub parent_thread_id: String,
+    pub thread_id: ThreadRef,
+    pub parent_thread_id: ThreadRef,
     pub title: Option<String>,
 }
 
@@ -399,6 +506,6 @@ pub struct ModelRef {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RemoteInfo {
-    pub name: String,
+    pub name: RemoteName,
     pub status: String,
 }

--- a/crates/infinity-protocol/src/lib.rs
+++ b/crates/infinity-protocol/src/lib.rs
@@ -209,7 +209,7 @@ pub enum ClientMessage {
         keeps_session_alive: bool,
     },
     UserInput {
-        root_thread_id: ThreadRef,
+        thread_id: ThreadRef,
         text: String,
     },
     /// Disconnect from the session while letting the agent continue to run in the background.
@@ -217,12 +217,18 @@ pub enum ClientMessage {
     /// Immediately attempt to detach. If the agent is idle, the daemon shuts
     /// down the session (closing the display channel). If not idle, the daemon
     /// responds with `DisconnectNotIdle` so the client can show a picker.
-    SoftDetach { root_thread_id: ThreadRef },
+    SoftDetach {
+        root_thread_id: ThreadRef,
+    },
     /// Disconnects from the session and shuts down the agent so that it can only be woken bu
     /// new user inputs.
-    ShutdownSession { root_thread_id: ThreadRef },
+    ShutdownSession {
+        root_thread_id: ThreadRef,
+    },
     /// Archive a session (shut it down and hide from the main list).
-    ArchiveSession { root_thread_id: ThreadRef },
+    ArchiveSession {
+        root_thread_id: ThreadRef,
+    },
     /// Switch the model used for future requests on a thread. `thread_id`
     /// may be any thread (root or subthread); the switch affects only that
     /// specific thread — it does not propagate to child threads. If a
@@ -234,9 +240,14 @@ pub enum ClientMessage {
     },
     /// Notify the daemon that a user choice was answered so it can be
     /// removed from the pending replay list.
-    UserChoiceAnswered { choice_id: String, selected: usize },
+    UserChoiceAnswered {
+        choice_id: String,
+        selected: usize,
+    },
     /// Trigger compaction for the given session.
-    TriggerCompaction { root_thread_id: ThreadRef },
+    TriggerCompaction {
+        root_thread_id: ThreadRef,
+    },
     /// Request migration of a session to a different host.
     RequestMigrate {
         root_thread_id: ThreadRef,
@@ -253,7 +264,9 @@ pub enum ClientMessage {
         dest_rap_urls: HashMap<String, String>,
     },
     /// Daemon-to-daemon: immigration is complete, source can clean up.
-    EmigrateDone { root_thread_id: ThreadId },
+    EmigrateDone {
+        root_thread_id: ThreadId,
+    },
     /// Daemon-to-daemon: import a serialized session at the given cwd.
     ImportSession {
         root_thread_id: ThreadId,
@@ -261,7 +274,9 @@ pub enum ClientMessage {
         session_data: String,
     },
     /// Daemon-to-daemon: boot RAP servers at the given cwd and return their ports.
-    BootRapServers { cwd: PathBuf },
+    BootRapServers {
+        cwd: PathBuf,
+    },
     /// Request directory listing for path completion.
     ListDirectory {
         path: String,

--- a/crates/infinity-rap-bridge/src/lib.rs
+++ b/crates/infinity-rap-bridge/src/lib.rs
@@ -151,7 +151,7 @@ impl RapToolSet {
     /// [`RapCallbackBridge`] or another receiver for RAP callbacks.
     pub async fn connect(
         server_urls: impl IntoIterator<Item = String>,
-        session_id: &str,
+        session_id: &rap_protocol::ThreadId<str>,
         callback_url: impl Into<String>,
     ) -> Result<Self, BoxError> {
         let server_urls: Vec<String> = server_urls.into_iter().collect();

--- a/crates/infinity-slack-bot/src/daemon_client.rs
+++ b/crates/infinity-slack-bot/src/daemon_client.rs
@@ -77,10 +77,14 @@ impl DaemonClient {
         Ok(())
     }
 
-    pub async fn send_input(&self, session_id: &str, text: &str) -> Result<(), BoxError> {
+    pub async fn send_input(
+        &self,
+        session_id: &infinity_protocol::ThreadRef,
+        text: &str,
+    ) -> Result<(), BoxError> {
         self.tx
             .send(ClientMessage::UserInput {
-                session_id: session_id.to_owned(),
+                root_thread_id: session_id.clone(),
                 text: text.to_owned(),
             })
             .await?;
@@ -89,12 +93,12 @@ impl DaemonClient {
 
     pub async fn connect_session(
         &self,
-        session_id: &str,
-        thread_id: Option<String>,
+        session_id: &infinity_protocol::ThreadRef,
+        thread_id: Option<infinity_protocol::ThreadRef>,
     ) -> Result<(), BoxError> {
         self.tx
             .send(ClientMessage::Connect {
-                session_id: session_id.to_owned(),
+                root_thread_id: session_id.clone(),
                 thread_id,
                 keeps_session_alive: false,
             })

--- a/crates/infinity-slack-bot/src/daemon_client.rs
+++ b/crates/infinity-slack-bot/src/daemon_client.rs
@@ -84,7 +84,7 @@ impl DaemonClient {
     ) -> Result<(), BoxError> {
         self.tx
             .send(ClientMessage::UserInput {
-                root_thread_id: session_id.clone(),
+                thread_id: session_id.clone(),
                 text: text.to_owned(),
             })
             .await?;

--- a/crates/infinity-slack-bot/src/daemon_sidecar.rs
+++ b/crates/infinity-slack-bot/src/daemon_sidecar.rs
@@ -25,12 +25,12 @@ pub enum DaemonCommand {
     /// Connect to an existing session.
     ConnectSession {
         thread_ts: String,
-        session_id: String,
+        session_id: infinity_protocol::ThreadRef,
     },
     /// Send user input on the connection for this thread.
     SendInput {
         thread_ts: String,
-        session_id: String,
+        session_id: infinity_protocol::ThreadRef,
         text: String,
     },
     /// Answer a choice prompt on the connection for this thread.
@@ -212,7 +212,11 @@ fn spawn_receiver(
                 );
             } else {
                 // Not a Welcome — forward it normally.
-                if let DaemonMessage::Connected { ref session_id, .. } = first_msg {
+                if let DaemonMessage::Connected {
+                    root_thread_id: ref session_id,
+                    ..
+                } = first_msg
+                {
                     let rt = crate::runtime::get();
                     let pending_text = {
                         let mut pending = rt.pending_input.lock().expect("bug: lock poisoned");
@@ -221,7 +225,7 @@ fn spawn_receiver(
                     if let Some(text) = pending_text {
                         let _ = tx_for_input
                             .send(infinity_protocol::ClientMessage::UserInput {
-                                session_id: session_id.clone(),
+                                root_thread_id: session_id.clone(),
                                 text,
                             })
                             .await;
@@ -243,7 +247,11 @@ fn spawn_receiver(
 
         while let Some(msg) = rx.recv().await {
             // On Connected, send pending input automatically.
-            if let DaemonMessage::Connected { ref session_id, .. } = msg {
+            if let DaemonMessage::Connected {
+                root_thread_id: ref session_id,
+                ..
+            } = msg
+            {
                 let rt = crate::runtime::get();
                 let pending_text = {
                     let mut pending = rt.pending_input.lock().expect("bug: lock poisoned");
@@ -252,7 +260,7 @@ fn spawn_receiver(
                 if let Some(text) = pending_text {
                     let _ = tx_for_input
                         .send(infinity_protocol::ClientMessage::UserInput {
-                            session_id: session_id.clone(),
+                            root_thread_id: session_id.clone(),
                             text,
                         })
                         .await;

--- a/crates/infinity-slack-bot/src/daemon_sidecar.rs
+++ b/crates/infinity-slack-bot/src/daemon_sidecar.rs
@@ -225,7 +225,7 @@ fn spawn_receiver(
                     if let Some(text) = pending_text {
                         let _ = tx_for_input
                             .send(infinity_protocol::ClientMessage::UserInput {
-                                root_thread_id: session_id.clone(),
+                                thread_id: session_id.clone(),
                                 text,
                             })
                             .await;
@@ -260,7 +260,7 @@ fn spawn_receiver(
                 if let Some(text) = pending_text {
                     let _ = tx_for_input
                         .send(infinity_protocol::ClientMessage::UserInput {
-                            root_thread_id: session_id.clone(),
+                            thread_id: session_id.clone(),
                             text,
                         })
                         .await;

--- a/crates/infinity-slack-bot/src/flow.rs
+++ b/crates/infinity-slack-bot/src/flow.rs
@@ -229,7 +229,9 @@ pub fn slack_dataflow<'a, P: 'a>(
 
             match &de.message {
                 infinity_protocol::DaemonMessage::Connected {
-                    session_id, title, ..
+                    root_thread_id: session_id,
+                    title,
+                    ..
                 } => {
                     {
                         let mut sessions = rt.sessions.lock().expect("bug: lock poisoned");

--- a/crates/infinity-slack-bot/src/session_store.rs
+++ b/crates/infinity-slack-bot/src/session_store.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use infinity_protocol::ThreadRef;
+
 use crate::BoxError;
 
 /// A pending approval/choice waiting for user response.
@@ -10,9 +12,11 @@ pub struct PendingChoice {
     pub choices: Vec<String>,
 }
 
-/// Persists the Slack thread_ts → Infinity session_id mapping to disk.
+/// Persists the Slack thread_ts → Infinity session (root thread) mapping to
+/// disk. `ThreadRef` serializes as the plain id string, so the JSON format is
+/// unchanged.
 pub struct SessionStore {
-    map: HashMap<String, String>,
+    map: HashMap<String, ThreadRef>,
     /// thread_ts → pending choice (not persisted; transient)
     pending_choices: HashMap<String, PendingChoice>,
     path: PathBuf,
@@ -38,11 +42,11 @@ impl SessionStore {
         })
     }
 
-    pub fn get(&self, thread_ts: &str) -> Option<&String> {
+    pub fn get(&self, thread_ts: &str) -> Option<&ThreadRef> {
         self.map.get(thread_ts)
     }
 
-    pub fn insert(&mut self, thread_ts: String, session_id: String) {
+    pub fn insert(&mut self, thread_ts: String, session_id: ThreadRef) {
         self.map.insert(thread_ts, session_id);
         if let Err(e) = self.save() {
             tracing::error!("failed to persist session map: {e}");
@@ -50,7 +54,7 @@ impl SessionStore {
     }
 
     /// Insert without persisting to disk (for use in tests or transient state).
-    pub fn insert_ephemeral(&mut self, thread_ts: String, session_id: String) {
+    pub fn insert_ephemeral(&mut self, thread_ts: String, session_id: ThreadRef) {
         self.map.insert(thread_ts, session_id);
     }
 
@@ -63,7 +67,7 @@ impl SessionStore {
         }
     }
 
-    pub fn values(&self) -> impl Iterator<Item = &String> {
+    pub fn values(&self) -> impl Iterator<Item = &ThreadRef> {
         self.map.values()
     }
 
@@ -114,7 +118,10 @@ mod tests {
 
         // Reload from disk
         let store = SessionStore::load(path.clone()).expect("reload should succeed");
-        assert_eq!(store.get("thread1").expect("key should exist"), "session1");
+        assert_eq!(
+            store.get("thread1").expect("key should exist"),
+            &ThreadRef::from("session1")
+        );
 
         let _ = std::fs::remove_file(&path);
     }
@@ -126,8 +133,14 @@ mod tests {
         std::fs::write(&path, r#"{"t1":"s1","t2":"s2"}"#).expect("write should succeed");
 
         let store = SessionStore::load(path.clone()).expect("load should succeed");
-        assert_eq!(store.get("t1").expect("t1 should exist"), "s1");
-        assert_eq!(store.get("t2").expect("t2 should exist"), "s2");
+        assert_eq!(
+            store.get("t1").expect("t1 should exist"),
+            &ThreadRef::from("s1")
+        );
+        assert_eq!(
+            store.get("t2").expect("t2 should exist"),
+            &ThreadRef::from("s2")
+        );
         assert!(store.get("t3").is_none());
 
         let _ = std::fs::remove_file(&path);
@@ -142,7 +155,7 @@ mod tests {
         store.insert("t1".into(), "s1".into());
         store.insert("t2".into(), "s2".into());
 
-        let mut vals: Vec<&String> = store.values().collect();
+        let mut vals: Vec<String> = store.values().map(|v| v.to_string()).collect();
         vals.sort();
         assert_eq!(vals, vec!["s1", "s2"]);
 

--- a/crates/infinity-slack-bot/tests/dataflow_sim.rs
+++ b/crates/infinity-slack-bot/tests/dataflow_sim.rs
@@ -246,8 +246,8 @@ fn existing_session_produces_send_input() {
         daemon_tx.send(devent(
             &thread_ts,
             infinity_protocol::DaemonMessage::Connected {
-                session_id: session_id.clone(),
-                thread_id: String::new(),
+                root_thread_id: session_id.clone().into(),
+                thread_id: infinity_protocol::ThreadRef::from(""),
                 model_name: String::new(),
                 context_window: 0,
                 title: Some("My Thread".to_owned()),
@@ -276,7 +276,7 @@ fn existing_session_produces_send_input() {
                 text,
             } => {
                 assert_eq!(t, thread_ts);
-                assert_eq!(s, session_id);
+                assert_eq!(s.to_string(), session_id);
                 assert_eq!(text, "follow up");
             }
             other => panic!("expected SendInput, got {other:?}"),

--- a/crates/rap-client/src/notifier.rs
+++ b/crates/rap-client/src/notifier.rs
@@ -20,7 +20,7 @@ impl<H: HttpClient> RapNotifier<H> {
     }
 
     /// Best-effort notification that a thread has been closed.
-    pub async fn notify_thread_closed(&self, thread_id: &rap_protocol::ThreadId) {
+    pub async fn notify_thread_closed(&self, thread_id: &rap_protocol::ThreadId<str>) {
         let payload = serde_json::json!({ "thread_id": thread_id }).to_string();
         for url in &self.server_urls {
             let endpoint = format!("{}/close_thread", url.trim_end_matches('/'));
@@ -38,7 +38,7 @@ impl<H: HttpClient> RapNotifier<H> {
     /// Best-effort notification that a tool call has been cancelled.
     pub async fn notify_tool_cancelled(
         &self,
-        thread_id: &rap_protocol::ThreadId,
+        thread_id: &rap_protocol::ThreadId<str>,
         tool_call_id: &str,
     ) {
         let payload = serde_json::json!({
@@ -68,7 +68,7 @@ impl<H: HttpClient> RapNotifier<H> {
     /// `destination_urls` maps config ID → destination server URL.
     pub async fn request_migration(
         &self,
-        session_id: &str,
+        session_id: &rap_protocol::ThreadId<str>,
         servers_needing_migration: &[(String, String)],
         destination_urls: &HashMap<String, String>,
     ) -> Result<(), Vec<String>> {

--- a/crates/rap-client/src/toolset_loader.rs
+++ b/crates/rap-client/src/toolset_loader.rs
@@ -35,7 +35,7 @@ impl<H: HttpClient, C: ToolsetCache> ToolsetLoader<H, C> {
     pub async fn load_toolsets(
         &self,
         server_urls: &[String],
-        session_id: &str,
+        session_id: &rap_protocol::ThreadId<str>,
     ) -> Result<Vec<LoadedToolset>, Box<dyn std::error::Error + Send + Sync>> {
         let mut results = Vec::new();
         for url in server_urls {
@@ -48,7 +48,7 @@ impl<H: HttpClient, C: ToolsetCache> ToolsetLoader<H, C> {
     async fn load_single(
         &self,
         server_url: &str,
-        session_id: &str,
+        session_id: &rap_protocol::ThreadId<str>,
     ) -> Result<LoadedToolset, Box<dyn std::error::Error + Send + Sync>> {
         let cache_key = format!("__toolset__{}_{}", session_id, server_url);
 

--- a/infinity-ui/src/types.ts
+++ b/infinity-ui/src/types.ts
@@ -70,7 +70,7 @@ export type DaemonMessage =
     }
   | {
       Connected: {
-        session_id: string;
+        root_thread_id: string;
         model_name: string;
         context_window: number;
         title: string | null;
@@ -147,10 +147,10 @@ export type DaemonMessage =
   | { RemotesUpdated: { remotes: RemoteInfo[] } }
   | "DisconnectNotIdle"
   | "DetachedIdle"
-  | { EmigrateResult: { session_id: string; session_data: string } }
-  | { MigrateStarted: { session_id: string } }
-  | { MigrateComplete: { session_id: string; new_session_id: string } }
-  | { MigrateError: { session_id: string; error: string } }
+  | { EmigrateResult: { root_thread_id: string; session_data: string } }
+  | { MigrateStarted: { root_thread_id: string } }
+  | { MigrateComplete: { root_thread_id: string; new_root_thread_id: string } }
+  | { MigrateError: { root_thread_id: string; error: string } }
   | {
       DirectoryListing: {
         request_path: string;
@@ -169,25 +169,30 @@ export type ClientMessage =
         model?: ModelRef | null;
       };
     }
-  | { Connect: { session_id: string; thread_id: string | null } }
-  | { UserInput: { session_id: string; text: string } }
+  | { Connect: { root_thread_id: string; thread_id: string | null } }
+  | { UserInput: { root_thread_id: string; text: string } }
   | "Disconnect"
-  | { SoftDetach: { session_id: string } }
-  | { ShutdownSession: { session_id: string } }
+  | { SoftDetach: { root_thread_id: string } }
+  | { ShutdownSession: { root_thread_id: string } }
   | { LoadSession: { target_session_id: string } }
-  | { SwitchModel: { session_id: string; model: ModelRef } }
+  | { SwitchModel: { thread_id: string; model: ModelRef } }
   | { UserChoiceAnswered: { choice_id: string; selected: number } }
-  | { TriggerCompaction: { session_id: string } }
+  | { TriggerCompaction: { root_thread_id: string } }
   | {
       RequestMigrate: {
-        session_id: string;
+        root_thread_id: string;
         to: string | null;
         dest_cwd: string;
       };
     }
-  | { Emigrate: { session_id: string; dest_rap_urls: Record<string, string> } }
-  | { EmigrateDone: { session_id: string } }
-  | { ArchiveSession: { session_id: string } }
+  | {
+      Emigrate: {
+        root_thread_id: string;
+        dest_rap_urls: Record<string, string>;
+      };
+    }
+  | { EmigrateDone: { root_thread_id: string } }
+  | { ArchiveSession: { root_thread_id: string } }
   | { ListDirectory: { path: string; on: string | null } };
 
 /* ── Connection status ── */

--- a/infinity-ui/src/types.ts
+++ b/infinity-ui/src/types.ts
@@ -170,7 +170,7 @@ export type ClientMessage =
       };
     }
   | { Connect: { root_thread_id: string; thread_id: string | null } }
-  | { UserInput: { root_thread_id: string; text: string } }
+  | { UserInput: { thread_id: string; text: string } }
   | "Disconnect"
   | { SoftDetach: { root_thread_id: string } }
   | { ShutdownSession: { root_thread_id: string } }

--- a/infinity-web/src/App.tsx
+++ b/infinity-web/src/App.tsx
@@ -259,7 +259,7 @@ export function App() {
             // Flush pending inputs
             for (const text of pendingInputRef.current) {
               sendRef.current({
-                UserInput: { root_thread_id: p.thread_id, text },
+                UserInput: { thread_id: p.thread_id, text },
               });
             }
             pendingInputRef.current = [];
@@ -631,7 +631,7 @@ export function App() {
   const handleSend = useCallback(
     (text: string) => {
       if (threadRef.current) {
-        send({ UserInput: { root_thread_id: threadRef.current, text } });
+        send({ UserInput: { thread_id: threadRef.current, text } });
       } else {
         pendingInputRef.current.push(text);
         setNewSessionPickerOpen(true);

--- a/infinity-web/src/App.tsx
+++ b/infinity-web/src/App.tsx
@@ -137,11 +137,11 @@ export function App() {
       clearConnectRetry();
       setSessionConnected(false);
       sendRef.current({
-        Connect: { session_id: sessionId, thread_id: threadId },
+        Connect: { root_thread_id: sessionId, thread_id: threadId },
       });
       connectRetryRef.current = setInterval(() => {
         sendRef.current({
-          Connect: { session_id: sessionId, thread_id: threadId },
+          Connect: { root_thread_id: sessionId, thread_id: threadId },
         });
       }, 5000);
     },
@@ -154,7 +154,7 @@ export function App() {
   const isForCurrentView = useCallback(
     (msgThreadId: string | null) => {
       const viewing = viewThreadId ?? threadRef.current;
-      // null thread_id = root, session_id = root
+      // null thread_id = root, root_thread_id = root
       return msgThreadId === null || msgThreadId === viewing;
     },
     [viewThreadId],
@@ -240,7 +240,7 @@ export function App() {
           }
           case "Connected": {
             const p = msgPayload<{
-              session_id: string;
+              root_thread_id: string;
               thread_id: string;
               model_name: string;
               context_window: number;
@@ -248,7 +248,7 @@ export function App() {
               total_tokens_used: number;
               provider_id: string;
             }>(m);
-            sessionRef.current = p.session_id;
+            sessionRef.current = p.root_thread_id;
             threadRef.current = p.thread_id;
             setModelName(p.model_name);
             setProviderName(p.provider_id);
@@ -259,7 +259,7 @@ export function App() {
             // Flush pending inputs
             for (const text of pendingInputRef.current) {
               sendRef.current({
-                UserInput: { session_id: p.thread_id, text },
+                UserInput: { root_thread_id: p.thread_id, text },
               });
             }
             pendingInputRef.current = [];
@@ -579,10 +579,10 @@ export function App() {
           }
           case "MigrateComplete": {
             const p = msgPayload<{
-              session_id: string;
-              new_session_id: string;
+              root_thread_id: string;
+              new_root_thread_id: string;
             }>(m);
-            if (sessionRef.current === p.session_id) {
+            if (sessionRef.current === p.root_thread_id) {
               sendRef.current("Disconnect");
               sessionRef.current = null;
               threadRef.current = null;
@@ -595,13 +595,13 @@ export function App() {
               setActiveTab(null);
               setChatAsTab(false);
               streamingRef.current = false;
-              sendConnect(p.new_session_id, null);
+              sendConnect(p.new_root_thread_id, null);
             }
             appendMessage({ type: "info", text: "Migration complete" });
             break;
           }
           case "MigrateError": {
-            const p = msgPayload<{ session_id: string; error: string }>(m);
+            const p = msgPayload<{ root_thread_id: string; error: string }>(m);
             appendMessage({
               type: "error",
               text: `Migration failed: ${p.error}`,
@@ -631,7 +631,7 @@ export function App() {
   const handleSend = useCallback(
     (text: string) => {
       if (threadRef.current) {
-        send({ UserInput: { session_id: threadRef.current, text } });
+        send({ UserInput: { root_thread_id: threadRef.current, text } });
       } else {
         pendingInputRef.current.push(text);
         setNewSessionPickerOpen(true);
@@ -685,7 +685,7 @@ export function App() {
 
   const handleArchiveSession = useCallback(() => {
     if (!sessionRef.current) return;
-    send({ ArchiveSession: { session_id: sessionRef.current } });
+    send({ ArchiveSession: { root_thread_id: sessionRef.current } });
     sessionRef.current = null;
     threadRef.current = null;
     setViewThreadId(null);
@@ -759,7 +759,7 @@ export function App() {
         // with ModelSwitched.
         send({
           SwitchModel: {
-            session_id: target,
+            thread_id: target,
             model: { provider_id: m.provider_id, model_id: m.model_id },
           },
         });
@@ -788,7 +788,7 @@ export function App() {
       if (sessionRef.current) {
         send({
           RequestMigrate: {
-            session_id: sessionRef.current,
+            root_thread_id: sessionRef.current,
             to: destination,
             dest_cwd: cwd,
           },


### PR DESCRIPTION
Stage 3 of the string-ID to typed-ID migration (#108), implementing the
decision that a session IS its root thread. This is the one deliberate
wire-format break of the migration: JSON field names change; values are
unchanged (ThreadRef serializes as the historical composite string).
Verified end-to-end: full test suite + Playwright web e2e (7/7) against
the live daemon.

* infinity-protocol: `session_id` renamed to `root_thread_id` across
  ClientMessage/DaemonMessage (`new_session_id` to `new_root_thread_id`;
  SwitchModel's mislabeled `session_id` is now honestly `thread_id`). New
  `ThreadRef { remote: Option<RemoteName>, id: ThreadId }` replaces the
  ad-hoc `"remote/uuid"` string encoding: Display/FromStr/serde use the
  composite form, `.prefixed()`/`.strip()` replace split_once logic; Ord
  derives (local-before-remote, then id). New `RemoteName` kind; typed
  `location`/`to`/`on` fields, `SessionInfo.remote`, `RemoteInfo.name`,
  `SubthreadInfo`, and sessions maps keyed by `ThreadRef`. Client-facing
  fields are `ThreadRef`; daemon-to-daemon variants (Emigrate family) are
  plain `ThreadId`
* infinity-daemon: `IdSource::generate() -> ThreadId`; client_handler's
  is_remote_session/strip_id string surgery replaced by ThreadRef
  operations; remote.rs session maps and control workers typed
  (RemoteConfig.name: RemoteName, remotes.json unchanged); migrate.rs
  orchestration fully typed (composite-string juggling eliminated)
* rap-client: `ToolsetLoader::load_toolsets` and
  `RapNotifier::request_migration` take `&ThreadId`; rap-bridge connect too
* infinity-agent-cli (sub-agent): terminal state keyed by ThreadRef,
  session picker/daemon client typed, ACP boundary documented (ACP-side
  ids stay String; acp-sessions.json format unchanged); zero terminal
  snapshot changes
* infinity-slack-bot + TS (sub-agent): SessionStore/DaemonCommand/client
  typed with ThreadRef (persisted JSON unchanged); infinity-ui types.ts +
  infinity-web App.tsx field renames — including the App.tsx conflation
  `UserInput { session_id: p.thread_id }` which the rename makes honest

BREAKING CHANGE: daemon wire protocol field renames (session_id family);
old clients/daemons cannot interop across this version for the renamed
messages. TS clients updated in the same change.

Deferred to the &ThreadId<str> loosening rebase: Stage-3's new `&ThreadId`
params (handle_emigrate, connect_remote_session, load_toolsets, etc.).