### PR TITLE
docs: clean up stale docs that don't match the actual code

### DIFF
--- a/docs/docs/infinity-code/slack-bot.md
+++ b/docs/docs/infinity-code/slack-bot.md
@@ -118,8 +118,9 @@ To find your Slack user ID: click your profile in Slack → **⋮** → **Copy m
 Start the Infinity daemon first (if not already running), then start the Slack bot:
 
 ```bash
-# Start the daemon (if not running)
-infinity --daemon
+# Start the daemon (if not running; any `infinity` run auto-starts it,
+# or run it in the foreground with `infinity daemon`)
+infinity
 
 # Start the Slack bot
 infinity-slack-bot
@@ -145,7 +146,7 @@ Use the `/model` slash command (responses are ephemeral — only you see them):
 
 | Command | Effect |
 |---------|--------|
-| `/model` | List available models, with the current default marked |
+| `/model` | Open an interactive model picker (falls back to a text listing with the current default marked) |
 | `/model <provider_id>/<model_id>` | Switch the default model for new sessions |
 | `/model <display name or model id>` | Same, matching by name (case-insensitive) |
 
@@ -156,7 +157,7 @@ The switch applies to sessions created afterwards; existing threads keep their m
 | Symptom | Fix |
 |---------|-----|
 | Bot doesn't respond | Check that the user's ID is in `allowed_users` (or leave the list empty) |
-| "Cannot connect to daemon" | Start the daemon with `infinity --daemon` first |
+| "Cannot connect to daemon" | Start the daemon first (run `infinity` once, or `infinity daemon` in the foreground) |
 | "apps.connections.open failed" | Verify `app_token` is correct and Socket Mode is enabled in app settings |
 | "auth.test failed" | Verify `bot_token` is correct and the app is installed to the workspace |
 | Bot responds but no streaming | The `assistant:write` scope is required for `chat.startStream` |

--- a/docs/docs/infinity-runtime/agent-systems/custom-tools.md
+++ b/docs/docs/infinity-runtime/agent-systems/custom-tools.md
@@ -10,13 +10,12 @@ The tool below looks up a build and returns its status. `execute` schedules the 
 
 ```rust
 use async_trait::async_trait;
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::message::{InputMessage, InputMessageContent};
 use infinity_agent_core::system::local::ChannelSender;
 use infinity_agent_core::tools::{Tool, ToolContext};
 use infinity_agent_core::traits::InputSender;
-use rig::OneOrMany;
-use rig::agent::Text;
-use rig::message::{ToolResult, ToolResultContent, UserContent};
+use infinity_provider_protocol::message::{Text, ToolResult, ToolResultContent, UserContent};
 use serde_json::json;
 
 struct GetBuildStatus {
@@ -95,7 +94,7 @@ impl Tool<ChannelSender> for GetBuildStatus {
 
 async fn send_result(
     sender: ChannelSender,
-    group_id: String,
+    group_id: ThreadId,
     id: String,
     call_id: Option<String>,
     text: String,
@@ -104,7 +103,7 @@ async fn send_result(
         content: InputMessageContent::User(UserContent::ToolResult(ToolResult {
             id: id.clone(),
             call_id,
-            content: OneOrMany::one(ToolResultContent::Text(Text { text })),
+            content: vec![ToolResultContent::Text(Text { text })],
         })),
         group_id: group_id.clone(),
         metadata: None,
@@ -176,9 +175,9 @@ async fn execute_synchronous(
     Some(ToolResult {
         id: id.to_owned(),
         call_id: call_id.map(str::to_owned),
-        content: OneOrMany::one(ToolResultContent::Text(Text {
+        content: vec![ToolResultContent::Text(Text {
             text: calculate(args),
-        })),
+        })],
     })
 }
 ```
@@ -274,7 +273,7 @@ The helper differs from `send_result` by accepting a synthetic event and subscri
 use infinity_agent_core::message::{SyntheticKind, TaggedSyntheticKind};
 
 fn subscription_result(
-    group_id: &str,
+    group_id: &ThreadId<str>,
     id: &str,
     call_id: Option<String>,
     text: String,
@@ -285,7 +284,7 @@ fn subscription_result(
         content: InputMessageContent::User(UserContent::ToolResult(ToolResult {
             id: id.to_owned(),
             call_id,
-            content: OneOrMany::one(ToolResultContent::Text(Text { text })),
+            content: vec![ToolResultContent::Text(Text { text })],
         })),
         group_id: group_id.to_owned(),
         metadata: None,

--- a/docs/docs/infinity-runtime/agent-systems/customizing-the-engine.md
+++ b/docs/docs/infinity-runtime/agent-systems/customizing-the-engine.md
@@ -19,7 +19,7 @@ Tools and protocol integrations have dedicated guides: [Dynamic Thread Configura
 An agent system uses two stores with separate responsibilities:
 
 - **`ConversationStore`** persists messages, thread relationships, and compaction summaries.
-- **`StateStore`** persists processed IDs, thread metadata, and active subscriptions.
+- **`StateStore`** persists processed IDs, thread metadata, active subscriptions, and pending user choices.
 
 The runtime can resume a thread when both stores retain their state. In-memory implementations are complete stores, but their contents belong to one process. A service with multiple workers should provide shared implementations:
 
@@ -34,7 +34,7 @@ let system = AgentSystemBuilder::new_local(
 
 Store methods define the runtime's ordering, deduplication, and thread-tree contract. Implement both traits directly when adding a persistence provider, and test interrupted turns, duplicate inputs, child threads, compaction, and active subscriptions. The [platform traits](../low-level/overview.md#the-platform-traits) document the complete interfaces.
 
-`StateStore` also carries the local router's wake policy. Before an event-style input (a tool result, subscription event, OAuth completion, or user choice) wakes an idle thread, the router calls `should_wake_thread_for_event`. Returning `false` drops the input before any driver is spawned, so a stale callback cannot create thread records for a conversation that does not exist. The default admits everything. `InMemoryStateStore::for_conversations` links the in-memory pair so events are refused for threads the conversation store has never seen, and the Infinity Code daemon's stores refuse sessions the user shut down. User text is never gated, because first input is how threads are created.
+The stores also carry the local router's wake policy. Before an event-style input (a tool result, subscription event, OAuth completion, or user choice) wakes an idle thread, the router checks `ConversationStore::thread_exists` and `StateStore::is_thread_stopped`. An event for a thread the conversation store has never seen, or one the state store reports as stopped, is dropped before any driver is spawned, so a stale callback cannot create thread records for a conversation that does not exist. `is_thread_stopped` defaults to `false` (admitting everything); the Infinity Code daemon's store implements it to refuse events for sessions the user shut down. User text is never gated, because first input is how threads are created and how stopped threads are resumed.
 
 :::caution
 
@@ -48,7 +48,7 @@ A **`ModelSource`** chooses one `ResolvedModel` at the start of each completion 
 ```rust
 #[async_trait(?Send)]
 impl ModelSource for SelectedModelSource {
-    async fn resolve(&self, thread_id: &str) -> Result<ResolvedModel, BoxError> {
+    async fn resolve(&self, thread_id: &ThreadId<str>) -> Result<ResolvedModel, BoxError> {
         let selection = self.selections.load(thread_id).await?;
         self.catalog.resolve(&selection)
     }

--- a/docs/docs/infinity-runtime/agent-systems/dynamic-configuration.md
+++ b/docs/docs/infinity-runtime/agent-systems/dynamic-configuration.md
@@ -19,7 +19,7 @@ For configuration chosen when a process creates a new thread, local systems also
 pub trait ThreadConfigSource<M: InputSender, H: HttpClient> {
     async fn resolve(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId<str>,
     ) -> Result<ThreadConfig<M, H>, BoxError>;
 }
 ```
@@ -36,6 +36,7 @@ The following source gives every root conversation and its subagents the same te
 use std::rc::Rc;
 
 use async_trait::async_trait;
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::system::{ThreadConfig, ThreadConfigSource};
 use infinity_agent_core::system::local::ChannelSender;
 use infinity_agent_core::tools::Tool;
@@ -64,14 +65,14 @@ where
 {
     async fn resolve(
         &self,
-        thread_id: &str,
+        thread_id: &ThreadId<str>,
     ) -> Result<ThreadConfig<ChannelSender, SimpleHttpClient>, BoxError> {
         let ancestors = self.conversations.get_ancestor_chain(thread_id).await?;
         let root_id = ancestors
             .first()
-            .map(|(id, _)| id.as_str())
-            .unwrap_or(thread_id);
-        let tenant = self.tenants.for_root_thread(root_id).await?;
+            .map(|(id, _)| id.clone())
+            .unwrap_or_else(|| thread_id.to_owned());
+        let tenant = self.tenants.for_root_thread(&root_id).await?;
 
         Ok(ThreadConfig {
             tools: tenant.tools,
@@ -121,7 +122,7 @@ Resolution receives the ID of the thread that is about to run. For a root conver
 ```rust
 #[async_trait(?Send)]
 pub trait ModelSource {
-    async fn resolve(&self, thread_id: &str) -> Result<ResolvedModel, BoxError>;
+    async fn resolve(&self, thread_id: &ThreadId<str>) -> Result<ResolvedModel, BoxError>;
 }
 ```
 
@@ -131,6 +132,7 @@ The constructor accepts the source directly. A fixed deployment can pass `Static
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use infinity_agent_core::ThreadId;
 use infinity_agent_core::system::{ModelSource, ResolvedModel};
 use infinity_agent_core::traits::ConversationStore;
 use infinity_provider_protocol::ModelProvider;
@@ -153,13 +155,13 @@ impl<C> ModelSource for TenantModelSource<C>
 where
     C: ConversationStore + 'static,
 {
-    async fn resolve(&self, thread_id: &str) -> Result<ResolvedModel, BoxError> {
+    async fn resolve(&self, thread_id: &ThreadId<str>) -> Result<ResolvedModel, BoxError> {
         let ancestors = self.conversations.get_ancestor_chain(thread_id).await?;
         let root_id = ancestors
             .first()
-            .map(|(id, _)| id.as_str())
-            .unwrap_or(thread_id);
-        let selection = self.selections.for_root_thread(root_id).await?;
+            .map(|(id, _)| id.clone())
+            .unwrap_or_else(|| thread_id.to_owned());
+        let selection = self.selections.for_root_thread(&root_id).await?;
         let model = self.catalog.resolve(&selection)?;
 
         Ok(ResolvedModel {

--- a/docs/docs/infinity-runtime/agent-systems/observers.md
+++ b/docs/docs/infinity-runtime/agent-systems/observers.md
@@ -4,23 +4,21 @@ title: Observers
 ---
 
 # Observers
-A `ThreadObserver` receives everything a thread does. [Thread handles](./running-locally.md#sending-input-and-receiving-events) deliver events on a channel, and when that is all you need, you never write an observer. You implement one when your embedding has its own clients to serve: a UI that renders events live, a database that records token usage, a protocol that surfaces pending user choices. The trait provides two instruments: a **synchronous event feed** for display, and **awaited durability hooks** for persisting your own state at defined moments.
+A `ThreadObserver` receives everything a thread does. [Thread handles](./running-locally.md#sending-input-and-receiving-events) deliver events on a channel, and when that is all you need, you never write an observer. You implement one when your embedding has its own clients to serve: a UI that renders events live, a database that records token usage, a protocol that surfaces pending user choices. The trait provides two instruments: a **synchronous event feed** (`on_event`) for display and state derived from events, and a **live-attach hook** (`on_subscribe`) for catching up clients that connect mid-conversation.
 
 For example, a chat server that broadcasts every thread's activity to connected WebSocket clients while keeping a per-thread token counter in a database is one observer:
 
 ```rust
 struct MyObserver {
-    thread_id: String,
     clients: ClientRegistry,          // your fan-out list
-    db: Database,                     // your storage
-    tokens_this_step: Cell<u64>,
+    token_counter: TokenCounter,      // your storage
 }
 
 #[async_trait(?Send)]
 impl ThreadObserver for MyObserver {
     type SubscribeRequest = WebSocketClient;
 
-    fn on_event(&self, thread_id: &str, event: &AgentEvent) {
+    fn on_event(&self, thread_id: &ThreadId<str>, event: &AgentEvent) {
         // Called synchronously at the emission point: keep it fast.
         if let AgentEvent::CompletionFinished { usage: Some(u) } = event {
             self.token_counter.add(thread_id, u.total_tokens);
@@ -28,7 +26,7 @@ impl ThreadObserver for MyObserver {
         self.clients.broadcast(render(thread_id, event));
     }
 
-    fn on_subscribe(&self, thread_id: &str, client: WebSocketClient, snapshot: ReplaySnapshot) {
+    fn on_subscribe(&self, thread_id: &ThreadId<str>, client: WebSocketClient, snapshot: ReplaySnapshot) {
         client.send(render_replay(thread_id, &snapshot));
         self.clients.register(client);
     }
@@ -37,24 +35,27 @@ impl ThreadObserver for MyObserver {
 let running = system.start_with_observer(|thread_id| MyObserver::new(thread_id));
 ```
 
-`start_with_observer` takes a factory rather than an observer because each thread's driver receives its own instance, created when the driver spawns. State that must outlive a driver, such as the client registry above, lives outside and is cloned into each observer. Two provided implementations cover the trivial cases: `EventCollector` buffers `(thread_id, event)` pairs in memory (suited to a [step-mode](./step-mode.md) handler that inspects them after the slice), and `NullObserver` discards everything.
+`start_with_observer` takes a factory rather than an observer because each thread's driver receives its own instance, created when the driver spawns. State that must outlive a driver, such as the client registry above, lives outside and is cloned into each observer. A provided implementation covers the trivial case: `EventCollector` buffers `(thread_id, event)` pairs in memory (suited to a [step-mode](./step-mode.md) handler that inspects them after the slice).
 
-The observer API has three connected responsibilities. `AgentEvent` is the display-level record of a step, in order: the `UserInput` echo, `CompletionStarted`, streamed `TextChunk`s and `ThinkingStarted`/`ThinkingChunk`/`ThinkingEnded`, `ToolCall` (with a pretty-printed `display_as` when the tool has a display script), `ToolResult` (with RAP display segments), and `CompletionFinished` (with token usage), plus out-of-band `SubscriptionEvent`, `OAuthRequired`, `CompactionApplied`, and `Info` diagnostics. The type is `Clone` and generic-free, so you can fan events out to any number of subscribers or buffer them freely.
+The observer API has three connected responsibilities. `AgentEvent` is the display-level record of a step, in order: the `UserInput` echo, `CompletionStarted`, streamed `TextChunk`s and `ThinkingStarted`/`ThinkingChunk`/`ThinkingEnded`, `ToolCall` (with a pretty-printed `display_as` when the tool has a display script), `ToolResult` (with RAP display segments), and `CompletionFinished` (with token usage), plus out-of-band `SubscriptionEvent`, `OAuthRequired`, `UserChoiceRequired`/`UserChoiceDismissed`, `CompactionApplied`, and `Info` diagnostics. The type is `Clone` and generic-free, so you can fan events out to any number of subscribers or buffer them freely.
 
 `on_event` is synchronous and called inline at the emission point. Keep it fast: push to channels, append to buffers, or update in-memory counters. Work that needs to await belongs on a task you spawn from it.
 
-## Persist State and Attach Live Clients
-The async methods are awaited by the runtime at precise points in the step, so state you persist in them is durable before the world can move on:
+## Durability and Pending Choices
+Stateful events are emitted only after the runtime has awaited the corresponding `StateStore` transition, so the state an event describes is durable before you can observe it:
 
-- **`on_user_choice_required`** fires when a tool server asks the user to choose among options. It is awaited before the step continues, so a crash can never lose a choice the user has already been shown; persist the pending choice, then surface it to clients.
-- **`on_user_choice_dismissed`** fires when a pending choice becomes moot because its tool call was interrupted. Remove the pending-choice record here, durably, before the agent acts on the interruption.
+- **`AgentEvent::UserChoiceRequired`** fires when a tool server asks the user to choose among options. The pending choice has already been persisted when the event is emitted, so a crash can never lose a choice the user has been shown; surface it to clients from `on_event`.
+- **`AgentEvent::UserChoiceDismissed`** fires when a pending choice becomes moot because its tool call was interrupted. The choice has already been removed from persistent state; drop it from your UI here.
+
+Choices still awaiting a response are also included in `ReplaySnapshot::pending_choices`, so a client that attaches later sees them without your embedding tracking them separately.
 
 The turn itself needs no hook: the runtime syncs history to the `ConversationStore` before dispatching any tool call, so by the time your embedding can observe an external effect, the turn that caused it is already durable. This is the same turn-durability barrier described in [Architecture](../architecture.md).
 
+## Attach Live Clients
 In [local mode](./running-locally.md), clients can attach to a thread that is already running mid-completion, and `on_subscribe` is where you catch them up. `RunningSystem::subscribe(thread_id, request)` routes your `SubscribeRequest` (any type you choose: a client handle, a channel, a session token) to the thread's driver, which calls `on_subscribe` with a `ReplaySnapshot`: the committed history *plus* in-memory state that exists nowhere else, namely the partially streamed turn and any in-progress reasoning. Render the snapshot into your catch-up message, then register the subscriber in the same list your `on_event` fan-out broadcasts to, as the example above does.
 
 The guarantee that makes this correct is **exactly-once delivery relative to attach**: every event is either already reflected in the snapshot a new subscriber receives, or broadcast to it afterwards, never both and never neither. To keep the guarantee, register the subscriber inside `on_subscribe` and render the snapshot from there. Handing the snapshot to another task to register later reopens the gap the guarantee closes, and events emitted in between are lost.
 
 `subscribe` resolves once the subscriber is installed, so the common attach-then-send sequence is safe: any message sent after it returns is observed by the new subscriber.
 
-For a production-grade example, read the Infinity Code daemon's `DaemonObserver`: `on_event` updates session state derived from events (its stores are in-memory, so this is a cheap synchronous call) and broadcasts protocol messages to attached terminal and web clients, the choice hooks persist pending choices so a reconnecting client sees them, and `on_subscribe` replays history, mid-stream text, and in-progress thinking to the attaching client.
+For a production-grade example, read the Infinity Code daemon's `DaemonObserver`: `on_event` persists session state derived from events (token usage, last-updated timestamps) and broadcasts protocol messages to attached terminal and web clients, and `on_subscribe` replays history, in-progress thinking, and the snapshot's pending choices to the attaching client.

--- a/docs/docs/infinity-runtime/agent-systems/overview.md
+++ b/docs/docs/infinity-runtime/agent-systems/overview.md
@@ -54,16 +54,16 @@ A local `RunningSystem` or `LaunchingSystem` remains available until `shutdown()
 
 Individual threads have a shorter active lifetime. A thread driver starts when a message arrives and exits once nothing is queued and no tool result is on its way. Active subscriptions do not keep a driver resident: a subscription event respawns the driver when it arrives. The conversation remains in the stores, so the next message loads it and continues from the persisted history.
 
-`thread_lifecycle` reports a `ThreadLifecycleEvent` for each driver transition: `Live` when a driver spawns and `Idle` when it exits, and `is_idle()` reports whether any driver remains. Use these signals to track conversation activity and release per-conversation resources such as command-based RAP servers or caches:
+`next_lifecycle_event()` reports a `ThreadLifecycleEvent` for each driver transition: `ThreadLifecycleState::Live` when a driver spawns and `ThreadLifecycleState::Idle` when it exits, and `is_idle()` reports whether any driver remains. Use these signals to track conversation activity and release per-conversation resources such as command-based RAP servers or caches:
 
 ```rust
-while let Some(event) = system.thread_lifecycle.recv().await {
-    match event {
-        ThreadLifecycleEvent::Live { thread_id } => {
-            status.mark_conversation_active(&thread_id).await?;
+while let Some(event) = system.next_lifecycle_event().await {
+    match event.state {
+        ThreadLifecycleState::Live => {
+            status.mark_conversation_active(&event.thread_id).await?;
         }
-        ThreadLifecycleEvent::Idle { thread_id } => {
-            resources.release_if_conversation_is_idle(&thread_id).await?;
+        ThreadLifecycleState::Idle => {
+            resources.release_if_conversation_is_idle(&event.thread_id).await?;
         }
     }
 }

--- a/docs/docs/infinity-runtime/low-level/completion-loop.md
+++ b/docs/docs/infinity-runtime/low-level/completion-loop.md
@@ -32,9 +32,9 @@ Many messages end at this phase: a slice pays for a model call only when an inpu
 As the stream runs, it buffers the turn into the history manager (`handle_completion`) and flushes at turn boundaries, retrying transient provider failures from clean committed history. Tools that opt into synchronous execution (`Tool::execute_synchronous`) are invoked inline and their results loop back into the completion without ending the slice. The stream's terminal event is a `CompletionAction`:
 
 ```rust
-pub enum CompletionAction<R> {
+pub enum CompletionAction {
     /// Model produced text and is done (no tool call).
-    Done(R),
+    Done(FinalResponse),
     /// Model wants to execute a tool call (fire-and-forget under RAP).
     ExecuteToolCall {
         tool_name: String,
@@ -48,8 +48,8 @@ pub enum CompletionAction<R> {
 
 ## `execute_action`: Dispatch and Stop
 ```rust
-pub async fn execute_action<M, R>(
-    action: CompletionAction<R>,
+pub async fn execute_action<M>(
+    action: CompletionAction,
     tool_registry: &HashMap<String, &dyn Tool<M>>,
     tool_context: &ToolContext<M>,
 ) -> Result<(), BoxError>

--- a/docs/docs/infinity-runtime/low-level/overview.md
+++ b/docs/docs/infinity-runtime/low-level/overview.md
@@ -33,7 +33,7 @@ Porting the runtime to a new platform means implementing four traits, defined in
 | Trait | Responsibility | Lambda | Daemon |
 |---|---|---|---|
 | `ConversationStore` | Per-thread history, thread hierarchy, compaction summaries | Aurora DSQL | In-memory + JSON files |
-| `StateStore` | Processed IDs, metadata, active subscriptions | DynamoDB | In-memory + JSON files |
+| `StateStore` | Processed IDs, metadata, active subscriptions, pending user choices | DynamoDB | In-memory + JSON files |
 | `InputSender` | Delivering messages to the input queue | SQS FIFO | `mpsc` channels |
 | `HttpClient` | POST/GET to tool servers | SigV4-signed reqwest | Plain reqwest |
 

--- a/docs/docs/infinity-runtime/model-providers.md
+++ b/docs/docs/infinity-runtime/model-providers.md
@@ -12,7 +12,7 @@ The Infinity Runtime never calls an LLM API directly. All inference goes through
 
 Everything else in the runtime (the agent loop, threading, compaction, token accounting) is written against this trait. The Lambda deployment plugs in the Bedrock provider directly; the Infinity Code daemon registers each provider under a stable **provider id** and references models globally as `provider id + model id`, so multiple providers can coexist and even offer models with the same name.
 
-Providers own all backend-specific behavior. Callers hand them a plain [rig](https://docs.rs/rig-core) `CompletionRequest`; the provider is responsible for backend-specific request parameters: thinking configuration, beta feature flags, per-model output token limits, and so on. For example, the Bedrock provider injects Anthropic's adaptive thinking configuration and the 1M-context beta flag for the models that need them, without the agent loop knowing those exist.
+Providers own all backend-specific behavior. Callers hand them a plain `CompletionRequest` (defined by the protocol crate); the provider is responsible for backend-specific request parameters: thinking configuration, beta feature flags, per-model output token limits, and so on. For example, the Bedrock provider injects Anthropic's adaptive thinking configuration and the 1M-context beta flag for the models that need them, without the agent loop knowing those exist.
 
 ## The `ModelProvider` trait
 
@@ -26,17 +26,12 @@ pub trait ModelProvider: Send + Sync {
     async fn list_models(&self) -> Result<Vec<ModelEntry>, BoxError>;
 
     /// Invoke a model by its provider-scoped id, streaming the completion
-    /// response. Behaves exactly like rig's `CompletionModel::stream`, with
-    /// the streaming response type erased.
+    /// response.
     async fn invoke_model(
         &self,
         model_id: &str,
         request: CompletionRequest,
-    ) -> Result<ProviderCompletionResponse, CompletionError>;
-
-    /// Whether the given model accepts image content in its input.
-    /// The default implementation looks the model up in `list_models`.
-    async fn supports_image_input(&self, model_id: &str) -> bool { /* default */ }
+    ) -> Result<ModelStream, CompletionError>;
 }
 ```
 
@@ -64,26 +59,32 @@ Because `model_id` is provider-scoped rather than the upstream id, a provider ca
 
 ## Writing a provider
 
-A provider typically wraps a rig `CompletionModel` internally:
+A provider implements the two trait methods against its backend's API:
 
 1. Implement `list_models` to return your catalog (often a static list).
-2. Implement `invoke_model`: resolve the `model_id` to your backend's model, apply any backend-specific request parameters, call the underlying model's `stream`, and erase the response with the `erase_streaming_response` helper:
+2. Implement `invoke_model`: resolve the `model_id` to your backend's model, apply any backend-specific request parameters, call the backend, and adapt its streaming response into a `ModelStream` — a pinned stream of `StreamChunk` items (text, tool calls and tool-call deltas, reasoning, and a `Final` chunk carrying the completion's token usage).
+
+For single-model setups and tests there's a ready-made adapter: implement the one-method `CompletionModel` trait and wrap it with `SingleModelProvider::new(entry, model)`, which advertises the given `ModelEntry` and forwards every invocation to that model.
+
+The protocol crate itself has no dependency on any LLM SDK. To serve one of [rig](https://docs.rs/rig-core)'s backends (OpenAI, Anthropic, Gemini, ...), use the optional `infinity-provider-rig` bridge crate: `RigCompletionModel::new(rig_model).into_provider(entry)` produces a `ModelProvider`, and its `convert` module exposes the raw request/stream conversions for providers that need to inject per-model request parameters themselves:
 
 ```rust
-async fn invoke_model(
-    &self,
-    model_id: &str,
-    mut request: CompletionRequest,
-) -> Result<ProviderCompletionResponse, CompletionError> {
-    // ...apply backend-specific parameters to `request`...
-    let model = self.client.completion_model(model_id);
-    Ok(erase_streaming_response(model.stream(request).await?))
-}
+use infinity_provider_rig::RigCompletionModel;
+use infinity_provider_protocol::ModelEntry;
+use rig::client::{CompletionClient, ProviderClient};
+
+let client = rig::providers::anthropic::Client::from_env();
+let model = client.completion_model("claude-sonnet-4-5");
+let provider = RigCompletionModel::new(model).into_provider(ModelEntry {
+    model_id: "claude-sonnet-4-5".to_owned(),
+    display_name: "Claude Sonnet 4.5".to_owned(),
+    context_window: 200_000,
+    max_output_tokens: Some(64_000),
+    supports_image_input: true,
+});
 ```
 
-For tests or single-model setups there's a ready-made adapter, `SingleModelProvider`, which exposes one rig `CompletionModel` as a provider.
-
-The trait is dyn-compatible, which requires erasing the backend-specific streaming response type: streams yield the usual text / tool call / reasoning chunks, and the final response is reduced to a `ProviderStreamingResponse` carrying the token usage, which is all that downstream code needs.
+The trait is dyn-compatible: the backend-specific streaming response type is erased behind `ModelStream`, and the final `StreamChunk::Final` is reduced to a `FinalResponse` carrying the token usage, which is all that downstream code needs.
 
 ## The provider process transport
 

--- a/docs/docs/rap/about/mcp-compatibility.md
+++ b/docs/docs/rap/about/mcp-compatibility.md
@@ -72,35 +72,30 @@ new HTTPMCPToolSet(this, 'RemoteServer', {
 });
 ```
 
-## Stateful Session Continuity
+## Session Handling
 
-MCP includes a session mechanism (`Mcp-Session-Id` header) that allows clients to resume sessions with a server. The proxy uses this to bridge MCP's session model with RAP's ephemeral execution.
+MCP includes a session mechanism (`Mcp-Session-Id` header) that allows clients to resume sessions with a server. The two proxy implementations handle it differently, reflecting their execution models.
+
+The **local in-process proxy** is part of the long-lived Infinity Code daemon. It connects to the MCP server lazily on first use and keeps the connection (and any `Mcp-Session-Id` the server assigns) alive for the duration of the agent session, so successive tool calls share one MCP session.
+
+The **Lambda proxy** creates a fresh MCP connection for each invocation. When the server assigns a session ID during the `initialize` handshake, the proxy echoes it on the subsequent JSON-RPC requests within that same invocation, but it does not persist session IDs across invocations: each tool call runs in its own short-lived MCP session.
 
 ```mermaid
 sequenceDiagram
     participant R as Agent Runtime
-    participant P as MCP Proxy
+    participant P as MCP Proxy (Lambda)
     participant M as MCP Server (HTTP)
 
-    Note over R,M: First invocation
-
     R->>P: POST invocation
     P-->>R: HTTP 200 (ack)
-    P->>M: JSON-RPC request
+    P->>M: JSON-RPC initialize
     M-->>P: response + Mcp-Session-Id: abc123
-    P->>P: persist session ID
-    P->>R: POST tool_result to callback URL
-
-    Note over R,M: Later invocation (new proxy instance)
-
-    R->>P: POST invocation
-    P-->>R: HTTP 200 (ack)
-    P->>M: JSON-RPC request + Mcp-Session-Id: abc123
-    M-->>P: response (session restored)
+    P->>M: JSON-RPC tools/call + Mcp-Session-Id: abc123
+    M-->>P: tool result
     P->>R: POST tool_result to callback URL
 ```
 
-When an MCP server returns a session ID, the proxy stores it. On subsequent invocations, the proxy includes the stored session ID in the request, allowing the server to restore context. For MCP servers that support this pattern, the proxy can spawn a fresh process on each invocation and still maintain session continuity.
+This means MCP servers that accumulate important in-memory state across tool calls won't retain it between invocations of the Lambda proxy. Tools that need durable per-user state should externalize it, the way the proxy itself stores OAuth tokens in DynamoDB (see below).
 
 ## OAuth support
 

--- a/docs/docs/rap/spec/basic/toolsets.md
+++ b/docs/docs/rap/spec/basic/toolsets.md
@@ -56,7 +56,7 @@ Each entry in the `tools` array describes a single operation that the LLM can in
 | `name` | `string` | Yes | Unique operation name within the toolset. This value is sent as the `operation` field in [tool invocations](/docs/rap/spec/basic/tool-invocation). |
 | `description` | `string` | Yes | Human-readable description of what the tool does. This is passed to the LLM for tool selection. |
 | `inputSchema` | `object` | Yes | JSON Schema defining the expected `arguments` for this tool. MUST be a valid JSON Schema object. |
-| `annotations` | `object` | No | Optional metadata describing tool behavior. See [Annotations](#annotations). |
+| `annotations` | `object` | No | Optional, opaque metadata about the tool. Not interpreted by runtimes. See [Annotations](#annotations). |
 | `displayScript` | `string` | No | A [Rhai](https://rhai.rs/) script that returns a human-readable string for displaying the tool call. See [Display Script](#display-script). |
 
 ### Tool Names
@@ -81,17 +81,9 @@ For tools that accept no parameters, the schema SHOULD explicitly indicate that 
 
 ### Annotations
 
-Tools MAY include an `annotations` object that provides metadata about their behavior. Annotations are informational: they help runtimes and LLMs make better decisions about when and how to invoke a tool, but they do not change the protocol mechanics. For example, a runtime might use the `destructive` annotation to prompt for user confirmation.
+Tools MAY include an `annotations` object that provides metadata about their behavior. Annotations are informational: they do not change the protocol mechanics, and the protocol does not currently define any annotation keys. Runtimes MUST treat the `annotations` object as opaque, implementation-defined metadata: they MUST NOT fail to load a toolset because of unrecognized annotations, and MAY ignore the field entirely.
 
-| Annotation | Type | Description |
-|---|---|---|
-| `requiresAuth` | `string` | Identifier for the authentication provider this tool requires. Indicates the tool may initiate an [OAuth flow](/docs/rap/spec/server/oauth). |
-| `readOnly` | `boolean` | If `true`, indicates this tool performs only read operations and does not modify external state. |
-| `destructive` | `boolean` | If `true`, indicates this tool performs destructive operations (e.g., deleting resources). Runtimes SHOULD prompt for user confirmation. |
-| `idempotent` | `boolean` | If `true`, indicates the tool can be safely retried without side effects. |
-| `longRunning` | `boolean` | If `true`, indicates the tool is expected to take significant time (minutes or hours) to complete. |
-
-Implementations MAY define additional custom annotations. Custom annotation keys SHOULD use a namespaced format (e.g., `x-mycompany-priority`) to avoid conflicts with future protocol-defined annotations.
+Implementations that define custom annotations SHOULD use a namespaced key format (e.g., `x-mycompany-priority`) to avoid conflicts with annotation keys the protocol may define in the future.
 
 ### Display Script
 

--- a/docs/docs/rap/spec/overview.md
+++ b/docs/docs/rap/spec/overview.md
@@ -90,7 +90,7 @@ RAP enables powerful capabilities through arbitrary HTTP communication and async
 
 ### Key Principles
 
-**User Consent and Control.** Users MUST explicitly consent to and understand all tool operations before they are dispatched. Because RAP tools can perform long-running and potentially irreversible actions (deploying infrastructure, modifying repositories, sending messages on behalf of the user), runtimes MUST ensure that users retain control over what data is shared and what actions are taken. Implementors SHOULD provide clear interfaces for reviewing and authorizing tool invocations, especially for tools annotated as `destructive`.
+**User Consent and Control.** Users MUST explicitly consent to and understand all tool operations before they are dispatched. Because RAP tools can perform long-running and potentially irreversible actions (deploying infrastructure, modifying repositories, sending messages on behalf of the user), runtimes MUST ensure that users retain control over what data is shared and what actions are taken. Implementors SHOULD provide clear interfaces for reviewing and authorizing tool invocations, especially for tools that perform destructive operations.
 
 **Data Privacy.** Runtimes MUST NOT expose user data to tools without explicit user consent. Tools MUST NOT store or transmit user data beyond what is required for the requested operation. Because callback URLs can persist for the lifetime of a subscription, they SHOULD be scoped and short-lived where possible to limit the window of exposure if a URL is compromised.
 

--- a/docs/docs/rap/spec/server/oauth.md
+++ b/docs/docs/rap/spec/server/oauth.md
@@ -76,7 +76,7 @@ Tools that implement OAuth MUST detect when authorization is required before att
 
 The tool MUST handle the OAuth callback to receive authorization codes, exchange them securely for access tokens, and store the resulting tokens associated with the `user_id`. After successful authorization, the tool MUST retry the original operation using the new token and MUST send a `tool_result` to the callback URL when the operation completes, whether the retry succeeds or fails.
 
-Tools that require OAuth SHOULD include the OAuth provider identifier in the tool's [annotations](/docs/rap/spec/basic/toolsets#annotations) via the `requiresAuth` field, so that runtimes can inform users about authorization requirements before invocation.
+Tools that require OAuth SHOULD mention the authorization requirement in the tool's description, so that runtimes and LLMs are aware the tool may initiate an authorization flow before invocation.
 
 ## Token Management
 

--- a/docs/docs/rap/using-rap/building-a-rap-tool.md
+++ b/docs/docs/rap/using-rap/building-a-rap-tool.md
@@ -61,19 +61,7 @@ Each tool in the array has a `name` (which becomes the `operation` field in invo
 
 ### Annotations
 
-Tools can include optional [annotations](/docs/rap/spec/basic/toolsets#annotations) that inform the runtime and LLM about the tool's behavior:
-
-```javascript
-{
-  name: 'delete_repository',
-  description: 'Permanently delete a GitHub repository',
-  inputSchema: { /* ... */ },
-  annotations: {
-    destructive: true,    // Runtime may prompt for confirmation
-    longRunning: true,    // Expected to take minutes
-  },
-}
-```
+Tools can include an optional [`annotations`](/docs/rap/spec/basic/toolsets#annotations) object carrying metadata about the tool. The protocol doesn't define any annotation keys, and runtimes treat the field as opaque, so put behavioral guidance the LLM needs (e.g. "this permanently deletes the repository") in the tool's `description` instead. If you define custom annotations for your own tooling, namespace the keys (e.g. `x-mycompany-priority`) to avoid collisions with keys the protocol may define later.
 
 ## Handling invocations
 


### PR DESCRIPTION
Audited all 49 doc files (`docs/docs/rap/**`, `docs/docs/infinity-runtime/**`, `docs/docs/infinity-code/**`, README) against the actual implementation and fixed everything verifiably stale. 14 files changed.

## RAP docs

* **spec/basic/toolsets.md, using-rap/building-a-rap-tool.md**: removed the fabricated annotation keys (`requiresAuth`, `readOnly`, `destructive`, `idempotent`, `longRunning`) — `ToolDef.annotations` is an opaque `Option<serde_json::Value>` passthrough and no code interprets any key; docs now describe annotations as implementation-defined metadata
* **spec/server/oauth.md, spec/overview.md**: removed remaining references to the `requiresAuth`/`destructive` annotations
* **about/mcp-compatibility.md**: corrected the false claim that the Lambda MCP proxy persists `Mcp-Session-Id` across invocations (it creates a fresh client per invocation; DynamoDB stores only OAuth tokens)

## infinity-runtime docs

* **agent-systems/overview.md**: fixed lifecycle example (`next_lifecycle_event()` returning `thread_id` + `ThreadLifecycleState`, not the nonexistent `thread_lifecycle.recv()` + `Live/Idle` variants)
* **agent-systems/observers.md**: removed nonexistent `on_user_choice_required`/`on_user_choice_dismissed` hooks and `NullObserver`; documented the real `AgentEvent::UserChoiceRequired/Dismissed` flow
* **agent-systems/customizing-the-engine.md**: replaced nonexistent `StateStore::should_wake_thread_for_event` / `InMemoryStateStore::for_conversations` with the real wake-gating APIs
* **agent-systems/custom-tools.md, dynamic-configuration.md**: updated examples off stale rig types and `String` → `ThreadId` signatures
* **model-providers.md**: rewrote provider-authoring guidance around the rig-free protocol (`ModelStream`/`StreamChunk`, `SingleModelProvider`); removed nonexistent `ProviderCompletionResponse`, `supports_image_input`, `erase_streaming_response`
* **low-level/completion-loop.md, overview.md**: fixed `CompletionAction` generics and `FinalResponse`; StateStore also persists pending user choices

## infinity-code docs

* **slack-bot.md**: removed nonexistent `infinity --daemon` flag (daemon auto-starts, or use `infinity daemon`); updated `/model` to describe the Block Kit modal picker

Everything else (built-in tools, threading, CLI flags, config schemas, wire types, endpoints, git/jj docs, README) verified accurate against the code with no changes needed.